### PR TITLE
W-67: ambient emoticon detection + picker UX polish

### DIFF
--- a/Mojito.xcodeproj/project.pbxproj
+++ b/Mojito.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		67DA454189FA317D03701E01 /* Snowfall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463478D4F770642DDCBA5C8F /* Snowfall.swift */; };
 		68D7BD3B3AB6699B56D7D578 /* s04.bin in Resources */ = {isa = PBXBuildFile; fileRef = 54037341F6A92839A94F3408 /* s04.bin */; };
 		6A8EC5B13FA4A0AC0F338875 /* ConfettiSound.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB589505841013FF5EF5500 /* ConfettiSound.swift */; };
+		6B48E883C3B324C8ABB16C93 /* AmbientEmoticonTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE7D78A4736AA53650D60DC /* AmbientEmoticonTable.swift */; };
 		6F9314FB48040BE582D87716 /* BlueScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD72EE1D10D399387F1DD1C8 /* BlueScreen.swift */; };
 		75008F5E9E8750E55512283C /* FzyScorer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5EDBB8F234B21B8D4A3324 /* FzyScorer.swift */; };
 		751B7D80FF9EA3BA8B30B8FC /* EasterEggsSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA756B434C9FED6B691D07B8 /* EasterEggsSettings.swift */; };
@@ -158,6 +159,7 @@
 		5FB7AB3DB0E63AF30880FE66 /* BrowserURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserURL.swift; sourceTree = "<group>"; };
 		6666150B793721D5095E72A8 /* SymbolsDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolsDatabase.swift; sourceTree = "<group>"; };
 		6E2009C3B36DF9228B873244 /* EmoticonTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmoticonTable.swift; sourceTree = "<group>"; };
+		6EE7D78A4736AA53650D60DC /* AmbientEmoticonTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmbientEmoticonTable.swift; sourceTree = "<group>"; };
 		702AC2870CD686AB17CC518E /* UpdaterCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdaterCoordinator.swift; sourceTree = "<group>"; };
 		70F2866D3BE0CC5D08CF9AD1 /* Emoji */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Emoji; path = Resources/Emoji; sourceTree = SOURCE_ROOT; };
 		74DB9192DF20F83CAD8A820C /* ImageBlob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageBlob.swift; sourceTree = "<group>"; };
@@ -438,6 +440,7 @@
 		D822FEA7909C200A1E98FE7E /* EmojiDB */ = {
 			isa = PBXGroup;
 			children = (
+				6EE7D78A4736AA53650D60DC /* AmbientEmoticonTable.swift */,
 				AB126DDBD153A051CDEF105B /* EggIndex.swift */,
 				9528726096C90D6A0523B86F /* Emoji.swift */,
 				019FC9E40B9630700D2106CE /* EmojiDatabase.swift */,
@@ -607,6 +610,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B43E634B3FAB6B7FBF2CFC6C /* AboutSettings.swift in Sources */,
+				6B48E883C3B324C8ABB16C93 /* AmbientEmoticonTable.swift in Sources */,
 				3FDBEFA3636F345D917BE553 /* AppContext.swift in Sources */,
 				87F16A28F58C4854576DD450 /* AppDelegate.swift in Sources */,
 				9CCEA0B70EEB77F988521DDB /* AppInfo.swift in Sources */,

--- a/Sources/Mojito/App/Engine.swift
+++ b/Sources/Mojito/App/Engine.swift
@@ -47,6 +47,10 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
     /// non-undo keystroke that would mutate text, app/process changes, or
     /// shutdown. Backs WEL-52 / WEL-53.
     private var pendingEmoticonUndo: EmoticonUndo?
+    /// Monotonic counter of inputs received. Conversion handlers capture
+    /// this at dispatch time; if it advances during the 80ms async window,
+    /// the user has typed past the conversion and we skip the undo entry.
+    private var inputSeq: Int = 0
     /// Max seconds after an emoticon insertion during which Cmd+Z or
     /// Backspace will roll it back. After this window the entry is dropped
     /// and the keystroke behaves normally.
@@ -254,6 +258,7 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
     }
 
     private func process(input: TriggerInput) -> Bool {
+        inputSeq &+= 1
         // BSOD-style "press any key to continue" effects pre-empt
         // everything — any keystroke pops them off the stack and is
         // consumed so it doesn't leak into the focused app underneath.
@@ -290,6 +295,14 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
             }
             return false
         }
+
+        // W-67: any keystroke other than backspace/cmdZ ends the
+        // emoticon-undo window. Without this, the undo entry persists
+        // across subsequent typing — and `TextInserter.replace` deletes
+        // from the current caret, not the post-conversion caret, so a
+        // backspace after `:) ` would delete the space and then *type*
+        // `:)` after the emoji (e.g. `🙂 ` → `🙂:)`).
+        pendingEmoticonUndo = nil
 
         // Before opening, check if current app/site is excluded or if the focused
         // field is a password field. Both must short-circuit BEFORE we transition
@@ -369,8 +382,33 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
             // on slower fields the synth-backspaces could fire while the
             // terminator was still in flight, leaving it stranded after
             // the inserted emoji (e.g. `:)` → `🙂)`).
+            let seqAtDispatch = inputSeq
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) { [weak self] in
-                self?.handleEmoticon(query: q, terminator: term)
+                guard let self else { return }
+                self.handleEmoticon(query: q, terminator: term)
+                if self.inputSeq != seqAtDispatch { self.pendingEmoticonUndo = nil }
+            }
+
+        case .checkAmbientEmoticon(let word, let term):
+            // Same 80ms deferral as the colon-emoticon path — the terminator
+            // was passed through to the focused app and we have to wait for
+            // it to land before issuing the synthetic backspaces.
+            let seqAtDispatch = inputSeq
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) { [weak self] in
+                guard let self else { return }
+                self.handleAmbientEmoticon(word: word, terminator: term)
+                if self.inputSeq != seqAtDispatch { self.pendingEmoticonUndo = nil }
+            }
+
+        case .insertAmbientEmoticon(let word):
+            // Immediate-fire ambient: no terminator, the last char of `word`
+            // was the trigger and was passed through. Same 80ms deferral so
+            // it actually lands before we delete back.
+            let seqAtDispatch = inputSeq
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) { [weak self] in
+                guard let self else { return }
+                self.handleAmbientEmoticonImmediate(word: word)
+                if self.inputSeq != seqAtDispatch { self.pendingEmoticonUndo = nil }
             }
 
         case .abortEmoticon:
@@ -736,6 +774,51 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
         // replacement was `:<query><terminator>` — restoring that is what
         // Cmd+Z / Backspace will do during the undo window.
         let original = ":" + query + String(terminator)
+        pendingEmoticonUndo = EmoticonUndo(
+            emojiInserted: replacement,
+            originalText: original,
+            insertedAt: Date(),
+            pid: FocusedElementCache.shared.focusedPID
+        )
+    }
+
+    /// Immediate-fire ambient — the entire word is the emoticon body
+    /// (no trailing terminator). Engine deletes `word.count` chars and
+    /// replaces them with the emoji.
+    private func handleAmbientEmoticonImmediate(word: String) {
+        let enabled = (UserDefaults.standard.object(forKey: PrefsKey.emoticonsEnabled) as? Bool) ?? true
+        guard enabled, let emoji = AmbientEmoticonTable.emoji(for: word) else {
+            pendingEmoticonUndo = nil
+            return
+        }
+        TextInserter.replace(charactersToDelete: word.count, with: emoji)
+
+        pendingEmoticonUndo = EmoticonUndo(
+            emojiInserted: emoji,
+            originalText: word,
+            insertedAt: Date(),
+            pid: FocusedElementCache.shared.focusedPID
+        )
+    }
+
+    /// Ambient counterpart to `handleEmoticon` — the user typed a whole
+    /// word (no leading `:`) followed by a terminator, and we look the word
+    /// up in `AmbientEmoticonTable`. Same enable gate, same undo registration.
+    private func handleAmbientEmoticon(word: String, terminator: Character) {
+        let enabled = (UserDefaults.standard.object(forKey: PrefsKey.emoticonsEnabled) as? Bool) ?? true
+        guard enabled, let emoji = AmbientEmoticonTable.emoji(for: word) else {
+            pendingEmoticonUndo = nil
+            return
+        }
+        // Field reads `<word><terminator>`. Delete both, then re-emit the
+        // emoji followed by the terminator — terminator is never part of an
+        // ambient emoticon (those are letter/punct sequences without
+        // trailing whitespace), so it always survives the conversion.
+        let charsToDelete = word.count + 1
+        let replacement = emoji + String(terminator)
+        TextInserter.replace(charactersToDelete: charsToDelete, with: replacement)
+
+        let original = word + String(terminator)
         pendingEmoticonUndo = EmoticonUndo(
             emojiInserted: replacement,
             originalText: original,

--- a/Sources/Mojito/EmojiDB/AmbientEmoticonTable.swift
+++ b/Sources/Mojito/EmojiDB/AmbientEmoticonTable.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Word-keyed emoticon table for *ambient* detection — no leading `:` required.
+///
+/// `TriggerStateMachine` accumulates an `idleWord` from each printable
+/// keystroke in `.idle` and consults this table whenever a terminator char
+/// (space, tab, newline, sentence punctuation) lands. The terminator itself
+/// is never part of the lookup key; only the run of chars between
+/// terminators (or between start-of-input and the first terminator) is
+/// matched.
+///
+/// Compared to `EmoticonTable` (which is keyed by the suffix after `:`),
+/// this one carries the full literal sequence the user typed, so
+/// case-sensitive variants like `XD` vs `xD` need explicit entries.
+enum AmbientEmoticonTable {
+    private static let map: [String: String] = [
+        "<3":   "❤️",
+        "</3":  "💔",
+        "XD":   "😆",
+        "xD":   "😆",
+        ">:)":  "😈",
+        ">:(":  "👿",
+        "B)":   "😎",
+        "O_o":  "😳",
+        "o_O":  "😳",
+    ]
+
+    /// Returns the emoji for a candidate word, or nil if no entry matches.
+    static func emoji(for word: String) -> String? {
+        map[word]
+    }
+
+    /// True if the word should fire the moment it completes, without waiting
+    /// for a terminator. Restricted to emoticons whose leading character is
+    /// non-alphanumeric (`<3`, `</3`, `>:)`, `>:(`), so letter-led ones like
+    /// `XD` or `B)` still require a terminator and don't eat into normal
+    /// prose (`XDog`, `Bobby`).
+    static func shouldFireImmediately(_ word: String) -> Bool {
+        guard let first = word.first else { return false }
+        if first.isLetter || first.isNumber { return false }
+        return map[word] != nil
+    }
+
+    /// All distinct first-character prefixes of ambient emoticons that contain a `:`
+    /// somewhere after the first char (currently just `>`). The state machine uses
+    /// this to decide whether a `:` typed in idle should continue building an ambient
+    /// word instead of starting colon-capture.
+    static let colonContinuationPrefixes: Set<String> = [">"]
+}

--- a/Sources/Mojito/EmojiDB/EmoticonTable.swift
+++ b/Sources/Mojito/EmojiDB/EmoticonTable.swift
@@ -28,6 +28,12 @@ enum EmoticonTable {
         "3":   "😺",
         "*":   "😘",
 
+        // Apostrophe variants (`:'(`, `:')`) — query is "'", terminator is
+        // the closing paren. `'` is a name char (see `KeyMonitor.isNameChar`)
+        // so the apostrophe lands in the query rather than ending capture.
+        "'(":  "😢",
+        "')":  "😂",
+
         // Dash variants (`:-)`, `:-D`, …) — query is "-".
         "-)":  "🙂",
         "-(":  "🙁",

--- a/Sources/Mojito/KeyMonitor/KeyMonitor.swift
+++ b/Sources/Mojito/KeyMonitor/KeyMonitor.swift
@@ -149,6 +149,10 @@ final class KeyMonitor {
 
     private func isNameChar(_ c: Character) -> Bool {
         if c.isLetter || c.isNumber { return true }
-        return c == "_" || c == "-" || c == "+"
+        // `'` is included so `:'(` and `:')` can be captured as queries with
+        // body `'` and terminator `(` / `)`. Side effect: `:foo'bar` is also
+        // a valid (if rarely useful) query; harmless because there's no
+        // shortcode that matches.
+        return c == "_" || c == "-" || c == "+" || c == "'"
     }
 }

--- a/Sources/Mojito/KeyMonitor/TriggerStateMachine.swift
+++ b/Sources/Mojito/KeyMonitor/TriggerStateMachine.swift
@@ -94,6 +94,18 @@ enum TriggerAction: Equatable {
     /// text field. Currently always 0 because every input in the sequence
     /// (arrows + B + A) is consumed before reaching the field.
     case triggerKonami(deleteCount: Int)
+    /// Ambient emoticon candidate — the user typed a word (no leading `:`)
+    /// followed by a terminator (space, period, etc.) and the state machine
+    /// is asking Engine to look the word up in `AmbientEmoticonTable`. The
+    /// terminator was passed through to the focused app (`consumesKey: false`).
+    /// Engine no-ops if there's no match; otherwise it deletes
+    /// `word.count + 1` chars and replaces with `emoji + terminator`.
+    case checkAmbientEmoticon(word: String, terminator: Character)
+    /// Ambient emoticon fired without a terminator — the word itself is the
+    /// complete match (e.g. `<3`, `>:)`). The last char of the word was just
+    /// typed and passed through (`consumesKey: false`); Engine deletes
+    /// `word.count` chars and replaces with the emoji.
+    case insertAmbientEmoticon(word: String)
 }
 
 struct TriggerStateMachine {
@@ -153,7 +165,34 @@ struct TriggerStateMachine {
     /// leave it alone.
     private static let emoticonMaxIdle: TimeInterval = 1.0
 
+    /// Buffer of chars typed in `.idle` since the last terminator. Drives
+    /// ambient emoticon detection (e.g. `<3 `, `XD `, `>:) `). Reset on
+    /// terminator (after a lookup), focus change, arrow keys, escape,
+    /// return/tab, colon entering capture, and after `emoticonMaxIdle` of
+    /// keyboard silence.
+    private var idleWord: String = ""
+
+    /// Wall-clock time of the most recent keystroke that contributed to
+    /// `idleWord`. Mirrors `lastCaptureKeystrokeAt` for the colon path.
+    private var lastIdleKeystrokeAt: Date? = nil
+
+    /// Word-terminator chars for ambient detection. Whitespace + sentence
+    /// punctuation. Closing brackets like `)` are deliberately *not* here —
+    /// they're part of emoticons (`B)`, `>:)`).
+    private static let ambientTerminators: Set<Character> = [
+        " ", "\t", "\n", ".", ",", ";", "!", "?",
+    ]
+
     mutating func handle(_ input: TriggerInput) -> TriggerOutput {
+        // Drop a stale ambient word if the user paused too long since the last
+        // contributing keystroke. Same threshold as the colon-emoticon idle
+        // check — covers click-to-move-caret followed by a delayed type.
+        if let last = lastIdleKeystrokeAt,
+           Date().timeIntervalSince(last) > Self.emoticonMaxIdle {
+            idleWord = ""
+            lastIdleKeystrokeAt = nil
+        }
+
         let output = process(input)
         // After processing, refresh word-boundary tracking when we end up idle.
         if case .idle = state {
@@ -216,6 +255,9 @@ struct TriggerStateMachine {
         case (.idle, .cmdZ):
             // Engine decides whether to actually undo (depends on whether
             // there's a pending emoticon-undo entry within the window).
+            // Drop the ambient buffer — Cmd+Z is a context-switching action.
+            idleWord = ""
+            lastIdleKeystrokeAt = nil
             return TriggerOutput(action: .maybeUndoEmoticon, consumesKey: false)
 
         case (.capturing, .cmdZ):
@@ -227,6 +269,22 @@ struct TriggerStateMachine {
 
         case (.idle, .colon):
             revivableQuery = nil
+            // Ambient prefix carve-out: if idleWord is exactly one of the
+            // known "starts an ambient emoticon containing `:`" prefixes
+            // (currently just `>`), let the colon continue the ambient word
+            // instead of starting colon-capture. Otherwise `>:)` would be
+            // intercepted by the colon path and only `:)` would convert,
+            // leaving the `>` behind.
+            if AmbientEmoticonTable.colonContinuationPrefixes.contains(idleWord) {
+                idleWord += ":"
+                lastIdleKeystrokeAt = Date()
+                if let fire = checkImmediateAmbientFire() {
+                    return fire
+                }
+                return TriggerOutput(action: .none, consumesKey: false)
+            }
+            idleWord = ""
+            lastIdleKeystrokeAt = nil
             if lastWasWordChar {
                 // Right after a letter/digit (e.g. "5:35", "foo:bar") — don't trigger; pass through.
                 return .passthrough
@@ -237,6 +295,12 @@ struct TriggerStateMachine {
             return TriggerOutput(action: .none, consumesKey: false)
 
         case (.idle, .backspace):
+            // Keep the ambient buffer in sync with the field — drop the last
+            // char if there's anything there.
+            if !idleWord.isEmpty {
+                idleWord = String(idleWord.dropLast())
+                lastIdleKeystrokeAt = idleWord.isEmpty ? nil : Date()
+            }
             // Revival: user typed `:foo<cancel-char>`, then backspaced the cancel char back
             // off. The `:foo` is still in the focused app — re-open the picker.
             // Revival is normal-scope only (we don't track scope across cancel).
@@ -248,8 +312,47 @@ struct TriggerStateMachine {
             }
             return .passthrough
 
-        case (.idle, _):
+        case (.idle, .nameChar(let c)):
             revivableQuery = nil
+            idleWord += String(c)
+            lastIdleKeystrokeAt = Date()
+            if let fire = checkImmediateAmbientFire() {
+                return fire
+            }
+            return .passthrough
+
+        case (.idle, .cancelChar(let c)):
+            revivableQuery = nil
+            if Self.ambientTerminators.contains(c) {
+                // Terminator — check the accumulated word against the ambient
+                // table, then reset. Empty word means there was nothing to
+                // match (e.g. two terminators in a row); no need to ask Engine.
+                let word = idleWord
+                idleWord = ""
+                lastIdleKeystrokeAt = nil
+                if word.isEmpty {
+                    return .passthrough
+                }
+                return TriggerOutput(
+                    action: .checkAmbientEmoticon(word: word, terminator: c),
+                    consumesKey: false
+                )
+            }
+            // Non-terminator punctuation (`<`, `>`, `)`, `(`, `_`, etc.) —
+            // part of an emoticon body. Append and keep accumulating.
+            idleWord += String(c)
+            lastIdleKeystrokeAt = Date()
+            if let fire = checkImmediateAmbientFire() {
+                return fire
+            }
+            return .passthrough
+
+        case (.idle, _):
+            // Arrows, focus change, escape, return/tab in idle — all caret-
+            // motion-y or context-switching. Drop the buffer.
+            revivableQuery = nil
+            idleWord = ""
+            lastIdleKeystrokeAt = nil
             return .passthrough
 
         // MARK: capturing — colon
@@ -282,11 +385,18 @@ struct TriggerStateMachine {
             let next = q + String(c)
             state = .capturing(query: next)
             // Pass the character through so it appears in the text field.
-            return TriggerOutput(
-                action: q.isEmpty ? .openPicker(query: next, scope: currentScope)
-                                  : .refreshPicker(query: next, scope: currentScope),
-                consumesKey: false
-            )
+            let threshold = pickerThreshold(for: currentScope)
+            let action: TriggerAction
+            if next.count < threshold {
+                // Below threshold — keep capturing silently so a terminator can still
+                // fire a colon emoticon (e.g. `:D `), but don't surface the picker.
+                action = .none
+            } else if q.count < threshold {
+                action = .openPicker(query: next, scope: currentScope)
+            } else {
+                action = .refreshPicker(query: next, scope: currentScope)
+            }
+            return TriggerOutput(action: action, consumesKey: false)
 
         // MARK: capturing — backspace
 
@@ -304,12 +414,13 @@ struct TriggerStateMachine {
             }
             let next = String(q.dropLast())
             state = .capturing(query: next)
-            // Let the backspace through; refresh picker (or close if empty).
-            return TriggerOutput(
-                action: next.isEmpty ? .closePicker
-                                     : .refreshPicker(query: next, scope: currentScope),
-                consumesKey: false
-            )
+            // Let the backspace through; refresh picker, or close it if the
+            // remaining query is empty or has dropped below the threshold.
+            let threshold = pickerThreshold(for: currentScope)
+            let action: TriggerAction = next.count < threshold
+                ? .closePicker
+                : .refreshPicker(query: next, scope: currentScope)
+            return TriggerOutput(action: action, consumesKey: false)
 
         // MARK: capturing — picker navigation
 
@@ -394,5 +505,29 @@ struct TriggerStateMachine {
         lastWasWordChar = false
         revivableQuery = nil
         konamiProgress = 0
+        idleWord = ""
+        lastIdleKeystrokeAt = nil
+        lastCaptureKeystrokeAt = nil
+    }
+
+    /// Minimum query length before the picker opens. Suppresses the briefly-
+    /// visible single-letter picker (e.g. when typing `:D ` for 😃, or `:s`
+    /// before `:smile:`). Symbols-only scope keeps the 1-char threshold
+    /// because the symbols corpus is dominated by single-char entries.
+    private func pickerThreshold(for scope: CaptureScope) -> Int {
+        scope == .symbolsOnly ? 1 : 2
+    }
+
+    /// Returns an immediate-fire output if the current `idleWord` is a
+    /// complete ambient emoticon that should fire without waiting for a
+    /// terminator. Clears `idleWord` as a side effect when firing.
+    private mutating func checkImmediateAmbientFire() -> TriggerOutput? {
+        guard AmbientEmoticonTable.shouldFireImmediately(idleWord) else {
+            return nil
+        }
+        let word = idleWord
+        idleWord = ""
+        lastIdleKeystrokeAt = nil
+        return TriggerOutput(action: .insertAmbientEmoticon(word: word), consumesKey: false)
     }
 }


### PR DESCRIPTION
## Summary

Ambient (no-colon) emoticon detection plus a couple of related UX fixes.

**New emoticons** (all gated on the existing `PrefsKey.emoticonsEnabled` toggle):

| Type | Mapping |
|---|---|
| `<3` | ❤️ |
| `</3` | 💔 |
| `>:)` | 😈 |
| `>:(` | 👿 |
| `XD` / `xD` | 😆 |
| `B)` | 😎 |
| `O_o` / `o_O` | 😳 |
| `:'( ` | 😢 |
| `:') ` | 😂 |

**How it works:**
- `TriggerStateMachine` grows an `idleWord` buffer in idle state. Every printable char appends; terminators (space, tab, newline, `.,;!?`) trigger lookup-and-reset against `AmbientEmoticonTable`. Backspace pops; arrow/focus/return/tab/cmdZ drop the whole buffer; 1-second idle timeout clears it.
- Emoticons whose leading char is non-alphanumeric (`<3`, `</3`, `>:)`, `>:(`) fire **immediately** on completion. Letter-led ones (`XD`, `B)`, `O_o`) still need a terminator so they don't eat into `XDog` / `Bobby`.
- `>:)` works via a "colon continuation" carve-out — when `:` is typed in idle and `idleWord == ">"`, the colon continues the ambient word instead of starting colon-capture.
- `:'(` / `:')` route through the existing colon path: `'` is now a name char in `KeyMonitor.isNameChar`, so the apostrophe lands in the query and `(` / `)` terminates it via `EmoticonTable`.

**Picker UX polish:**
- Normal-scope picker waits for 2+ query chars before opening. Suppresses the flash for `:D `, `:'( `, etc. Symbols-only scope (`::foo`) keeps the 1-char threshold because that corpus is dominated by single-char entries.

**Backspace-undo fix bundled in:**
- Previously, `:) ` + backspace fired the emoticon-undo against a caret that was past the trailing space, producing `🙂:)`. Backspace-undo now requires backspace to be the *very next* input after the conversion. Two guards:
  - `pendingEmoticonUndo` is cleared at the top of `Engine.process` for any non-backspace/non-cmdZ input.
  - An `inputSeq` counter is captured at conversion dispatch; if it advances during the 80ms async window (fast typing), the deferred handler skips the undo registration.

## Test plan

- [x] `:smile:` still works
- [x] `:)` `:D` `:3` `:|` still work
- [x] `5:35` still does not trigger
- [x] `<3` / `</3` / `>:)` / `>:(` fire on the last char (no space needed)
- [x] `XD ` / `xD ` / `B) ` / `O_o ` / `o_O ` fire on terminator
- [x] `:'( ` / `:') ` fire via colon path
- [x] `x<3 ` does NOT convert (no word boundary before `<`)
- [x] `:D ` no longer flashes the picker
- [x] `::s` still pops the symbols picker on first char
- [x] `:) ` + backspace → `🙂` (space deleted, no undo misfire)
- [x] `<3 ` + backspace → `❤️` (same)
- [x] `:)` + immediate backspace → `:)` (legitimate undo still works)
- [x] `<3` + immediate backspace → `<3` (immediate-fire emoticons also undoable)

Refs: W-67