### PR TITLE
W-193: README — Translations contribution section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ Other things it does:
 
 Mojito reads keystrokes to recognize shortcodes. Nothing is logged or sent anywhere. Password fields are skipped. The only outbound request is the update check.
 
+## Translations
+
+Available in English (US + UK), German, Spanish (Spain + Latin America), French, Italian, Brazilian Portuguese, Japanese, Simplified and Traditional Chinese, Korean, Hindi, Russian, Polish, Dutch, Arabic, Farsi, and Hebrew. The non-English strings start as LLM drafts and improve as native speakers review them — corrections are very welcome.
+
+To contribute, edit `Resources/Localizable.xcstrings` (open it in Xcode for the catalog editor, or edit the JSON directly), then open a pull request. Preserve `%@` / `%lld` placeholders, Markdown like `**bold**`, and backticked code samples like `` `:tada:` `` exactly as they appear in the source string.
+
+To preview a locale without changing your Mac's system language:
+
+```bash
+scripts/run-locale.sh fr   # or de, ja, ar, zh-Hans, etc.
+```
+
 ## Credits
 
 emojibase, Sparkle, KeyboardShortcuts, and a Swift port of fzy.


### PR DESCRIPTION
## Summary

Brief Translations section in the README pointing contributors at `Resources/Localizable.xcstrings`, listing the 19 supported locales, explaining what to preserve (`%@` / `%lld` placeholders, Markdown, backticked code samples), and mentioning `scripts/run-locale.sh` for previewing a locale locally.

Kept it user/contributor-facing and short — implementation detail stays in CLAUDE.md.

## Test plan
- [x] Markdown renders correctly on GitHub.

Refs: W-193