### PR TITLE
W-117: banner bounce, WOPR voice via say, .icon fix, dev auto-relaunch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,8 +25,10 @@ xcodegen generate
 # as a fallback layer (see Sources/Mojito/App/main.swift).
 xcodebuild -project Mojito.xcodeproj -scheme Mojito -configuration Debug -destination 'platform=macOS' build
 
-# Run a fresh Debug build (a post-build phase rsyncs Mojito Dev.app to /Applications)
-pkill -x "Mojito Dev"; open "/Applications/Mojito Dev.app"
+# A post-build phase rsyncs Mojito Dev.app to /Applications and — if the app
+# was already running — auto-kills + relaunches it so the new binary takes
+# over. Cold builds (app not running) don't auto-launch; start manually:
+open "/Applications/Mojito Dev.app"
 
 # Full release (Developer ID signing → notarize → staple → Sparkle-sign DMG → gh release → push gh-pages).
 # APPLE_TEAM_ID and GITHUB_REPO come from your shell env (e.g. ~/.zshrc or a local .envrc).

--- a/Mojito.xcodeproj/project.pbxproj
+++ b/Mojito.xcodeproj/project.pbxproj
@@ -145,7 +145,7 @@
 		151DC25F7CEE4F3BE8F23650 /* CRTPowerOff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CRTPowerOff.swift; sourceTree = "<group>"; };
 		186ED6EF6F678E8C3F082FD8 /* MoofSound.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoofSound.swift; sourceTree = "<group>"; };
 		1A1F4596F8DFA66A87D50D02 /* OnboardingWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingWindowController.swift; sourceTree = "<group>"; };
-		1BA5A32889912268FF08AB30 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder; name = AppIcon.icon; path = Resources/AppIcon.icon; sourceTree = SOURCE_ROOT; };
+		1BA5A32889912268FF08AB30 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = AppIcon.icon; sourceTree = "<group>"; };
 		1C7AACE4E2FA1FB07AB5083A /* XPLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XPLogin.swift; sourceTree = "<group>"; };
 		2027256AFD59D65C41FAA2AD /* PermissionsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsCoordinator.swift; sourceTree = "<group>"; };
 		22B06D1C751C2161A7A99DA1 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -224,7 +224,7 @@
 		C410F8B7AF8493C098EA2AF1 /* ConfettiRain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfettiRain.swift; sourceTree = "<group>"; };
 		C7CD240E9450366313F15198 /* PrivacyPermissionsSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyPermissionsSettings.swift; sourceTree = "<group>"; };
 		C876AD00FBA92A6CA56ABD95 /* s07.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; path = s07.bin; sourceTree = "<group>"; };
-		CDB886D82441D68D2F815AD3 /* AppIconDev.icon */ = {isa = PBXFileReference; lastKnownFileType = folder; name = AppIconDev.icon; path = Resources/AppIconDev.icon; sourceTree = SOURCE_ROOT; };
+		CDB886D82441D68D2F815AD3 /* AppIconDev.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = AppIconDev.icon; sourceTree = "<group>"; };
 		D05EB6710B1D2B6310DE45AC /* s14.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; path = s14.bin; sourceTree = "<group>"; };
 		D2C4C16E01184684E33C3437 /* MyLegSound.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyLegSound.swift; sourceTree = "<group>"; };
 		D2F34180D15CF8B53F58B2A2 /* TextInserter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextInserter.swift; sourceTree = "<group>"; };
@@ -675,7 +675,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \"$CONFIGURATION\" = \"Debug\" ]; then\n  rsync -a --delete \"$TARGET_BUILD_DIR/$WRAPPER_NAME/\" \"/Applications/$WRAPPER_NAME/\"\n  echo \"Copied $WRAPPER_NAME to /Applications/\"\nfi\n";
+			shellScript = "if [ \"$CONFIGURATION\" = \"Debug\" ]; then\n  # Xcode 26's build system schedules this script BEFORE the\n  # bundle's implicit codesign step (and serializes them — we\n  # can't poll-wait because codesign blocks on us finishing).\n  # So we sign the destination ourselves with the same identity\n  # Xcode uses (`EXPANDED_CODE_SIGN_IDENTITY` is the cert SHA-1).\n  # Sparkle.framework was signed earlier in the build and rsyncs\n  # over already-signed; we just need to (re)sign the dylibs and\n  # the bundle wrapper.\n  rsync -a --delete \"$TARGET_BUILD_DIR/$WRAPPER_NAME/\" \"/Applications/$WRAPPER_NAME/\"\n  DEST=\"/Applications/$WRAPPER_NAME\"\n  for f in \"$DEST/Contents/MacOS\"/*.dylib; do\n    [ -f \"$f\" ] && codesign --force --sign \"$EXPANDED_CODE_SIGN_IDENTITY\" \\\n      --options runtime --timestamp=none \"$f\" >/dev/null\n  done\n  codesign --force --sign \"$EXPANDED_CODE_SIGN_IDENTITY\" \\\n    --entitlements \"$SRCROOT/$CODE_SIGN_ENTITLEMENTS\" \\\n    --options runtime --timestamp=none \"$DEST\" >/dev/null\n  echo \"Copied $WRAPPER_NAME to /Applications/ (signed in place)\"\n  # If the app was already running, quit and relaunch from the new\n  # build. `pkill` returns 0 only when it actually signalled something,\n  # which doubles as our \"was running\" check — skip the relaunch on\n  # a cold build so we don't surprise-launch the app.\n  APP_NAME=\"${WRAPPER_NAME%.app}\"\n  if pkill -x \"$APP_NAME\" 2>/dev/null; then\n    # Wait for clean exit so `open` picks up the freshly-copied bundle.\n    for _ in 1 2 3 4 5 6 7 8 9 10; do\n      pgrep -x \"$APP_NAME\" >/dev/null || break\n      sleep 0.1\n    done\n    open \"/Applications/$WRAPPER_NAME\"\n    echo \"Relaunched $WRAPPER_NAME\"\n  fi\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -893,7 +893,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APP_ICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				ASSETCATALOG_COMPILER_APPICON_NAME = "$(APP_ICON_NAME)";
 				CODE_SIGN_ENTITLEMENTS = Resources/Mojito.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 5;
@@ -985,7 +985,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APP_ICON_NAME = AppIconDev;
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				ASSETCATALOG_COMPILER_APPICON_NAME = "$(APP_ICON_NAME)";
 				CODE_SIGN_ENTITLEMENTS = Resources/Mojito.dev.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 5;

--- a/Mojito.xcodeproj/xcshareddata/xcschemes/Mojito.xcscheme
+++ b/Mojito.xcodeproj/xcshareddata/xcschemes/Mojito.xcscheme
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
-   version = "1.7">
+   LastUpgradeVersion = "2650"
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES"
-      runPostActionsOnFailure = "NO">
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -16,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "314D574AC0650E4957C28C71"
-               BuildableName = "Mojito.app"
+               BuildableName = "Mojito Dev.app"
                BlueprintName = "Mojito"
                ReferencedContainer = "container:Mojito.xcodeproj">
             </BuildableReference>
@@ -27,13 +26,12 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "314D574AC0650E4957C28C71"
-            BuildableName = "Mojito.app"
+            BuildableName = "Mojito Dev.app"
             BlueprintName = "Mojito"
             ReferencedContainer = "container:Mojito.xcodeproj">
          </BuildableReference>
@@ -51,8 +49,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -69,13 +65,11 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "314D574AC0650E4957C28C71"
-            BuildableName = "Mojito.app"
+            BuildableName = "Mojito Dev.app"
             BlueprintName = "Mojito"
             ReferencedContainer = "container:Mojito.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -88,13 +82,11 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "314D574AC0650E4957C28C71"
-            BuildableName = "Mojito.app"
+            BuildableName = "Mojito Dev.app"
             BlueprintName = "Mojito"
             ReferencedContainer = "container:Mojito.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Mojito.xcodeproj/xcshareddata/xcschemes/Mojito.xcscheme
+++ b/Mojito.xcodeproj/xcshareddata/xcschemes/Mojito.xcscheme
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2650"
-   version = "1.3">
+   LastUpgradeVersion = "1430"
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -15,7 +16,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "314D574AC0650E4957C28C71"
-               BuildableName = "Mojito Dev.app"
+               BuildableName = "Mojito.app"
                BlueprintName = "Mojito"
                ReferencedContainer = "container:Mojito.xcodeproj">
             </BuildableReference>
@@ -26,12 +27,13 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "314D574AC0650E4957C28C71"
-            BuildableName = "Mojito Dev.app"
+            BuildableName = "Mojito.app"
             BlueprintName = "Mojito"
             ReferencedContainer = "container:Mojito.xcodeproj">
          </BuildableReference>
@@ -49,6 +51,8 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -65,11 +69,13 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "314D574AC0650E4957C28C71"
-            BuildableName = "Mojito Dev.app"
+            BuildableName = "Mojito.app"
             BlueprintName = "Mojito"
             ReferencedContainer = "container:Mojito.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -82,11 +88,13 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "314D574AC0650E4957C28C71"
-            BuildableName = "Mojito Dev.app"
+            BuildableName = "Mojito.app"
             BlueprintName = "Mojito"
             ReferencedContainer = "container:Mojito.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -10,6 +10,8 @@
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIconFile</key>
 	<string>$(APP_ICON_NAME)</string>
+	<key>CFBundleIconName</key>
+	<string>$(APP_ICON_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/Sources/Mojito/App/AchievementBanner.swift
+++ b/Sources/Mojito/App/AchievementBanner.swift
@@ -1,6 +1,11 @@
 import AppKit
 import SwiftUI
 
+@MainActor
+final class BannerController: ObservableObject {
+    @Published var visible: Bool = false
+}
+
 /// In-app achievement banner shown when an easter egg is first discovered.
 /// Top-center blue pill — deliberately distinct from the macOS notification
 /// banner (which slides in from the top-right with glass material). The
@@ -18,9 +23,8 @@ enum AchievementBanner {
     /// doesn't block clicks.
     private static let panelSize = NSSize(width: 600, height: 80)
     private static let topMargin: CGFloat = 4
-    private static let exitOffsetY: CGFloat = 24
     private static let holdDuration: TimeInterval = 3.5
-    private static let exitDuration: TimeInterval = 0.18
+    private static let exitDuration: TimeInterval = 0.3
 
     static func show(_ egg: EasterEgg) {
         queue.append(egg)
@@ -39,8 +43,6 @@ enum AchievementBanner {
             width: panelSize.width,
             height: panelSize.height
         )
-        // Exit-only motion: panel slides up + fades out after the hold.
-        let exitFrame = restingFrame.offsetBy(dx: 0, dy: exitOffsetY)
 
         let panel = NSPanel(
             contentRect: restingFrame,
@@ -51,12 +53,13 @@ enum AchievementBanner {
         panel.isOpaque = false
         panel.backgroundColor = .clear
         panel.hasShadow = false  // SwiftUI draws its own shadow under the capsule
-        panel.alphaValue = 1.0  // no fade-in; the SwiftUI scale-pop is the entry
+        panel.alphaValue = 1.0
         panel.ignoresMouseEvents = true
         panel.level = NSWindow.Level(Int(CGWindowLevelForKey(.popUpMenuWindow)))
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle, .stationary]
 
-        let host = NSHostingView(rootView: BannerView(egg: egg))
+        let controller = BannerController()
+        let host = NSHostingView(rootView: BannerView(egg: egg, controller: controller))
         host.translatesAutoresizingMaskIntoConstraints = false
         let container = NSView(frame: NSRect(origin: .zero, size: panelSize))
         container.addSubview(host)
@@ -70,12 +73,16 @@ enum AchievementBanner {
         panel.orderFrontRegardless()
         currentPanel = panel
 
-        // Entry is SwiftUI-driven (scale spring in BannerView). Schedule the
-        // fadeOutUp exit after the hold.
+        // Entry + exit are both SwiftUI-driven scale springs in BannerView.
+        // After the hold, flip `visible` to false to play the shrink-down,
+        // then order the panel out once the spring has settled.
         DispatchQueue.main.asyncAfter(deadline: .now() + holdDuration) {
             MainActor.assumeIsolated {
                 guard currentPanel === panel else { return }
-                tween(panel: panel, from: restingFrame, to: exitFrame, startAlpha: 1, endAlpha: 0, duration: exitDuration) {
+                withAnimation(.easeIn(duration: 0.22)) {
+                    controller.visible = false
+                }
+                DispatchQueue.main.asyncAfter(deadline: .now() + exitDuration) {
                     MainActor.assumeIsolated {
                         panel.orderOut(nil)
                         if currentPanel === panel { currentPanel = nil }
@@ -85,45 +92,11 @@ enum AchievementBanner {
             }
         }
     }
-
-    /// Non-blocking timer-driven frame + alpha tween with ease-out cubic.
-    /// `setFrame(animate:)` blocks the main thread (freezing the very
-    /// egg effect we're announcing) and `animator().setFrame` silently
-    /// no-ops on borderless panels, so we drive the animation by hand.
-    private static func tween(
-        panel: NSPanel,
-        from start: NSRect,
-        to end: NSRect,
-        startAlpha: CGFloat,
-        endAlpha: CGFloat,
-        duration: TimeInterval,
-        completion: @escaping () -> Void
-    ) {
-        panel.setFrameOrigin(NSPoint(x: start.minX, y: start.minY))
-        panel.alphaValue = startAlpha
-        let startTime = Date()
-        let timer = Timer(timeInterval: 1.0 / 60.0, repeats: true) { t in
-            MainActor.assumeIsolated {
-                let elapsed = Date().timeIntervalSince(startTime)
-                let progress = min(1.0, elapsed / duration)
-                let eased = 1 - pow(1 - progress, 3)
-                let x = start.minX + (end.minX - start.minX) * eased
-                let y = start.minY + (end.minY - start.minY) * eased
-                panel.setFrameOrigin(NSPoint(x: x, y: y))
-                panel.alphaValue = startAlpha + (endAlpha - startAlpha) * eased
-                if progress >= 1.0 {
-                    t.invalidate()
-                    completion()
-                }
-            }
-        }
-        RunLoop.main.add(timer, forMode: .common)
-    }
 }
 
 private struct BannerView: View {
     let egg: EasterEgg
-    @State private var entered: Bool = false
+    @ObservedObject var controller: BannerController
 
     var body: some View {
         HStack(spacing: 8) {
@@ -149,14 +122,15 @@ private struct BannerView: View {
                 .shadow(color: .black.opacity(0.25), radius: 8, y: 2)
         )
         .fixedSize()  // pill width hugs content
-        // Horizontal scale-pop: starts at ~14% width (≈ pill height → circle)
-        // and snaps to 100% with a mild elastic overshoot (~peak 1.05).
-        // y stays at 1.0 so text height doesn't squash. Anchor defaults to .center.
-        .scaleEffect(x: entered ? 1.0 : 0.14, y: 1.0)
+        // Bouncy scale-pop in/out from center. Both axes scale together so
+        // the pill grows from a tiny dot into its resting size with an
+        // elastic overshoot, and shrinks back to a dot on dismiss.
+        .scaleEffect(controller.visible ? 1.0 : 0.0, anchor: .center)
+        .opacity(controller.visible ? 1.0 : 0.0)
         .frame(maxWidth: .infinity, maxHeight: .infinity)  // center pill within the oversized panel stage
         .onAppear {
-            withAnimation(.spring(response: 0.28, dampingFraction: 0.65)) {
-                entered = true
+            withAnimation(.spring(response: 0.42, dampingFraction: 0.55)) {
+                controller.visible = true
             }
         }
     }

--- a/Sources/Mojito/App/TicTacToeGame.swift
+++ b/Sources/Mojito/App/TicTacToeGame.swift
@@ -79,8 +79,7 @@ private struct TicTacToeView: View {
     @State private var showMonologue = false
     @State private var typedCount: Int = 0
     @State private var typeTimer: Timer?
-    @State private var speechSynth: AVSpeechSynthesizer?
-    @State private var speechDelegate: SpeechDelegate?
+    @State private var sayTask: Process?
     /// Set at each `\n\n` so the on-screen pause matches the narration's
     /// `[[slnc …]]` beat.
     @State private var typeResumeAt: Date?
@@ -215,9 +214,8 @@ private struct TicTacToeView: View {
         .onDisappear {
             typeTimer?.invalidate()
             typeTimer = nil
-            speechSynth?.stopSpeaking(at: .immediate)
-            speechSynth = nil
-            speechDelegate = nil
+            sayTask?.terminate()
+            sayTask = nil
         }
     }
 
@@ -236,7 +234,10 @@ private struct TicTacToeView: View {
         typeTimer?.invalidate()
         startNarration()
         let chars = Array(monologue)
-        typeTimer = Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { t in
+        // 0.085s/char keeps the typewriter roughly in sync with Fred at
+        // his default ~175 wpm pace; the 700ms pause below mirrors
+        // `[[slnc 700]]` so the mid-monologue beat lines up.
+        typeTimer = Timer.scheduledTimer(withTimeInterval: 0.085, repeats: true) { t in
             DispatchQueue.main.async {
                 if let resumeAt = typeResumeAt, Date() < resumeAt {
                     return
@@ -261,41 +262,36 @@ private struct TicTacToeView: View {
         }
     }
 
-    /// Junior voice, falling back to system default. The monologue is
-    /// split at `\n\n` into separate utterances; the second utterance's
-    /// `preUtteranceDelay` injects the 700ms beat that matches the
-    /// typewriter pause. (AVSpeechSynthesizer doesn't honor the
-    /// `[[slnc …]]` markup that NSSpeechSynthesizer did.)
+    /// Speaks the monologue via `/usr/bin/say -v Fred`, matching the
+    /// donation thank-you. No `-r` override so Fred speaks at his default
+    /// ~175 wpm — the WOPR monologue lands better at a measured pace than
+    /// at the donation's clipped 300 wpm. `[[slnc 700]]` injects the
+    /// mid-monologue beat. `terminationHandler` fires when `say` exits
+    /// (or is terminated on dismiss), so we linger 3s after the last
+    /// syllable like before.
     private func startNarration() {
-        let synth = AVSpeechSynthesizer()
-        let voice = AVSpeechSynthesisVoice(identifier: "com.apple.speech.synthesis.voice.Junior")
-            ?? AVSpeechSynthesisVoice(language: "en-US")
-
-        let parts = monologue.components(separatedBy: "\n\n").map {
-            $0.replacingOccurrences(of: "\n", with: " ")
-        }
-        var utterances: [AVSpeechUtterance] = []
-        for (i, part) in parts.enumerated() {
-            let u = AVSpeechUtterance(string: part)
-            u.voice = voice
-            // ~230 wpm in the NS API corresponded to a slightly fast Junior;
-            // 0.55 on the 0..1 AV scale lands in the same ballpark.
-            u.rate = 0.55
-            if i > 0 { u.preUtteranceDelay = 0.7 }
-            utterances.append(u)
-        }
-
-        let last = utterances.last
-        let delegate = SpeechDelegate(finalUtterance: last) {
-            // Linger 3s after the last syllable.
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/say")
+        let line = monologue
+            .replacingOccurrences(of: "\n\n", with: " [[slnc 700]] ")
+            .replacingOccurrences(of: "\n", with: " ")
+        task.arguments = ["-v", "Fred", line]
+        task.terminationHandler = { proc in
+            // `terminate()` on dismiss sends SIGTERM (non-zero status);
+            // skip the linger-and-dismiss in that case — we're already
+            // tearing down.
+            guard proc.terminationStatus == 0 else { return }
             DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
-                TicTacToeGame.dismiss()
+                MainActor.assumeIsolated { TicTacToeGame.dismiss() }
             }
         }
-        synth.delegate = delegate
-        for u in utterances { synth.speak(u) }
-        speechSynth = synth
-        speechDelegate = delegate
+        do {
+            try task.run()
+            sayTask = task
+        } catch {
+            // Voice unavailable: typewriter timer dismisses the window
+            // after its own 3s linger (see startTyping).
+        }
     }
 
     private func play(_ idx: Int) {
@@ -491,34 +487,6 @@ enum TicTacToeSounds {
             ))
         }
         return data
-    }
-}
-
-/// Stored in `@State` to outlive AVSpeechSynthesizer's weak ref. The
-/// monologue is queued as multiple utterances (so we can insert a
-/// preUtteranceDelay between them) — `onFinish` only fires on the very
-/// last one, identified by reference.
-@MainActor
-private final class SpeechDelegate: NSObject, AVSpeechSynthesizerDelegate {
-    // nonisolated(unsafe) because the delegate callback is nonisolated and
-    // only does `===` reference identity against this — that's atomic and
-    // the value never mutates after init, so no actual data race.
-    nonisolated(unsafe) let finalUtterance: AVSpeechUtterance?
-    let onFinish: () -> Void
-    init(finalUtterance: AVSpeechUtterance?, onFinish: @escaping () -> Void) {
-        self.finalUtterance = finalUtterance
-        self.onFinish = onFinish
-    }
-
-    nonisolated func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer,
-                                       didFinish utterance: AVSpeechUtterance) {
-        // Compare here so the async closure never captures the non-Sendable
-        // utterance — only the resulting Bool flows across the queue hop.
-        let isFinal = utterance === finalUtterance
-        guard isFinal else { return }
-        DispatchQueue.main.async {
-            MainActor.assumeIsolated { self.onFinish() }
-        }
     }
 }
 

--- a/project.yml
+++ b/project.yml
@@ -35,21 +35,16 @@ targets:
     sources:
       - path: Sources/Mojito
       - path: Resources/Assets.xcassets
+      # Xcode 26 Icon Composer `.icon` bundles. xcodegen 2.45+ recognises
+      # the extension as `folder.iconcomposer.icon` so actool processes
+      # them as app-icon assets (do NOT set `type: folder` here — that
+      # downgrades them to opaque folders and they get copied raw, which
+      # is what broke the rendered app icon previously). The active icon
+      # per config is selected via ASSETCATALOG_COMPILER_APPICON_NAME.
+      - path: Resources/AppIcon.icon
+      - path: Resources/AppIconDev.icon
       - path: Resources/Emoji
         type: folder
-      # Xcode 26 Icon Composer `.icon` bundles. actool compiles each into
-      # the final .icns at build time. Folder-typed so xcodegen ships the
-      # whole bundle without descending into individual SVG/JSON files.
-      - path: Resources/AppIcon.icon
-        type: folder
-        buildPhase: resources
-      # Debug builds use this icon (selected via the per-config
-      # APP_ICON_NAME build setting + $(APP_ICON_NAME) substitution in
-      # Info.plist). The extra ~3 MB ships in Release too because xcodegen
-      # doesn't conditionalize resource sources per config.
-      - path: Resources/AppIconDev.icon
-        type: folder
-        buildPhase: resources
       # Opaque-named effect assets. Names don't reveal their content; see
       # the Bundle.url(forResource:) call sites in Sources/Mojito/App/ for
       # which file is which.
@@ -115,10 +110,13 @@ targets:
         # picks it up so the shipped bundle always reflects the released version.
         CFBundleShortVersionString: "$(MARKETING_VERSION)"
         CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
-        # AppIcon.icns is shipped as a top-level Resources file (see sources
-        # block below). Tells LaunchServices / Finder / NSWorkspace.icon(forFile:)
-        # exactly which icon to use without round-tripping through actool.
+        # Both keys point at the active icon name. actool compiles the
+        # matching `.icon` bundle from Assets.xcassets into Assets.car and
+        # writes the right metadata into CFBundleIcons; the explicit name
+        # here keeps NSWorkspace.icon(forFile:) and older LaunchServices
+        # paths happy when they look for it by name.
         CFBundleIconFile: "$(APP_ICON_NAME)"
+        CFBundleIconName: "$(APP_ICON_NAME)"
         LSMinimumSystemVersion: "14.0"
         LSUIElement: true
         LSApplicationCategoryType: public.app-category.utilities
@@ -138,9 +136,9 @@ targets:
         ENABLE_USER_SCRIPT_SANDBOXING: NO
         GENERATE_INFOPLIST_FILE: NO
         COMBINE_HIDPI_IMAGES: YES
-        # Empty string disables actool's AppIcon compilation. We ship our own
-        # hand-built AppIcon.icns as a resource (see sources block above).
-        ASSETCATALOG_COMPILER_APPICON_NAME: ""
+        # Per-config $(APP_ICON_NAME) selects AppIcon vs AppIconDev from the
+        # asset catalog so the dev build is visually distinct.
+        ASSETCATALOG_COMPILER_APPICON_NAME: "$(APP_ICON_NAME)"
       configs:
         Debug:
           # Dev entitlements include cs.disable-library-validation so the
@@ -173,8 +171,38 @@ targets:
       - name: Install Mojito Dev to /Applications (Debug only)
         script: |
           if [ "$CONFIGURATION" = "Debug" ]; then
+            # Xcode 26's build system schedules this script BEFORE the
+            # bundle's implicit codesign step (and serializes them — we
+            # can't poll-wait because codesign blocks on us finishing).
+            # So we sign the destination ourselves with the same identity
+            # Xcode uses (`EXPANDED_CODE_SIGN_IDENTITY` is the cert SHA-1).
+            # Sparkle.framework was signed earlier in the build and rsyncs
+            # over already-signed; we just need to (re)sign the dylibs and
+            # the bundle wrapper.
             rsync -a --delete "$TARGET_BUILD_DIR/$WRAPPER_NAME/" "/Applications/$WRAPPER_NAME/"
-            echo "Copied $WRAPPER_NAME to /Applications/"
+            DEST="/Applications/$WRAPPER_NAME"
+            for f in "$DEST/Contents/MacOS"/*.dylib; do
+              [ -f "$f" ] && codesign --force --sign "$EXPANDED_CODE_SIGN_IDENTITY" \
+                --options runtime --timestamp=none "$f" >/dev/null
+            done
+            codesign --force --sign "$EXPANDED_CODE_SIGN_IDENTITY" \
+              --entitlements "$SRCROOT/$CODE_SIGN_ENTITLEMENTS" \
+              --options runtime --timestamp=none "$DEST" >/dev/null
+            echo "Copied $WRAPPER_NAME to /Applications/ (signed in place)"
+            # If the app was already running, quit and relaunch from the new
+            # build. `pkill` returns 0 only when it actually signalled something,
+            # which doubles as our "was running" check — skip the relaunch on
+            # a cold build so we don't surprise-launch the app.
+            APP_NAME="${WRAPPER_NAME%.app}"
+            if pkill -x "$APP_NAME" 2>/dev/null; then
+              # Wait for clean exit so `open` picks up the freshly-copied bundle.
+              for _ in 1 2 3 4 5 6 7 8 9 10; do
+                pgrep -x "$APP_NAME" >/dev/null || break
+                sleep 0.1
+              done
+              open "/Applications/$WRAPPER_NAME"
+              echo "Relaunched $WRAPPER_NAME"
+            fi
           fi
         basedOnDependencyAnalysis: false
     scheme:

--- a/project.yml
+++ b/project.yml
@@ -196,7 +196,7 @@ targets:
             APP_NAME="${WRAPPER_NAME%.app}"
             if pkill -x "$APP_NAME" 2>/dev/null; then
               # Wait for clean exit so `open` picks up the freshly-copied bundle.
-              for _ in 1 2 3 4 5 6 7 8 9 10; do
+              for _ in $(seq 1 10); do
                 pgrep -x "$APP_NAME" >/dev/null || break
                 sleep 0.1
               done


### PR DESCRIPTION
## Summary

- **AchievementBanner** — center-anchored two-axis spring on entry (bouncy ~0.42s response / 0.55 damping); fast easeIn shrink-to-center on dismiss (0.22s) replaces the old slide-up fade.
- **TicTacToe WOPR monologue** — narration now goes through `/usr/bin/say -v Fred` (matching the Donations thank-you), replacing `AVSpeechSynthesizer` + Junior. Default ~175 wpm pace, `[[slnc 700]]` for the mid-monologue beat. Typewriter slowed to 0.085s/char to stay in sync. `Process.terminate()` on window close cuts narration immediately.
- **Xcode 26 Icon Composer `.icon` fix** — dropping `type: folder` in `project.yml` lets xcodegen mark `.icon` bundles as `wrapper.icon` so `actool` processes them; reenable `ASSETCATALOG_COMPILER_APPICON_NAME` and add `CFBundleIconName`. Dock/Finder icon renders again.
- **Dev build pipeline** — post-build phase auto-quits + relaunches `Mojito Dev` if it was running; signs the `/Applications` copy in place to work around Xcode 26 scheduling the script before the implicit codesign step.

## Test plan

- [x] Clean build → `/Applications/Mojito Dev.app` signature valid, `open` launches, Dock icon renders.
- [x] Trigger easter-egg discovery → banner pops in / shrinks out from center.
- [x] TicTacToe → play to draw → Fred narrates at normal pace, typewriter in sync; close mid-narration → `say` terminates.
- [x] Rebuild with app running → quits + relaunches automatically.
- [x] Rebuild with app not running → no surprise auto-launch.

Refs: W-117