### PR TITLE
W-61: stop emoticon insert from triggering its own undo

### DIFF
--- a/Sources/Mojito/Inserter/TextInserter.swift
+++ b/Sources/Mojito/Inserter/TextInserter.swift
@@ -5,6 +5,14 @@ import CoreGraphics
 /// frontmost app, by posting synthetic key events.
 @MainActor
 enum TextInserter {
+    /// Sentinel stamped on `eventSourceUserData` of every event we post,
+    /// so `KeyMonitor` can tell our own synthetic events apart from real
+    /// keystrokes and drop them at the tap before they round-trip through
+    /// the state machine. Without this, the first synthetic backspace we
+    /// emit during an emoticon insert lands while `pendingEmoticonUndo`
+    /// is set, the undo path fires immediately, and `:)` ends up as `::)`.
+    static let synthMarker: Int64 = 0x4D4F4A49544F  // ASCII "MOJITO"
+
     static func replace(charactersToDelete: Int, with string: String) {
         // 1. Send N backspaces to delete the typed `:query[:]`.
         for _ in 0..<charactersToDelete {
@@ -21,6 +29,8 @@ enum TextInserter {
             downEvent?.keyboardSetUnicodeString(stringLength: buf.count, unicodeString: buf.baseAddress)
             upEvent?.keyboardSetUnicodeString(stringLength: buf.count, unicodeString: buf.baseAddress)
         }
+        downEvent?.setIntegerValueField(.eventSourceUserData, value: synthMarker)
+        upEvent?.setIntegerValueField(.eventSourceUserData, value: synthMarker)
         downEvent?.post(tap: .cghidEventTap)
         upEvent?.post(tap: .cghidEventTap)
     }
@@ -38,6 +48,8 @@ enum TextInserter {
         let up   = CGEvent(keyboardEventSource: nil, virtualKey: virtualKey, keyDown: false)
         down?.flags = flags
         up?.flags = flags
+        down?.setIntegerValueField(.eventSourceUserData, value: synthMarker)
+        up?.setIntegerValueField(.eventSourceUserData, value: synthMarker)
         down?.post(tap: .cghidEventTap)
         up?.post(tap: .cghidEventTap)
     }

--- a/Sources/Mojito/KeyMonitor/KeyMonitor.swift
+++ b/Sources/Mojito/KeyMonitor/KeyMonitor.swift
@@ -71,6 +71,13 @@ final class KeyMonitor {
     }
 
     private func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        // Skip events we posted ourselves (via TextInserter). Without this,
+        // synthetic backspaces emitted during an emoticon replacement land
+        // in this callback while `pendingEmoticonUndo` is set and trigger
+        // the undo path immediately — turning `:)` into `::)`.
+        if event.getIntegerValueField(.eventSourceUserData) == TextInserter.synthMarker {
+            return Unmanaged.passUnretained(event)
+        }
         // The tap can be auto-disabled by the system if it takes too long; re-enable.
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
             if let tap = eventTap { CGEvent.tapEnable(tap: tap, enable: true) }


### PR DESCRIPTION
## Summary
Fixes a long-standing issue where typing `:)` produced `::)` instead of 🙂.

**Root cause:** when `handleEmoticon` posted its 2 backspaces + emoji insert and then set `pendingEmoticonUndo`, the first synthetic backspace round-tripped through Mojito's own session tap. The undo guard saw a fresh entry, fired immediately, and re-typed `:)` mid-sequence. The remaining synthetic events played out on top — net result `::)`.

**Fix:** stamp every event TextInserter posts with `eventSourceUserData = "MOJITO"`, and have `KeyMonitor.handle` pass those straight through at the tap. Our synthetic events no longer feed back into our own pipeline.

## Test plan
- [x] `:)` → 🙂
- [x] `:D ` → 😃 (space preserved)
- [x] `:-)` → 🙂 (dash variant)
- [x] `:smile:` → 😄 (regular shortcode path didn't regress)
- [x] `:)` then backspace within 3s → `:)` (emoticon-undo still works)

Refs: W-61