### PR TITLE
W-63: delay celery video swap until 4d3d3d3 chant lands

### DIFF
--- a/Sources/Mojito/App/CeleryMan.swift
+++ b/Sources/Mojito/App/CeleryMan.swift
@@ -109,21 +109,26 @@ enum CeleryMan {
         NSApp.activate(ignoringOtherApps: true)
     }
 
-    /// Called by Paul's COMPUTER's click handler. One-shot: swap the two
-    /// video sources and fire the "4d3d3d3-engage" chant once.
+    /// Called by Paul's COMPUTER's click handler. One-shot: fire the
+    /// "4d3d3d3 engage" chant immediately and swap the two video sources
+    /// 2s into the audio so the visual change lands on cue with the
+    /// reference (Tim & Eric's Paul says the line *before* the new clips
+    /// appear).
     private static func handlePaulClicked() {
         guard !didSwap else { return }
         didSwap = true
-        // Swap clip assignments (user wanted these flipped from the
-        // previous round: now celery6/v09 → CINCO panel, celery9/v10 →
-        // Celery Man panel).
-        celeryHost?.swap(to: "v10")
-        cincoHost?.swap(to: "v09")
-        // Fire the engage chant once. AudioBlob is the standard scrambled
+        // Fire the engage chant first. AudioBlob is the standard scrambled
         // loader; s16.bin is 4d3d3d3d.wav.
         if let sound = AudioBlob.load("s16") {
             engagePlayer = sound
             sound.play()
+        }
+        // Hold the videos on their original clips until the chant has been
+        // playing for ~2s, then swap (celery6/v09 → CINCO, celery9/v10 →
+        // Celery Man — flipped from the previous round on purpose).
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+            celeryHost?.swap(to: "v10")
+            cincoHost?.swap(to: "v09")
         }
     }
 


### PR DESCRIPTION
## Summary
`handlePaulClicked()` was swapping the Celery Man / CINCO ID video clips and firing the "4d3d3d3 engage" chant at the same instant. The Tim & Eric reference has Paul say the line *before* the new clips appear — the chant runs ~2s before the visual beat.

Move the chant playback to fire immediately on click, then schedule the video swap 2s later via `DispatchQueue.main.asyncAfter`. The typewriter "4d3d3d3 Engaged" reveal in Paul's COMPUTER continues to start immediately on click, so the audio + the typed text + the swap now land in sequence.

## Test plan
- [ ] Trigger `:celery:`, click Paul's COMPUTER
- [ ] Chant + typewriter reveal fire instantly
- [ ] Video swap happens ~2s later, on cue with the chant landing
- [ ] Closing the windows before 2s elapse cleans up without crashing (`celeryHost`/`cincoHost` are weak and the deferred closure no-ops if they've dropped)

Refs: W-63