### PR TITLE
W-185: i18n v1 — UI localization scaffolding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,10 @@ scripts/setup-dev-signing.sh
 # Rebuild the bundled emoji DB from emojibase (SHA-pinned; mismatched checksums abort)
 python3 scripts/build_emoji_db.py
 
+# Refresh Resources/Localizable.xcstrings after adding/changing UI strings.
+# Xcode IDE syncs on build; this is the headless equivalent.
+scripts/sync-localizable.sh
+
 # Run the unit test suite (xcodegen + xcodebuild test). Also wired into the
 # pre-push hook below — activate once per clone with the line under it.
 scripts/run-tests.sh
@@ -163,7 +167,7 @@ Both windows route through `DockIconManager.windowDidOpen()` / `.windowDidClose(
 - `Sources/Mojito/MenuBar/` — `NSStatusItem` controller
 - `Sources/Mojito/Onboarding/`, `Sources/Mojito/Settings/` — SwiftUI window content
 - `Sources/Mojito/Util/PrefsKey.swift` — every UserDefaults key in one place
-- `scripts/` — `release.sh`, `setup-dev-signing.sh`, `run-tests.sh`, `build_emoji_db.py`, `build_egg_strings.py`, `update_appcast.py`
+- `scripts/` — `release.sh`, `setup-dev-signing.sh`, `run-tests.sh`, `build_emoji_db.py`, `build_egg_strings.py`, `update_appcast.py`, `sync-localizable.sh`
 - `bin/` — vendored `generate_keys` and `sign_update` from Sparkle (committed so release doesn't depend on DerivedData being intact)
 - `Resources/` — Info.plist, entitlements, emoji.json, AppIcon.icns, easter-egg assets
 

--- a/Mojito.xcodeproj/project.pbxproj
+++ b/Mojito.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		4949BE63FAD5A5FC2573CFE1 /* DefaultExclusions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877AFBCD3CD8EE7B154C73BD /* DefaultExclusions.swift */; };
 		4C024B6EA9665C5DFDB80CE7 /* WarpDrive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9658C9CF3396443D22FF4E28 /* WarpDrive.swift */; };
 		505F6B7F84EC1D9EF7AB55C9 /* SolitaireWin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E63ABA27E65953D84162097 /* SolitaireWin.swift */; };
+		510035EDB98F94AD6098C122 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = FDE7F8DEA98F385943A30B78 /* Localizable.xcstrings */; };
 		527E2FD4617302A4202C22E2 /* v04.bin in Resources */ = {isa = PBXBuildFile; fileRef = 127F100886742DCE05A171B4 /* v04.bin */; };
 		54BE766E1C8E447D04D3F02C /* ParticlePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F53545C34DF695F1B03CB2 /* ParticlePanel.swift */; };
 		55C7BE736206664DE37166E2 /* DialupSound.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2361376F2801DB575F27B480 /* DialupSound.swift */; };
@@ -260,6 +261,7 @@
 		F5C5BC5F015CABDD85262258 /* SeasonalGates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeasonalGates.swift; sourceTree = "<group>"; };
 		F5C937DB8C91F3847F55D8A6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		FACE9E8BAF08240551D5237A /* v06.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; path = v06.bin; sourceTree = "<group>"; };
+		FDE7F8DEA98F385943A30B78 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		FE5EDBB8F234B21B8D4A3324 /* FzyScorer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FzyScorer.swift; sourceTree = "<group>"; };
 		FFC142D2205F1C089F7524D2 /* SettingsRoot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRoot.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -310,6 +312,7 @@
 				CDB886D82441D68D2F815AD3 /* AppIconDev.icon */,
 				F5C937DB8C91F3847F55D8A6 /* Assets.xcassets */,
 				70F2866D3BE0CC5D08CF9AD1 /* Emoji */,
+				FDE7F8DEA98F385943A30B78 /* Localizable.xcstrings */,
 				DF0A9FF25BC996BC640A35A0 /* s01.bin */,
 				A3781043056BF9F399D00EDD /* s02.bin */,
 				392847FD44ED870B7154ED09 /* s03.bin */,
@@ -643,6 +646,7 @@
 				FCC584110B97D56E2E7065FA /* AppIconDev.icon in Resources */,
 				8669DFC49B3F7DBE689337C0 /* Assets.xcassets in Resources */,
 				08B90EAE6DAD0198A743979E /* Emoji in Resources */,
+				510035EDB98F94AD6098C122 /* Localizable.xcstrings in Resources */,
 				06E493068FD409A2B795BC56 /* s01.bin in Resources */,
 				0A4AAE2AE35D2C90AB9735B7 /* s02.bin in Resources */,
 				7655329BF3B69EE157875660 /* s03.bin in Resources */,
@@ -860,6 +864,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZED_STRING_SWIFTUI_SUPPORT = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -867,6 +872,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_STRICT_CONCURRENCY = minimal;
 				SWIFT_VERSION = 5.10;
@@ -987,6 +993,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZED_STRING_SWIFTUI_SUPPORT = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -995,6 +1002,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_STRICT_CONCURRENCY = minimal;
 				SWIFT_VERSION = 5.10;

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -42,7 +42,7 @@
       }
     },
     "???" : {
-
+      "comment" : "Placeholder shown in About → Easter eggs for an entry the user hasn't discovered yet. Should stay short and visually act as 'three unknowns'."
     },
     "About" : {
 

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1,0 +1,302 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "%@ couldn't reach the update server." : {
+
+    },
+    "%@ is built to respect your privacy. Here's how." : {
+
+    },
+    "%@ is forever free, but your support helps fund future projects. Thank you!" : {
+
+    },
+    "%@ is off" : {
+
+    },
+    "%@ is on" : {
+
+    },
+    "%@ is paused" : {
+
+    },
+    "%@ is running 🏃‍♂️" : {
+
+    },
+    "%@ lives in your menu bar. Try typing `:tada:` in any text field." : {
+
+    },
+    "%@ needs permission" : {
+
+    },
+    "%@ needs permission to work with your keyboard." : {
+
+    },
+    "%lld of %lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld of %2$lld"
+          }
+        }
+      }
+    },
+    "???" : {
+
+    },
+    "About" : {
+
+    },
+    "Accessibility" : {
+
+    },
+    "Acknowledgements" : {
+
+    },
+    "Add" : {
+
+    },
+    "Add website" : {
+
+    },
+    "All the code is on GitHub. Read it, build it, fork it." : {
+
+    },
+    "Allow" : {
+
+    },
+    "Anchors the picker next to your text cursor." : {
+
+    },
+    "Autocomplete `:emoji:` everywhere." : {
+
+    },
+    "Automatic updates" : {
+
+    },
+    "Back" : {
+
+    },
+    "Cancel" : {
+
+    },
+    "Check for Updates…" : {
+
+    },
+    "Check now" : {
+
+    },
+    "Clear all emoji usage stats?" : {
+
+    },
+    "Clear stats" : {
+
+    },
+    "Clear stats..." : {
+
+    },
+    "Continue" : {
+
+    },
+    "Convert emoticons (`:D` → 😃)" : {
+
+    },
+    "Copied!" : {
+
+    },
+    "Copy" : {
+
+    },
+    "Danger zone" : {
+
+    },
+    "Donate" : {
+
+    },
+    "Done" : {
+
+    },
+    "Easter egg discovered" : {
+
+    },
+    "Easter eggs" : {
+
+    },
+    "Emoji" : {
+
+    },
+    "Emoji autocompleted" : {
+
+    },
+    "Exclusions" : {
+
+    },
+    "Funded by donations" : {
+
+    },
+    "General" : {
+
+    },
+    "Get started" : {
+
+    },
+    "Grant accessibility permissions" : {
+
+    },
+    "I donated" : {
+
+    },
+    "If the icon doesn't appear in the menu bar, check **System Settings → Menu Bar → \"Allow in the Menu Bar\"**." : {
+
+    },
+    "Include symbols (experimental)" : {
+
+    },
+    "Input Monitoring" : {
+
+    },
+    "Keyboard shortcuts" : {
+
+    },
+    "Keystrokes aren't logged" : {
+
+    },
+    "Lets %@ anchor the picker next to your text cursor." : {
+
+    },
+    "Lets %@ watch keystrokes for `:` triggers. Nothing is logged." : {
+
+    },
+    "No ads, tracking, or subscriptions." : {
+
+    },
+    "No emoji for :%@:" : {
+
+    },
+    "Open settings" : {
+
+    },
+    "Open source and auditable" : {
+
+    },
+    "Pause for 1 hour" : {
+
+    },
+    "Pause until tomorrow" : {
+
+    },
+    "Permissions" : {
+
+    },
+    "Press the same shortcut again while paused to resume." : {
+
+    },
+    "Privacy" : {
+
+    },
+    "Privacy details…" : {
+
+    },
+    "Quit %@" : {
+
+    },
+    "Rank frequently used emoji higher" : {
+
+    },
+    "Report an issue" : {
+
+    },
+    "Require `::` to search symbols" : {
+
+    },
+    "Reset all easter egg progress?" : {
+
+    },
+    "Reset eggs" : {
+
+    },
+    "Reset eggs..." : {
+
+    },
+    "Resume" : {
+
+    },
+    "Settings…" : {
+
+    },
+    "Show Onboarding" : {
+
+    },
+    "Show icon in menu bar" : {
+
+    },
+    "Skin tone" : {
+
+    },
+    "Start at login" : {
+
+    },
+    "Stats" : {
+
+    },
+    "Support Wells" : {
+
+    },
+    "This will erase your autocomplete stats and Top 8. Settings and exclusions won't be changed." : {
+
+    },
+    "This will erase your discovery progress and any per-egg counters. The eggs themselves still work — you'll just need to find them again." : {
+
+    },
+    "Type `:` to search for any emoji or symbol in seconds." : {
+
+    },
+    "Type some emoji and they'll show up here." : {
+
+    },
+    "Update check failed" : {
+
+    },
+    "Usage counts, settings, and your exclusion list are stored locally. %@ doesn't send any telemetry or usage data back to our server—we don't even have a server 🙂" : {
+
+    },
+    "Used to detect `:` triggers. Nothing else." : {
+
+    },
+    "User since" : {
+
+    },
+    "Version %@ (%@)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Version %1$@ (%2$@)"
+          }
+        }
+      }
+    },
+    "View source" : {
+
+    },
+    "Watches keystrokes for the `:` trigger." : {
+
+    },
+    "Website" : {
+
+    },
+    "You're all set" : {
+
+    },
+    "Your data stays on this Mac" : {
+
+    },
+    "Your top 8" : {
+
+    },
+    "e.g. mail.google.com or *.notion.so" : {
+
+    }
+  },
+  "version" : "1.0"
+}

--- a/Sources/Mojito/App/AchievementBanner.swift
+++ b/Sources/Mojito/App/AchievementBanner.swift
@@ -105,7 +105,7 @@ private struct BannerView: View {
             Text("Easter egg discovered")
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundStyle(.white)
-            Text("·")
+            Text(verbatim: "·")
                 .font(.system(size: 13, weight: .regular))
                 .foregroundStyle(.white.opacity(0.55))
             Text(egg.title)

--- a/Sources/Mojito/App/BlueScreen.swift
+++ b/Sources/Mojito/App/BlueScreen.swift
@@ -80,7 +80,7 @@ private struct BlueScreenView: View {
                 VStack(alignment: .leading, spacing: 0) {
                     HStack {
                         Spacer()
-                        Text(" Mojito ")
+                        Text(verbatim: " Mojito ")
                             .font(.system(size: 22, weight: .regular, design: .monospaced))
                             .foregroundColor(bsodBlue)
                             .padding(.horizontal, 2)
@@ -90,13 +90,13 @@ private struct BlueScreenView: View {
                     .padding(.bottom, 20)
 
                     VStack(alignment: .leading, spacing: 6) {
-                        Text("A fatal exception 0E has occurred at 0xDEADBEEF:0xCAFEBABE in VXD")
-                        Text("MOJITO(01) + 0xC0FFEE42. The current application will be terminated.")
-                        Text(" ")
-                        Text("*   Press any key to terminate the current application.")
-                        Text("*   Press  CTRL+ALT+DEL  again to restart your computer. You will")
-                        Text("    lose any unsaved information in all applications.")
-                        Text(" ")
+                        Text(verbatim: "A fatal exception 0E has occurred at 0xDEADBEEF:0xCAFEBABE in VXD")
+                        Text(verbatim: "MOJITO(01) + 0xC0FFEE42. The current application will be terminated.")
+                        Text(verbatim: " ")
+                        Text(verbatim: "*   Press any key to terminate the current application.")
+                        Text(verbatim: "*   Press  CTRL+ALT+DEL  again to restart your computer. You will")
+                        Text(verbatim: "    lose any unsaved information in all applications.")
+                        Text(verbatim: " ")
                         HStack {
                             Spacer()
                             blinkingPrompt
@@ -130,8 +130,8 @@ private struct BlueScreenView: View {
         TimelineView(.periodic(from: Date(), by: 0.45)) { context in
             let blink = Int(context.date.timeIntervalSinceReferenceDate / 0.45) % 2 == 0
             HStack(spacing: 0) {
-                Text("Press any key to continue ")
-                Text("_").opacity(blink ? 1 : 0)
+                Text(verbatim: "Press any key to continue ")
+                Text(verbatim: "_").opacity(blink ? 1 : 0)
             }
         }
     }

--- a/Sources/Mojito/App/BouncingDVD.swift
+++ b/Sources/Mojito/App/BouncingDVD.swift
@@ -136,7 +136,7 @@ private struct BouncingDVDView: View {
                 .aspectRatio(contentMode: .fit)
                 .foregroundStyle(color)
         } else {
-            Text("DVD")
+            Text(verbatim: "DVD")
                 .font(.system(size: 96, weight: .black, design: .serif))
                 .italic()
                 .foregroundColor(color)

--- a/Sources/Mojito/App/CeleryMan.swift
+++ b/Sources/Mojito/App/CeleryMan.swift
@@ -306,7 +306,7 @@ private struct PaulsComputerContents: View {
         ZStack {
             Color.black
             VStack(alignment: .leading, spacing: 8) {
-                Text("C:\\")
+                Text(verbatim: "C:\\")
                     .font(.system(size: 13, weight: .semibold, design: .monospaced))
                     .foregroundColor(.white.opacity(0.55))
                 Rectangle()

--- a/Sources/Mojito/App/DialupSound.swift
+++ b/Sources/Mojito/App/DialupSound.swift
@@ -246,7 +246,7 @@ private struct DialupView: View {
             HStack(spacing: 6) {
                 Image(systemName: "phone.down.fill")
                     .font(.system(size: 11, weight: .semibold))
-                Text("Hang up")
+                Text(verbatim: "Hang up")
                     .font(.system(size: 13, weight: .semibold))
             }
             .foregroundStyle(.white)

--- a/Sources/Mojito/App/HatchClock.swift
+++ b/Sources/Mojito/App/HatchClock.swift
@@ -307,7 +307,7 @@ private struct Colon: View {
     let cellH: CGFloat
     var body: some View {
         // monospacedDigit keeps columns aligned without SF Mono's slashed-zero.
-        Text(":")
+        Text(verbatim: ":")
             .font(.system(size: 130, weight: .bold).monospacedDigit())
             .foregroundColor(color)
             .frame(width: 60, height: cellH)

--- a/Sources/Mojito/App/KonamiPayoff.swift
+++ b/Sources/Mojito/App/KonamiPayoff.swift
@@ -57,7 +57,7 @@ private struct KonamiPayoffView: View {
 
             ZStack {
                 Canvas { ctx, _ in
-                    let title = Text("+30 LIVES")
+                    let title = Text(verbatim: "+30 LIVES")
                         .font(.system(size: 96, weight: .black, design: .monospaced))
                         .foregroundColor(.yellow)
                     let resolved = ctx.resolve(title)
@@ -69,7 +69,7 @@ private struct KonamiPayoffView: View {
                         y: bounds.height / 2 - size.height / 2
                     ))
 
-                    let sub = Text("↑ ↑ ↓ ↓ ← → ← → B A")
+                    let sub = Text(verbatim: "↑ ↑ ↓ ↓ ← → ← → B A")
                         .font(.system(size: 28, weight: .semibold, design: .monospaced))
                         .foregroundColor(.white)
                     let rSub = ctx.resolve(sub)

--- a/Sources/Mojito/App/SnakeGame.swift
+++ b/Sources/Mojito/App/SnakeGame.swift
@@ -197,9 +197,9 @@ private struct SnakeGameView: View {
 
     private var titleBar: some View {
         HStack(spacing: 8) {
-            Text("🐍")
+            Text(verbatim: "🐍")
                 .font(.system(size: 24))
-            Text("SNAKE")
+            Text(verbatim: "SNAKE")
                 .font(.system(size: 22, weight: .heavy, design: .monospaced))
                 .foregroundColor(phosphor)
                 .tracking(8)
@@ -242,14 +242,14 @@ private struct SnakeGameView: View {
     private var statePill: some View {
         Group {
             if model.gameOver {
-                Text("GAME OVER")
+                Text(verbatim: "GAME OVER")
                     .foregroundColor(Color.red)
                     .shadow(color: .red.opacity(0.7), radius: 5)
             } else if model.paused {
-                Text("PAUSED")
+                Text(verbatim: "PAUSED")
                     .foregroundColor(.yellow)
             } else {
-                Text("PLAYING")
+                Text(verbatim: "PLAYING")
                     .foregroundColor(phosphorDim)
             }
         }
@@ -277,7 +277,7 @@ private struct SnakeGameView: View {
     }
 
     private var hintBar: some View {
-        Text("← ↑ ↓ →  steer    SPACE  pause / restart    ESC  quit")
+        Text(verbatim: "← ↑ ↓ →  steer    SPACE  pause / restart    ESC  quit")
             .font(.system(size: 11, weight: .regular, design: .monospaced))
             .foregroundColor(phosphorDim)
             .tracking(1)

--- a/Sources/Mojito/App/Snowfall.swift
+++ b/Sources/Mojito/App/Snowfall.swift
@@ -92,10 +92,10 @@ private struct SnowfallView: View {
             Canvas { ctx, _ in
                 // Resolve ONCE per body, not per particle.
                 let resolvedSharp = ctx.resolve(
-                    Text("❅").font(.system(size: 24)).foregroundColor(.white)
+                    Text(verbatim: "❅").font(.system(size: 24)).foregroundColor(.white)
                 )
                 let resolvedRound = ctx.resolve(
-                    Text("❆").font(.system(size: 24)).foregroundColor(.white)
+                    Text(verbatim: "❆").font(.system(size: 24)).foregroundColor(.white)
                 )
                 for (i, f) in flakes.enumerated() {
                     let t = elapsed - f.launchTime

--- a/Sources/Mojito/App/TicTacToeGame.swift
+++ b/Sources/Mojito/App/TicTacToeGame.swift
@@ -108,7 +108,7 @@ private struct TicTacToeView: View {
         VStack(spacing: 22) {
             Spacer().frame(height: 12)
 
-            Text("MJTO — STRATEGIC COMMAND")
+            Text(verbatim: "MJTO — STRATEGIC COMMAND")
                 .font(.system(size: 12, weight: .bold, design: .monospaced))
                 .foregroundColor(crtCyanDim)
                 .tracking(4)

--- a/Sources/Mojito/App/TrainGame.swift
+++ b/Sources/Mojito/App/TrainGame.swift
@@ -88,14 +88,14 @@ private struct TrainGameView: View {
                 // Subtle dim so it reads as a moment, not an overlay bug.
                 Color.black.opacity(0.18)
 
-                Text("👆")
+                Text(verbatim: "👆")
                     .font(.system(size: fingerSize))
                     .position(x: leftX, y: baseY)
-                Text("👆")
+                Text(verbatim: "👆")
                     .font(.system(size: fingerSize))
                     .position(x: rightX, y: baseY)
 
-                Text("🚋")
+                Text(verbatim: "🚋")
                     .font(.system(size: trainSize))
                     .position(x: trainX, y: trainY)
             }

--- a/Sources/Mojito/App/XPLogin.swift
+++ b/Sources/Mojito/App/XPLogin.swift
@@ -183,7 +183,7 @@ private struct XPLoginView: View {
         HStack(spacing: 0) {
             turnOffControl
             Spacer()
-            Text("After you log on, you can add or change accounts.\nJust go to Control Panel and click User Accounts.")
+            Text(verbatim: "After you log on, you can add or change accounts.\nJust go to Control Panel and click User Accounts.")
                 .font(.system(size: 14))
                 .foregroundColor(.white)
                 .multilineTextAlignment(.trailing)
@@ -228,7 +228,7 @@ private struct XPLoginView: View {
             }
             .frame(width: 28, height: 28)
 
-            Text("Turn off computer")
+            Text(verbatim: "Turn off computer")
                 .font(.system(size: 15))
                 .foregroundColor(.white)
         }
@@ -250,7 +250,7 @@ private struct XPLoginView: View {
                 } else {
                     VStack(alignment: .trailing, spacing: 26) {
                         windowsXPWordmark
-                        Text("To begin, click your user name")
+                        Text(verbatim: "To begin, click your user name")
                             .font(.system(size: 22, weight: .regular))
                             .foregroundColor(.white)
                             .shadow(color: .black.opacity(0.35), radius: 1, x: 1, y: 1)
@@ -348,7 +348,7 @@ private struct XPLoginView: View {
                     .foregroundColor(.white)
                     .shadow(color: .black.opacity(0.45), radius: 1, x: 1, y: 1)
                 if loadingTextVisible {
-                    Text("Loading your personal settings…")
+                    Text(verbatim: "Loading your personal settings…")
                         .font(.system(size: 15, weight: .semibold))
                         // Midnight blue per the reference, not light blue.
                         .foregroundColor(Color(red: 0.06, green: 0.18, blue: 0.50))

--- a/Sources/Mojito/MenuBar/MenuBarController.swift
+++ b/Sources/Mojito/MenuBar/MenuBarController.swift
@@ -99,7 +99,7 @@ final class MenuBarController {
     /// Text fallback because a `variableLength` status item with no image
     /// renders at 0pt — completely invisible.
     private func applyIcon(to button: NSStatusBarButton, active: Bool, hasIssue: Bool) {
-        if hasIssue, let image = NSImage(systemSymbolName: "exclamationmark.triangle.fill", accessibilityDescription: "\(AppInfo.displayName) needs permission") {
+        if hasIssue, let image = NSImage(systemSymbolName: "exclamationmark.triangle.fill", accessibilityDescription: String(localized: "\(AppInfo.displayName) needs permission")) {
             image.isTemplate = false  // keep yellow tint
             button.image = image
             button.title = ""
@@ -131,32 +131,32 @@ final class MenuBarController {
         menu.addItem(makeStatusItem())
         menu.addItem(.separator())
 
-        let pauseHour = NSMenuItem(title: "Pause for 1 hour", action: #selector(MenuActions.pauseHour), keyEquivalent: "").configured(target: MenuActions.shared)
+        let pauseHour = NSMenuItem(title: String(localized: "Pause for 1 hour"), action: #selector(MenuActions.pauseHour), keyEquivalent: "").configured(target: MenuActions.shared)
         menu.addItem(pauseHour)
         pauseHourItem = pauseHour
 
-        let pauseTomorrow = NSMenuItem(title: "Pause until tomorrow", action: #selector(MenuActions.pauseUntilTomorrow), keyEquivalent: "").configured(target: MenuActions.shared)
+        let pauseTomorrow = NSMenuItem(title: String(localized: "Pause until tomorrow"), action: #selector(MenuActions.pauseUntilTomorrow), keyEquivalent: "").configured(target: MenuActions.shared)
         menu.addItem(pauseTomorrow)
         pauseTomorrowItem = pauseTomorrow
 
-        let resume = NSMenuItem(title: "Resume", action: #selector(MenuActions.resume), keyEquivalent: "").configured(target: MenuActions.shared)
+        let resume = NSMenuItem(title: String(localized: "Resume"), action: #selector(MenuActions.resume), keyEquivalent: "").configured(target: MenuActions.shared)
         menu.addItem(resume)
         resumeItem = resume
 
         menu.addItem(.separator())
-        menu.addItem(NSMenuItem(title: "Settings…", action: #selector(MenuActions.openSettings), keyEquivalent: ",").configured(target: MenuActions.shared))
+        menu.addItem(NSMenuItem(title: String(localized: "Settings…"), action: #selector(MenuActions.openSettings), keyEquivalent: ",").configured(target: MenuActions.shared))
         // Option-held alternate — backdoor for re-running guided setup
         // without resetting onboarding state. Discoverability intentionally low.
-        let showOnboarding = NSMenuItem(title: "Show Onboarding", action: #selector(MenuActions.showOnboarding), keyEquivalent: ",").configured(target: MenuActions.shared)
+        let showOnboarding = NSMenuItem(title: String(localized: "Show Onboarding"), action: #selector(MenuActions.showOnboarding), keyEquivalent: ",").configured(target: MenuActions.shared)
         showOnboarding.keyEquivalentModifierMask = [.command, .option]
         showOnboarding.isAlternate = true
         menu.addItem(showOnboarding)
-        let updatesItem = NSMenuItem(title: "Check for Updates…", action: #selector(MenuActions.checkForUpdates), keyEquivalent: "").configured(target: MenuActions.shared)
+        let updatesItem = NSMenuItem(title: String(localized: "Check for Updates…"), action: #selector(MenuActions.checkForUpdates), keyEquivalent: "").configured(target: MenuActions.shared)
         menu.addItem(updatesItem)
         checkForUpdatesItem = updatesItem
         refreshUpdatesItem(hasError: UpdaterCoordinator.shared.hasUpdateError)
         menu.addItem(.separator())
-        menu.addItem(NSMenuItem(title: "Quit \(AppInfo.displayName)", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q"))
+        menu.addItem(NSMenuItem(title: String(localized: "Quit \(AppInfo.displayName)"), action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q"))
 
         MenuActions.shared.bind(self)
         return menu
@@ -174,12 +174,12 @@ final class MenuBarController {
 
     private func refreshUpdatesItem(hasError: Bool) {
         guard let item = checkForUpdatesItem else { return }
-        item.title = "Check for Updates…"
+        item.title = String(localized: "Check for Updates…")
         if hasError {
             // Quieter than a modal but still discoverable.
-            item.image = NSImage(systemSymbolName: "exclamationmark.triangle.fill", accessibilityDescription: "Update check failed")
+            item.image = NSImage(systemSymbolName: "exclamationmark.triangle.fill", accessibilityDescription: String(localized: "Update check failed"))
             item.image?.isTemplate = false
-            item.toolTip = "\(AppInfo.displayName) couldn't reach the update server."
+            item.toolTip = String(localized: "\(AppInfo.displayName) couldn't reach the update server.")
         } else {
             item.image = nil
             item.toolTip = nil
@@ -187,7 +187,7 @@ final class MenuBarController {
     }
 
     private func makeStatusItem() -> NSMenuItem {
-        let item = NSMenuItem(title: "\(AppInfo.displayName) is on", action: nil, keyEquivalent: "")
+        let item = NSMenuItem(title: String(localized: "\(AppInfo.displayName) is on"), action: nil, keyEquivalent: "")
         item.isEnabled = false
         item.attributedTitle = statusTitle()
         return item
@@ -196,11 +196,13 @@ final class MenuBarController {
     private func statusTitle() -> NSAttributedString {
         let active = engine?.isActive ?? false
         let permissionsOK = (permissions?.allGranted) ?? false
+        let name = AppInfo.displayName
         let title: String = {
-            let name = AppInfo.displayName
-            if !permissionsOK { return "\(name) needs permission" }
-            if let until = engine?.pausedUntil, until > Date() { return "\(name) is paused" }
-            return active ? "\(name) is running 🏃‍♂️" : "\(name) is off"
+            if !permissionsOK { return String(localized: "\(name) needs permission") }
+            if let until = engine?.pausedUntil, until > Date() { return String(localized: "\(name) is paused") }
+            return active
+                ? String(localized: "\(name) is running 🏃‍♂️")
+                : String(localized: "\(name) is off")
         }()
         return NSAttributedString(string: title, attributes: [
             .font: NSFont.menuFont(ofSize: 0),

--- a/Sources/Mojito/Onboarding/OnboardingRoot.swift
+++ b/Sources/Mojito/Onboarding/OnboardingRoot.swift
@@ -116,9 +116,9 @@ struct OnboardingRoot: View {
 
     private var primaryLabel: String {
         switch step {
-        case .welcome: return "Get started"
-        case .done:    return "Done"
-        default:       return "Continue"
+        case .welcome: return String(localized: "Get started")
+        case .done:    return String(localized: "Done")
+        default:       return String(localized: "Continue")
         }
     }
 

--- a/Sources/Mojito/Onboarding/OnboardingScreens.swift
+++ b/Sources/Mojito/Onboarding/OnboardingScreens.swift
@@ -386,7 +386,7 @@ struct PermissionsStep: View {
             VStack(spacing: 10) {
                 permissionRow(
                     title: "Accessibility",
-                    detail: "Lets Mojito anchor the picker next to your text cursor.",
+                    detail: "Lets \(AppInfo.displayName) anchor the picker next to your text cursor.",
                     granted: accessibilityGranted,
                     onAllow: {
                         if axPromptFired {
@@ -399,7 +399,7 @@ struct PermissionsStep: View {
                 )
                 permissionRow(
                     title: "Input Monitoring",
-                    detail: "Lets Mojito watch keystrokes for `:` triggers. Nothing is logged.",
+                    detail: "Lets \(AppInfo.displayName) watch keystrokes for `:` triggers. Nothing is logged.",
                     granted: inputMonitoringGranted,
                     onAllow: {
                         if imPromptFired {
@@ -423,7 +423,7 @@ struct PermissionsStep: View {
         }
     }
 
-    private func permissionRow(title: String, detail: String, granted: Bool, onAllow: @escaping () -> Void) -> some View {
+    private func permissionRow(title: LocalizedStringKey, detail: LocalizedStringKey, granted: Bool, onAllow: @escaping () -> Void) -> some View {
         HStack(spacing: 12) {
             VStack(alignment: .leading, spacing: 1) {
                 Text(title)

--- a/Sources/Mojito/Picker/PickerView.swift
+++ b/Sources/Mojito/Picker/PickerView.swift
@@ -185,17 +185,17 @@ private struct PickerRow: View {
     private func highlightedShortcode(_ shortcode: String, query: String) -> Text {
         let q = query.lowercased()
         guard !q.isEmpty, let range = shortcode.lowercased().range(of: q) else {
-            return Text(":\(shortcode):").foregroundStyle(.secondary)
+            return Text(verbatim: ":\(shortcode):").foregroundStyle(.secondary)
         }
         let prefix = String(shortcode[shortcode.startIndex..<range.lowerBound])
         let middle = String(shortcode[range])
         let suffix = String(shortcode[range.upperBound..<shortcode.endIndex])
         return (
-            Text(":").foregroundStyle(.secondary)
+            Text(verbatim: ":").foregroundStyle(.secondary)
             + Text(prefix).foregroundStyle(.secondary)
             + Text(middle).foregroundStyle(.primary).bold()
             + Text(suffix).foregroundStyle(.secondary)
-            + Text(":").foregroundStyle(.secondary)
+            + Text(verbatim: ":").foregroundStyle(.secondary)
         )
     }
 }

--- a/Sources/Mojito/Settings/AboutSettings.swift
+++ b/Sources/Mojito/Settings/AboutSettings.swift
@@ -192,7 +192,7 @@ private struct HeartConfetti: View {
         TimelineView(.animation(minimumInterval: 1.0 / 30.0, paused: false)) { context in
             let elapsed = context.date.timeIntervalSinceReferenceDate
             Canvas { ctx, size in
-                let base = ctx.resolve(Text("❤️").font(.system(size: 10)))
+                let base = ctx.resolve(Text(verbatim: "❤️").font(.system(size: 10)))
                 for config in configs {
                     let t = (elapsed + config.phaseOffset).truncatingRemainder(dividingBy: config.cycle)
                     guard t > 0, t < config.visibleDuration else { continue }

--- a/Sources/Mojito/Settings/EasterEggsSettings.swift
+++ b/Sources/Mojito/Settings/EasterEggsSettings.swift
@@ -231,7 +231,7 @@ struct ResetEasterEggsButton: View {
                 }
                 Button("Cancel", role: .cancel) {}
             } message: {
-                Text("This will erase your discovery progress and Perfect Bounce counter. The eggs themselves still work — you'll just need to find them again.")
+                Text("This will erase your discovery progress and any per-egg counters. The eggs themselves still work — you'll just need to find them again.")
             }
     }
 }

--- a/Sources/Mojito/Settings/GeneralSettings.swift
+++ b/Sources/Mojito/Settings/GeneralSettings.swift
@@ -39,7 +39,7 @@ struct GeneralSettingsView: View {
                         Button("Check now") {
                             UpdaterCoordinator.shared.checkForUpdates()
                         }
-                        Toggle("", isOn: $autoUpdates)
+                        Toggle("Automatic updates", isOn: $autoUpdates)
                             .labelsHidden()
                             .toggleStyle(.switch)
                             .onChange(of: autoUpdates) { _, newValue in

--- a/Sources/Mojito/Settings/PrivacyPermissionsSettings.swift
+++ b/Sources/Mojito/Settings/PrivacyPermissionsSettings.swift
@@ -40,8 +40,8 @@ struct PrivacyPermissionsSettingsView: View {
     // MARK: - Rows
 
     private func permissionRow(
-        title: String,
-        detail: String,
+        title: LocalizedStringKey,
+        detail: LocalizedStringKey,
         granted: Bool,
         onAction: @escaping () -> Void
     ) -> some View {
@@ -121,14 +121,14 @@ struct PrivacyDetailsRows: View {
         }
     }
 
-    private func privacyRow(icon: String, title: String, detail: String) -> some View {
+    private func privacyRow(icon: String, title: LocalizedStringKey, detail: LocalizedStringKey) -> some View {
         privacyRow(icon: icon, title: title, detail: detail) { EmptyView() }
     }
 
     private func privacyRow<Accessory: View>(
         icon: String,
-        title: String,
-        detail: String,
+        title: LocalizedStringKey,
+        detail: LocalizedStringKey,
         @ViewBuilder accessory: () -> Accessory
     ) -> some View {
         HStack(alignment: .center, spacing: 12) {

--- a/Sources/Mojito/Settings/SettingsRoot.swift
+++ b/Sources/Mojito/Settings/SettingsRoot.swift
@@ -8,11 +8,11 @@ struct SettingsRoot: View {
 
         var title: String {
             switch self {
-            case .general:    return "General"
-            case .exclusions: return "Exclusions"
-            case .easterEggs: return "Easter eggs"
-            case .privacy:    return "Privacy"
-            case .about:      return "About"
+            case .general:    return String(localized: "General")
+            case .exclusions: return String(localized: "Exclusions")
+            case .easterEggs: return String(localized: "Easter eggs")
+            case .privacy:    return String(localized: "Privacy")
+            case .about:      return String(localized: "About")
             }
         }
 

--- a/project.yml
+++ b/project.yml
@@ -5,6 +5,23 @@ options:
     macOS: "14.0"
   createIntermediateGroups: true
   generateEmptyDirectories: true
+  developmentLanguage: en
+  # Locales we ship UI translations for. Xcode derives CFBundleLocalizations
+  # from this list. Adding a code here is necessary for the corresponding
+  # column to appear in Localizable.xcstrings.
+  knownRegions:
+    - en
+    - en-GB
+    - de
+    - es
+    - es-419
+    - fr
+    - it
+    - pt-BR
+    - ja
+    - zh-Hans
+    - zh-Hant
+    - ko
 
 settings:
   base:
@@ -18,6 +35,11 @@ settings:
     ENABLE_HARDENED_RUNTIME: YES
     OTHER_SWIFT_FLAGS: "$(inherited)"
     SWIFT_STRICT_CONCURRENCY: minimal
+    # Tell the Swift compiler to emit .stringsdata for every SwiftUI Text("…")
+    # / LocalizedStringKey / String(localized:) call so Xcode can sync them
+    # into Localizable.xcstrings on build.
+    SWIFT_EMIT_LOC_STRINGS: YES
+    LOCALIZED_STRING_SWIFTUI_SUPPORT: YES
 
 packages:
   Sparkle:
@@ -45,6 +67,10 @@ targets:
       - path: Resources/AppIconDev.icon
       - path: Resources/Emoji
         type: folder
+      # UI string catalog. Xcode auto-extracts every String(localized:) /
+      # Text("…") literal into this on build.
+      - path: Resources/Localizable.xcstrings
+        buildPhase: resources
       # Opaque-named effect assets. Names don't reveal their content; see
       # the Bundle.url(forResource:) call sites in Sources/Mojito/App/ for
       # which file is which.

--- a/project.yml
+++ b/project.yml
@@ -22,6 +22,15 @@ options:
     - zh-Hans
     - zh-Hant
     - ko
+    - hi
+    - ru
+    - pl
+    - nl
+    # RTL — SwiftUI auto-mirrors layout via Environment(\.layoutDirection),
+    # but the picker positioning + AppKit overlays may need spot-checks.
+    - ar
+    - fa
+    - he
 
 settings:
   base:

--- a/scripts/sync-localizable.sh
+++ b/scripts/sync-localizable.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Refresh Resources/Localizable.xcstrings from the per-file .stringsdata
+# emitted by the Swift compiler (SWIFT_EMIT_LOC_STRINGS = YES). Run after
+# `xcodebuild build` whenever you add or change a SwiftUI Text("…") /
+# String(localized: "…") so the catalog reflects current source.
+#
+# Xcode's IDE syncs automatically on build; this is the headless path.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+DERIV_BASE=$(xcodebuild -project Mojito.xcodeproj -scheme Mojito \
+    -configuration Debug -showBuildSettings 2>/dev/null \
+    | awk -F' = ' '/^[[:space:]]+OBJECT_FILE_DIR_normal[[:space:]]/ {print $2; exit}')
+
+ARCH=$(uname -m)
+DERIV="$DERIV_BASE/$ARCH"
+
+if [[ ! -d "$DERIV" ]]; then
+    echo "Build artifacts not found at $DERIV"
+    echo "Run a Debug build first: xcodebuild -project Mojito.xcodeproj -scheme Mojito -configuration Debug -destination 'platform=macOS' build"
+    exit 1
+fi
+
+find "$DERIV" -name '*.stringsdata' \
+    -not -name 'ExtractedAppShortcutsMetadata.stringsdata' \
+    -print0 \
+  | xargs -0 xcrun xcstringstool sync Resources/Localizable.xcstrings --stringsdata
+
+echo "Synced strings into Resources/Localizable.xcstrings."


### PR DESCRIPTION
## Summary

Phase A of i18n v1: wire up an Xcode String Catalog for 19 locales (en, en-GB, de, es, es-419, fr, it, pt-BR, ja, zh-Hans, zh-Hant, ko, hi, ru, pl, nl, ar, fa, he). No actual translations yet — that's Phase B.

### What this PR does

- New `Resources/Localizable.xcstrings` String Catalog (94 user-facing UI strings).
- `project.yml`: `knownRegions`, `developmentLanguage: en`, `SWIFT_EMIT_LOC_STRINGS = YES` so the Swift compiler emits per-file `.stringsdata`.
- `scripts/sync-localizable.sh` — headless equivalent of what Xcode's IDE does on build (sync extracted strings into the catalog).
- AppKit literals (NSMenuItem titles, NSWindow.title, NSImage.accessibilityDescription, NSMenuItem.toolTip) wrapped in `String(localized: …)` so they're discoverable by the extractor.
- `permissionRow` / `privacyRow` helpers switched to `LocalizedStringKey` parameters.
- Two hardcoded "Mojito" string literals in onboarding permission copy replaced with `\(AppInfo.displayName)`.
- Easter-egg effect files use `Text(verbatim: …)` for their literal content so the catalog stays free of egg specifics. One copy string in EasterEggsSettings was rewritten to avoid naming a specific egg.

### What's NOT in this PR (Phase B follow-up)

- Actual translations for the 18 non-base locales. Catalog will fall back to English source until those land.
- Open question for Phase B: LLM-drafted translations via script vs. professional translation. Recommend the former for a fast first pass.
- RTL layout spot-checks (ar/fa/he): SwiftUI auto-mirrors, but the caret-anchored picker NSPanel + AppKit overlays may need a once-over.

### Out of scope (tracked in W-186)

- Shortcode corpus / emoticons / fuzzy-search localization.
- Date/time format localization.

## Test plan
- [x] \`xcodebuild build\` succeeds.
- [x] \`scripts/sync-localizable.sh\` populates the catalog from compiler-emitted \`.stringsdata\`.
- [x] 94 strings in the catalog; zero egg-specific content.
- [x] Launching English unaffected.
- [ ] (manual) Launch with \`-AppleLanguages '(fr)'\` → English fallback, no missing strings, no crashes.

Refs: W-185