### PR TITLE
W-133: calm examples carousel transition + tighter narrow hero-card

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
 <link rel="apple-touch-icon" href="favicon.png">
 <link rel="preload" as="image" fetchpriority="high" href="wallpaper.webp" type="image/webp" media="(prefers-color-scheme: light)">
 <link rel="preload" as="image" fetchpriority="high" href="wallpaper-dark.webp" type="image/webp" media="(prefers-color-scheme: dark)">
-<link rel="stylesheet" href="style.css?v=57">
+<link rel="stylesheet" href="style.css?v=59">
 </head>
 <body>
 
@@ -356,6 +356,6 @@ Changes not staged for commit:
   <p class="copyright">&copy; 2026 <a href="https://wells.ee">Wells Riley</a></p>
 </footer>
 
-<script src="picker.js?v=44" defer></script>
+<script src="picker.js?v=45" defer></script>
 </body>
 </html>

--- a/picker.js
+++ b/picker.js
@@ -17,7 +17,8 @@
   // advances or the user clicks into a different app's input.
   let input = inputs[0];
   const apps = Array.from(document.querySelectorAll('.app'));
-  const HUGE = 1400; // off-screen translateX distance, in px
+  // Small horizontal drift on enter/exit; opacity does the heavy lifting.
+  const SLIDE = 60;
 
   // Window corners use CSS border-radius (14px). We previously approximated
   // a real macOS squircle with a clip-path superellipse, but clip-path
@@ -36,45 +37,47 @@
 
   let currentAppIdx = -1;
 
-  // Every transition slides right-to-left: outgoing app exits left, incoming
-  // app snaps off-screen RIGHT (no transition) then animates back to 0.
-  // This means even the wrap (last → first) animates in the same direction.
+  // Every transition fades + drifts right-to-left: outgoing fades out drifting
+  // left, incoming snaps to the right at opacity 0 then fades in drifting to
+  // center. The fade carries most of the perceived motion; SLIDE just hints
+  // direction so the wrap (last → first) still reads as "next".
   function setActiveApp(idx) {
     if (idx === currentAppIdx) return;
     const prev = currentAppIdx;
     apps.forEach((app, i) => {
       if (i === idx) {
         if (reduceMotion) {
-          // Skip the off-screen snap + slide — appear instantly at center.
           app.style.transition = 'none';
           app.style.transform = transformAt(0);
+          app.style.opacity = '1';
           app.classList.add('is-active');
         } else {
-          // Snap to off-screen right, then animate to center.
+          // Snap to the right at opacity 0, then fade + drift to center.
           app.style.transition = 'none';
-          app.style.transform = transformAt(HUGE);
-          // Read a layout property to force the snap to commit before the
-          // animation starts. Then queue the final transform in the next frame.
+          app.style.transform = transformAt(SLIDE);
+          app.style.opacity = '0';
+          // Force the snap to commit before the animation starts.
           void app.offsetWidth;
           requestAnimationFrame(() => {
             app.style.transition = '';
             app.style.transform = transformAt(0);
+            app.style.opacity = '1';
             app.classList.add('is-active');
           });
         }
       } else if (i === prev) {
         if (reduceMotion) {
-          // Instant offscreen, no slide.
           app.style.transition = 'none';
-          app.style.transform = transformAt(-HUGE);
+          app.style.transform = transformAt(-SLIDE);
+          app.style.opacity = '0';
         } else {
-          // Animate off-screen left.
           app.style.transition = '';
-          app.style.transform = transformAt(-HUGE);
+          app.style.transform = transformAt(-SLIDE);
+          app.style.opacity = '0';
         }
         app.classList.remove('is-active');
       }
-      // Other apps: leave wherever they were (already off-screen).
+      // Other apps: leave wherever they were (already faded out).
     });
     currentAppIdx = idx;
     input = inputs[idx];

--- a/style.css
+++ b/style.css
@@ -60,11 +60,9 @@ html, body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-/* Off-screen carousel apps live at translateX(±1200px). .stage clip-path
-   hides them visually but doesn't stop them from contributing to body
-   scrollWidth, so the page scrolls sideways into empty space. `clip`
-   (not `hidden`) avoids creating a scroll container that would break
-   the sticky topbar. */
+/* Inactive carousel apps sit at opacity 0 with a small horizontal drift
+   (±60px). `clip` (not `hidden`) prevents any residual horizontal overflow
+   from creating a scroll container that would break the sticky topbar. */
 body { overflow-x: clip; }
 
 a { color: var(--accent); text-decoration: none; }
@@ -451,20 +449,20 @@ code {
   inset: 0;
 }
 
-/* each app is a fixed-size card centered in the hero-card, with translateX
-   for its current slide position. JS controls translateX:
-     - active app: 0
-     - exiting app: -HUGE (slides off-screen left)
-     - waiting apps: +HUGE (off-screen right; default state)
-   Window corners use a 14px squircle (continuous-curvature superellipse,
-   applied via clip-path in picker.js — see SQUIRCLE_R). */
+/* each app is a fixed-size card centered in the hero-card. JS controls
+   the slide-to-fade between states:
+     - active app: translateX(0), opacity 1
+     - exiting app: translateX(-SLIDE), opacity 0
+     - waiting apps: translateX(+SLIDE), opacity 0 (default state)
+   Window corners use a 14px border-radius. */
 .app {
   position: absolute;
   top: 50%;
   left: 50%;
-  transform: translate(-50%, -50%) translateX(1200px);
-  transition: transform 0.55s cubic-bezier(0.22, 0.61, 0.36, 1);
-  will-change: transform;
+  transform: translate(-50%, -50%) translateX(60px);
+  opacity: 0;
+  transition: transform 0.5s cubic-bezier(0.22, 0.61, 0.36, 1), opacity 0.4s ease;
+  will-change: transform, opacity;
   display: flex;
   flex-direction: column;
   border-radius: 14px;
@@ -1344,6 +1342,10 @@ footer {
      (e.g. the terminal shows the middle of each line, not the whole line). */
   .carousel,
   .picker-anchor { transform: scale(0.55); transform-origin: center center; }
+  /* hero-card min-height tracks the carousel scale so the wallpaper card
+     wraps the visible content instead of leaving a big empty pad below it.
+     Roughly 640px (full-size min-height) × scale factor. */
+  .hero-card { min-height: 380px; }
 }
 
 @media (max-width: 520px) {
@@ -1351,7 +1353,7 @@ footer {
   .nav-links a { font-size: 13px; }
   .brand span { display: none; }
   .picker { left: 12px; }
-  .hero-card { min-height: 520px; }
+  .hero-card { min-height: 320px; }
   .carousel,
   .picker-anchor { transform: scale(0.45); transform-origin: center center; }
   .desktop-icon { width: 48px; }


### PR DESCRIPTION
## Summary
- Replace the full-width carousel slide with a small ±60px drift + opacity crossfade. Direction (right-to-left) is preserved so the wrap from the last app back to TextEdit still reads as "next" — there's just less motion to track.
- At ≤640px and ≤520px the carousel/picker are CSS-scaled (0.55 / 0.45) but `.hero-card` kept its 640px min-height, leaving a tall empty pad below the visible content. Reduce `min-height` to track the scale factor (380px / 320px).
- Bump `style.css?v` and `picker.js?v` cache busters.

## Test plan
- [x] Pre-push check: lint, links, Lighthouse mobile/desktop all pass (perf 97/100 mobile, 100 desktop)
- [ ] Visual: open `index.html` and watch the autoplay loop — apps fade-drift in/out instead of sliding across
- [ ] Visual: resize down to ≤640px and ≤520px — hero-card should hug the scaled-down carousel, no big empty space below
- [ ] Visual: `prefers-reduced-motion` still shows a single static app without slides

Refs: W-133