### PR TITLE
W-82: in-app achievement banner above easter eggs

### DIFF
--- a/Mojito.xcodeproj/project.pbxproj
+++ b/Mojito.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		BE7285D962997851909C1498 /* GeneralSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3154DBEA72DA316E341C440 /* GeneralSettings.swift */; };
 		BEB1C0A9AD31B883B9B4E884 /* CaretLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786373C2E5DE4642148857B1 /* CaretLocator.swift */; };
 		BF8DBC3E1BD0A9EA4720C6DD /* FloppySound.swift in Sources */ = {isa = PBXBuildFile; fileRef = D73A20EA050B0CD0E8FB1CA6 /* FloppySound.swift */; };
+		C7EAEBA38EE85743E109E1B4 /* AchievementBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A31DD44ACC90D6CAC3A486 /* AchievementBanner.swift */; };
 		C892E976ED36AA1810770521 /* CeleryMan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 947CA35F448BC012E3F73860 /* CeleryMan.swift */; };
 		CA1857DDE9F106C6CCB3FD2F /* v09.bin in Resources */ = {isa = PBXBuildFile; fileRef = 4F4CFB098FFC29AB8C8B9855 /* v09.bin */; };
 		CA9FE651B042EFCC920407D5 /* ImageBlob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74DB9192DF20F83CAD8A820C /* ImageBlob.swift */; };
@@ -172,6 +173,7 @@
 		8792D3A9CA964FE06B29F30F /* PrideWave.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrideWave.swift; sourceTree = "<group>"; };
 		90F7DB616A5940BE3DE17B77 /* EggStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EggStrings.swift; sourceTree = "<group>"; };
 		947CA35F448BC012E3F73860 /* CeleryMan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CeleryMan.swift; sourceTree = "<group>"; };
+		94A31DD44ACC90D6CAC3A486 /* AchievementBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementBanner.swift; sourceTree = "<group>"; };
 		9528726096C90D6A0523B86F /* Emoji.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Emoji.swift; sourceTree = "<group>"; };
 		9A52A0EFB2F81DFBE699AC6D /* v05.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; path = v05.bin; sourceTree = "<group>"; };
 		9C81578D7A36FB7EA31D1985 /* Fireworks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fireworks.swift; sourceTree = "<group>"; };
@@ -373,6 +375,7 @@
 		ABDF9E60F36CAC7A465AC7B3 /* App */ = {
 			isa = PBXGroup;
 			children = (
+				94A31DD44ACC90D6CAC3A486 /* AchievementBanner.swift */,
 				22B06D1C751C2161A7A99DA1 /* AppDelegate.swift */,
 				AD72EE1D10D399387F1DD1C8 /* BlueScreen.swift */,
 				0836B5ACF7E24509928DA7B0 /* BouncingDVD.swift */,
@@ -610,6 +613,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B43E634B3FAB6B7FBF2CFC6C /* AboutSettings.swift in Sources */,
+				C7EAEBA38EE85743E109E1B4 /* AchievementBanner.swift in Sources */,
 				6B48E883C3B324C8ABB16C93 /* AmbientEmoticonTable.swift in Sources */,
 				3FDBEFA3636F345D917BE553 /* AppContext.swift in Sources */,
 				87F16A28F58C4854576DD450 /* AppDelegate.swift in Sources */,

--- a/Sources/Mojito/App/AchievementBanner.swift
+++ b/Sources/Mojito/App/AchievementBanner.swift
@@ -1,0 +1,132 @@
+import AppKit
+import SwiftUI
+
+/// In-app achievement banner shown when an easter egg is first discovered.
+/// Rendered at `kCGPopUpMenuWindowLevel` (101) so it draws above the full-
+/// screen egg panels (which sit at `kCGStatusWindowLevel` = 25). The system
+/// notification from `DiscoveryNotifier` still fires alongside this banner
+/// for Notification Center history — this is the primary, guaranteed signal.
+@MainActor
+enum AchievementBanner {
+    private static var queue: [EasterEgg] = []
+    private static var currentPanel: NSPanel?
+
+    static func show(_ egg: EasterEgg) {
+        queue.append(egg)
+        if currentPanel == nil { showNext() }
+    }
+
+    private static func showNext() {
+        guard !queue.isEmpty else { return }
+        let egg = queue.removeFirst()
+        guard let screen = NSScreen.main ?? NSScreen.screens.first else { return }
+
+        let bannerSize = NSSize(width: 360, height: 80)
+        let margin: CGFloat = 16
+        let visibleFrame = screen.visibleFrame
+        let restingOrigin = NSPoint(
+            x: visibleFrame.maxX - bannerSize.width - margin,
+            y: visibleFrame.maxY - bannerSize.height - margin
+        )
+        // Off-screen above the resting position; we animate down into place.
+        let offscreenOrigin = NSPoint(x: restingOrigin.x, y: restingOrigin.y + bannerSize.height + margin + 40)
+
+        let panel = NSPanel(
+            contentRect: NSRect(origin: offscreenOrigin, size: bannerSize),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.ignoresMouseEvents = true
+        panel.level = NSWindow.Level(Int(CGWindowLevelForKey(.popUpMenuWindow)))
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle, .stationary]
+
+        let total = EasterEggTracker.totalCount
+        let discovered = EasterEggTracker.discoveredCount
+        let host = NSHostingView(rootView: BannerView(
+            egg: egg,
+            discoveredCount: discovered,
+            totalCount: total
+        ))
+        host.frame = NSRect(origin: .zero, size: bannerSize)
+        panel.contentView = host
+        panel.orderFrontRegardless()
+        currentPanel = panel
+
+        // Slide in.
+        NSAnimationContext.runAnimationGroup({ ctx in
+            ctx.duration = 0.35
+            ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            panel.animator().setFrameOrigin(restingOrigin)
+        })
+
+        // Hold ~3.5 s, slide out, then dequeue the next banner.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35 + 3.5) {
+            MainActor.assumeIsolated {
+                guard currentPanel === panel else { return }
+                NSAnimationContext.runAnimationGroup({ ctx in
+                    ctx.duration = 0.35
+                    ctx.timingFunction = CAMediaTimingFunction(name: .easeIn)
+                    panel.animator().setFrameOrigin(offscreenOrigin)
+                    panel.animator().alphaValue = 0
+                }, completionHandler: {
+                    MainActor.assumeIsolated {
+                        panel.orderOut(nil)
+                        if currentPanel === panel { currentPanel = nil }
+                        showNext()
+                    }
+                })
+            }
+        }
+    }
+}
+
+private struct BannerView: View {
+    let egg: EasterEgg
+    let discoveredCount: Int
+    let totalCount: Int
+
+    // Sampled from the bundled app icons (also used by DialupView).
+    private let mojitoOrange = Color(red: 0.95, green: 0.70, blue: 0.25)
+
+    var body: some View {
+        HStack(spacing: 14) {
+            Text(egg.emojiGlyph ?? "🎉")
+                .font(.system(size: 36))
+                .frame(width: 44, height: 44)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Easter egg discovered")
+                    .font(.system(size: 11, weight: .semibold, design: .rounded))
+                    .foregroundStyle(mojitoOrange)
+                    .textCase(.uppercase)
+                Text(egg.title)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                Text(discoveredCount >= totalCount
+                     ? "All \(totalCount) found"
+                     : "\(discoveredCount) of \(totalCount)")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(.regularMaterial)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .strokeBorder(Color.primary.opacity(0.10), lineWidth: 1)
+                )
+                .shadow(color: .black.opacity(0.20), radius: 12, x: 0, y: 4)
+        )
+        .padding(2)
+    }
+}

--- a/Sources/Mojito/App/EasterEggTracker.swift
+++ b/Sources/Mojito/App/EasterEggTracker.swift
@@ -202,6 +202,10 @@ enum EasterEggTracker {
         guard cache.insert(egg.rawValue).inserted else { return }
         UserDefaults.standard.set(Array(cache), forKey: PrefsKey.easterEggsDiscovered)
         NotificationCenter.default.post(name: .easterEggDiscovered, object: nil)
+        // In-app banner is the primary signal — sits above egg panels and
+        // doesn't depend on notification permission. DiscoveryNotifier still
+        // fires so the discovery shows up in Notification Center history.
+        AchievementBanner.show(egg)
         DiscoveryNotifier.notify(egg)
     }
 


### PR DESCRIPTION
## Summary
- macOS notifications from `DiscoveryNotifier` already sit above egg panels at the window-server level, but they depend on notification permission and are easy to miss against a full-screen egg.
- New `AchievementBanner`: borderless, click-through `NSPanel` at `kCGPopUpMenuWindowLevel` (101, above the eggs' `kCGStatusWindowLevel` = 25). Slides down from top-right of the main screen, holds ~3.5 s, slides back out.
- Shows the egg's emoji glyph + title + "n of total" discovery count, styled with `.regularMaterial` glass and a subtle shadow.
- Multiple in-flight discoveries are queued so a second one doesn't overlap the first.
- `EasterEggTracker.record` now fires the banner next to `DiscoveryNotifier.notify` (kept for Notification Center history).

## Test plan
- [ ] Reset eggs via Settings → Easter Eggs → Reset
- [ ] Trigger any egg — banner slides in top-right *over* the full-screen effect, holds, slides out
- [ ] Trigger a second never-discovered egg while the first banner is up → second is queued, shows after first exits
- [ ] Already-discovered eggs do **not** re-trigger the banner (record is idempotent)
- [ ] Notification Center still receives an entry if permission granted

Refs: W-82