### PR TITLE
W-175: tidy Settings — inline menu-bar hint, move freq toggle to Emoji

### DIFF
--- a/Sources/Mojito/Settings/GeneralSettings.swift
+++ b/Sources/Mojito/Settings/GeneralSettings.swift
@@ -24,11 +24,15 @@ struct GeneralSettingsView: View {
                         LaunchAtLogin.syncFromSystem()
                     }
 
-                Toggle("Show icon in menu bar", isOn: $showMenuBarIcon)
-                    .toggleStyle(.switch)
-
-                Toggle("Rank frequently used emoji higher", isOn: $useFrequencyBoost)
-                    .toggleStyle(.switch)
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle("Show icon in menu bar", isOn: $showMenuBarIcon)
+                        .toggleStyle(.switch)
+                    if !showMenuBarIcon {
+                        Text("When hidden, open Settings by launching \(AppInfo.displayName) from Finder or Spotlight.")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                    }
+                }
 
                 LabeledContent {
                     HStack(spacing: 8) {
@@ -45,12 +49,6 @@ struct GeneralSettingsView: View {
                 } label: {
                     Text("Automatic updates")
                 }
-            } footer: {
-                if !showMenuBarIcon {
-                    Text("When hidden, open Settings by launching \(AppInfo.displayName) from Finder or Spotlight.")
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                }
             }
 
             Section("Emoji") {
@@ -59,6 +57,8 @@ struct GeneralSettingsView: View {
                     Spacer()
                     SkinToneSwatches(selection: $skinToneRaw)
                 }
+                Toggle("Rank frequently used emoji higher", isOn: $useFrequencyBoost)
+                    .toggleStyle(.switch)
                 Toggle("Convert emoticons (`:D` → 😃)", isOn: $emoticonsEnabled)
                     .toggleStyle(.switch)
                 Toggle("Include symbols (experimental)", isOn: $symbolsEnabled)


### PR DESCRIPTION
## Summary
- Inline the "open Settings via Finder/Spotlight" hint directly under the "Show icon in menu bar" toggle (was buried in the section footer below Automatic updates).
- Move "Rank frequently used emoji higher" from the General section to the Emoji section — it controls search behavior, not general app prefs.

## Test plan
- [x] Debug build succeeds
- [ ] Settings → General: toggle "Show icon in menu bar" off → hint appears immediately below the toggle, not at the section bottom
- [ ] Settings → General → Emoji section: "Rank frequently used emoji higher" now sits between Skin tone and Convert emoticons
- [ ] Toggling rank-higher still updates `PrefsKey.useFrequencyBoost` (no key change)

Refs W-175