### PR TITLE
W-203: site easter egg shows discovery banner + fanfare

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
 <link rel="apple-touch-icon" href="favicon.png">
 <link rel="preload" as="image" fetchpriority="high" href="wallpaper.webp" type="image/webp" media="(prefers-color-scheme: light)">
 <link rel="preload" as="image" fetchpriority="high" href="wallpaper-dark.webp" type="image/webp" media="(prefers-color-scheme: dark)">
-<link rel="stylesheet" href="style.css?v=64">
+<link rel="stylesheet" href="style.css?v=65">
 </head>
 <body>
 
@@ -61,6 +61,17 @@
            src="trash.png?v=1"
            srcset="trash.png?v=1 1x, trash@2x.png?v=1 2x"
            alt="" width="104" height="128" draggable="false">
+    </div>
+
+    <!-- Achievement banner — top-center blue pill that scale-pops in over the
+         crash overlay. Mirrors the in-app AchievementBanner discovery signal. -->
+    <div class="achievement" id="achievement" aria-hidden="true">
+      <div class="achievement-pill">
+        <span class="achievement-glyph" aria-hidden="true">💣</span>
+        <span class="achievement-lead">Your first easter egg!</span>
+        <span class="achievement-sep" aria-hidden="true">·</span>
+        <span class="achievement-detail">One down, 100 to go</span>
+      </div>
     </div>
 
     <!-- Sad Mac crash overlay, shown when the Website folder is dragged to trash. -->
@@ -411,6 +422,6 @@ Changes not staged for commit:
   <p class="copyright">&copy; 2026 <a href="https://wells.ee">Wells Riley</a></p>
 </footer>
 
-<script src="picker.js?v=45" defer></script>
+<script src="picker.js?v=48" defer></script>
 </body>
 </html>

--- a/picker.js
+++ b/picker.js
@@ -4161,6 +4161,8 @@
     // Hide the active app + picker instantly so the "crash" feels abrupt
     // — even before the overlay fades in.
     if (picker) picker.classList.remove('show');
+    // Crash half first: death chime + Sad Mac overlay. The chime runs
+    // ~1s end-to-end (440 → 277 → 130 Hz square pulses).
     playDeathChime();
     if (sadmac) {
       sadmac.setAttribute('aria-hidden', 'false');
@@ -4170,6 +4172,70 @@
         window.location.reload();
       }, { once: true });
     }
+    // Discovery half: once the chime has cleared, the banner scale-pops in
+    // and the cheerful fanfare plays on its own. Sequencing this way keeps
+    // the two sound effects from stepping on each other and lets the
+    // "you found an egg" reveal land after the joke crash.
+    const CHIME_MS = 1100;
+    setTimeout(() => {
+      showAchievementBanner();
+      playDiscoveryFanfare();
+    }, CHIME_MS);
+  }
+
+  // Ascending C-major arpeggio (C5 → E5 → G5) played as short square-wave
+  // pulses with tiny attack/release envelopes to de-click the edges.
+  // Mirrors `Sources/Mojito/App/DiscoveryFanfare.swift` — same notes,
+  // durations, and master gain so the web "discovery" sounds the same as
+  // the app's.
+  function playDiscoveryFanfare() {
+    try {
+      const Ctx = window.AudioContext || window.webkitAudioContext;
+      if (!Ctx) return;
+      const ctx = new Ctx();
+      const now = ctx.currentTime;
+      const notes = [
+        { f: 523.25, t: 0.000, d: 0.09 },
+        { f: 659.25, t: 0.115, d: 0.09 },
+        { f: 783.99, t: 0.230, d: 0.16 },
+      ];
+      const master = ctx.createGain();
+      master.gain.value = 0.06;
+      master.connect(ctx.destination);
+      notes.forEach((n) => {
+        const osc = ctx.createOscillator();
+        const g = ctx.createGain();
+        osc.type = 'square';
+        osc.frequency.setValueAtTime(n.f, now + n.t);
+        g.gain.setValueAtTime(0, now + n.t);
+        g.gain.linearRampToValueAtTime(1, now + n.t + 0.005);
+        g.gain.setValueAtTime(1, now + n.t + n.d - 0.020);
+        g.gain.linearRampToValueAtTime(0, now + n.t + n.d);
+        osc.connect(g).connect(master);
+        osc.start(now + n.t);
+        osc.stop(now + n.t + n.d + 0.02);
+      });
+      setTimeout(() => { try { ctx.close(); } catch (_) {} }, 1200);
+    } catch (_) { /* no audio, no problem */ }
+  }
+
+  // Scale-pop the banner in, hold for 3.5s, then scale it back out. Times
+  // match the in-app AchievementBanner (3.5s hold, ~0.3s exit). The CSS
+  // does the actual animation; this just toggles classes.
+  function showAchievementBanner() {
+    const el = document.getElementById('achievement');
+    if (!el) return;
+    el.setAttribute('aria-hidden', 'false');
+    el.classList.remove('is-off');
+    requestAnimationFrame(() => el.classList.add('is-on'));
+    setTimeout(() => {
+      el.classList.remove('is-on');
+      el.classList.add('is-off');
+      setTimeout(() => {
+        el.setAttribute('aria-hidden', 'true');
+        el.classList.remove('is-off');
+      }, 300);
+    }, 3500);
   }
 
   // Classic-Mac-style death chime — a short, harsh descending square-wave

--- a/style.css
+++ b/style.css
@@ -328,6 +328,82 @@ code {
   filter: drop-shadow(0 6px 14px rgba(0,0,0,0.20)) brightness(0.55);
 }
 
+/* Achievement banner — top-center systemBlue capsule that scale-pops in
+   when the easter egg fires, sits above the Sad Mac overlay (z-index >
+   .sadmac's 9999), and is click-through so the overlay still receives
+   the click-to-reboot. Geometry/typography mirrors the in-app
+   AchievementBanner (`Sources/Mojito/App/AchievementBanner.swift` on
+   `main`): 18px/10px padding, 13px text, 20px glyph, capsule, drop
+   shadow. Entry uses a bouncy cubic-bezier to approximate the SwiftUI
+   spring (response 0.42, damping 0.55); exit is a quick ease-in. */
+.achievement {
+  position: fixed;
+  top: 4px;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: center;
+  z-index: 10000;
+  pointer-events: none;
+}
+
+.achievement-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: 9999px;
+  background: #007aff;
+  color: #fff;
+  font: 13px / 1.2 -apple-system, BlinkMacSystemFont, "SF Pro Text",
+    "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: 600;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  white-space: nowrap;
+  transform: scale(0);
+  opacity: 0;
+  transition:
+    transform 0.42s cubic-bezier(0.34, 1.56, 0.64, 1),
+    opacity 0.18s ease-out;
+  transform-origin: center;
+}
+
+.achievement.is-on .achievement-pill {
+  transform: scale(1);
+  opacity: 1;
+}
+
+.achievement.is-off .achievement-pill {
+  transform: scale(0);
+  opacity: 0;
+  transition:
+    transform 0.22s ease-in,
+    opacity 0.22s ease-in;
+}
+
+.achievement-glyph {
+  font-size: 20px;
+  line-height: 1;
+}
+
+.achievement-lead {
+  font-weight: 600;
+}
+
+.achievement-sep {
+  font-weight: 400;
+  opacity: 0.55;
+}
+
+.achievement-detail {
+  font-weight: 400;
+  opacity: 0.95;
+}
+
+@media (prefers-color-scheme: dark) {
+  .achievement-pill { background: #0a84ff; }
+}
+
 /* Sad Mac crash overlay — full-viewport black screen with a tiny pixelated
    sad face centered in the middle, classic Mac OS bomb-style hex codes
    below, and a cursor hint. Click anywhere reloads the page. */


### PR DESCRIPTION
## Summary
- After the Sad Mac chime clears, the marketing site now scale-pops a top-center blue pill (**"Your first easter egg! · One down, 100 to go"**) and plays a quiet C-major arpeggio — mirroring the in-app `AchievementBanner` + `DiscoveryFanfare` pair so the site's hidden gesture lands the same "you found something" beat as the app does.
- Sequenced: death chime + Sad Mac fade-in first, then a ~1.1s gap, then the banner + fanfare. The two sound effects no longer overlap.
- Cache busters bumped: `style.css?v=65`, `picker.js?v=48`.

## Test plan
- [ ] Drag the "Website" folder onto the Trash. Sad Mac + chime appear immediately.
- [ ] ~1.1s after the chime, the blue pill scale-pops into the top center over the Sad Mac, the C-major fanfare plays, and the pill scale-pops back out after ~3.5s.
- [ ] Click anywhere on the Sad Mac (during or after the banner) reloads the page.
- [ ] The banner doesn't intercept the reboot click (pointer-events: none).
- [ ] Drop again after reload — fires every time.
- [ ] Looks correct in light + dark mode (banner blue tracks systemBlue).

Refs: W-203