### PR TITLE
W-66: scale Celery Man + CINCO ID windows up 30%

### DIFF
--- a/Sources/Mojito/App/CeleryMan.swift
+++ b/Sources/Mojito/App/CeleryMan.swift
@@ -44,12 +44,12 @@ enum CeleryMan {
         let visible = screen.visibleFrame
 
         // Sizes — side-by-side arrangement, baseline-aligned.
-        //   - Celery Man (landscape): 30% smaller than the prior 320pt height.
-        //   - CINCO ID (portrait):    20% taller than the prior 320pt height.
+        //   - Celery Man (landscape): 0.91x the 320pt baseline height.
+        //   - CINCO ID (portrait):    1.56x the 320pt baseline height.
         //   - Paul's COMPUTER:        small panel anchored under the videos.
-        let celeryHeight: CGFloat = 320 * 0.7
+        let celeryHeight: CGFloat = 320 * 0.91
         let celerySize = NSSize(width: celeryHeight * 300.0 / 206.0, height: celeryHeight)
-        let cincoHeight: CGFloat = 320 * 1.2
+        let cincoHeight: CGFloat = 320 * 1.56
         let cincoSize  = NSSize(width: cincoHeight * 180.0 / 290.0, height: cincoHeight)
         let paulSize   = NSSize(width: 320, height: 130)
         let columnGap: CGFloat = 24


### PR DESCRIPTION
## Summary
- Bump both video windows in the Celery Man easter egg by 1.3x — landscape Celery Man goes from 224pt → ~291pt tall, portrait CINCO ID from 384pt → ~499pt tall.
- Aspect ratios preserved (heights drive widths via the same ratios); side-by-side baseline alignment unchanged; Paul's COMPUTER panel deliberately not scaled.

## Test plan
- [x] Build clean
- [x] Trigger Celery Man easter egg in dev app — both video windows visibly larger, still side-by-side, baselines still aligned, Paul's COMPUTER unchanged
- [ ] Click Paul's COMPUTER → 4d3d3d3 chant + clip swap still lands correctly at the new size

Refs: W-66