### PR TITLE
W-205: force text presentation for symbol-picker entries

### DIFF
--- a/Mojito.xcodeproj/project.pbxproj
+++ b/Mojito.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		89AB6401CC7F94BCBF0D3437 /* s16.bin in Resources */ = {isa = PBXBuildFile; fileRef = E87A9C3A9251B8908CFB056A /* s16.bin */; };
 		8EE9F3A928A7AFDB16C6D9A2 /* OnboardingRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4512D76E20BD99269775200B /* OnboardingRoot.swift */; };
 		917B8512B30F3B6E8C9D2B8C /* SkinToneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74BDC060E2EAACF7A71A3A6 /* SkinToneTests.swift */; };
+		91A5F2A800EA1FC0700394EA /* SymbolsDatabaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25EC50F4D58E03E218947DF /* SymbolsDatabaseTests.swift */; };
 		9234FF3040DB70F660567DCB /* v12.bin in Resources */ = {isa = PBXBuildFile; fileRef = 8616DAC09008096A70541CEE /* v12.bin */; };
 		9CB4AA2C8D9DE6B788068AA9 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = EB2F085FF2A8206D2905DF27 /* Sparkle */; };
 		9CCEA0B70EEB77F988521DDB /* AppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1DA7C9FD3286A7839BA642D /* AppInfo.swift */; };
@@ -263,6 +264,7 @@
 		DF0A9FF25BC996BC640A35A0 /* s01.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; path = s01.bin; sourceTree = "<group>"; };
 		DF44D58B49F923004BEED6E7 /* FlyingToasters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlyingToasters.swift; sourceTree = "<group>"; };
 		E229DD4E9239183CD578F665 /* KonamiPayoff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KonamiPayoff.swift; sourceTree = "<group>"; };
+		E25EC50F4D58E03E218947DF /* SymbolsDatabaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolsDatabaseTests.swift; sourceTree = "<group>"; };
 		E5E4119DFCFBCC4A92FEEB1C /* v02.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; path = v02.bin; sourceTree = "<group>"; };
 		E6F0EF28CC67A6AB9FFF203F /* DiscoveryNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoveryNotifier.swift; sourceTree = "<group>"; };
 		E7D1F9E45C5D2C8B6FB43111 /* TrainGame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrainGame.swift; sourceTree = "<group>"; };
@@ -302,6 +304,7 @@
 				69CD38087938C1E258718C69 /* FzyScorerTests.swift */,
 				9E0C646543028E968FB6287E /* SeasonalGatesTests.swift */,
 				D74BDC060E2EAACF7A71A3A6 /* SkinToneTests.swift */,
+				E25EC50F4D58E03E218947DF /* SymbolsDatabaseTests.swift */,
 				B18B2F281B96164331FE772F /* TriggerStateMachineTests.swift */,
 			);
 			path = MojitoTests;
@@ -860,6 +863,7 @@
 				B32AE99482DA334BDD7CEEAC /* FzyScorerTests.swift in Sources */,
 				C025CD4AE30320C3FE69028A /* SeasonalGatesTests.swift in Sources */,
 				917B8512B30F3B6E8C9D2B8C /* SkinToneTests.swift in Sources */,
+				91A5F2A800EA1FC0700394EA /* SymbolsDatabaseTests.swift in Sources */,
 				C86E0BA1D69D1A6B33068221 /* TriggerStateMachineTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Mojito/EmojiDB/SymbolsDatabase.swift
+++ b/Sources/Mojito/EmojiDB/SymbolsDatabase.swift
@@ -9,10 +9,11 @@ enum SymbolsDatabase {
         var result: [IndexedEmoji] = []
 
         for entry in curatedAliases {
-            seenCharacters.insert(entry.character)
+            let char = textPresentation(entry.character)
+            seenCharacters.insert(char)
             let emoji = Emoji(
                 hexcode: "SYM_" + entry.shortcodes[0],
-                character: entry.character,
+                character: char,
                 label: entry.shortcodes[0],
                 shortcodes: entry.shortcodes,
                 tags: [],
@@ -30,7 +31,7 @@ enum SymbolsDatabase {
         for range in symbolRanges {
             for codepoint in range {
                 guard let scalar = Unicode.Scalar(codepoint) else { continue }
-                let char = String(scalar)
+                let char = textPresentation(String(scalar))
                 if seenCharacters.contains(char) { continue }
                 guard let name = scalar.properties.name, !name.isEmpty else { continue }
 
@@ -56,6 +57,17 @@ enum SymbolsDatabase {
         }
 
         return result
+    }
+
+    /// Scalars with the Unicode `Emoji` property render in color on macOS
+    /// unless explicitly pinned to text style with VS15 (U+FE0E). Without
+    /// this, ::aries: returned ♈️ (emoji) where the picker expects ♈︎.
+    /// No-op for scalars that have no emoji presentation (⌘, ←, π, …).
+    private static func textPresentation(_ s: String) -> String {
+        guard let scalar = s.unicodeScalars.first, scalar.properties.isEmoji else {
+            return s
+        }
+        return s + "\u{FE0E}"
     }
 
     private struct Alias {

--- a/Tests/MojitoTests/SymbolsDatabaseTests.swift
+++ b/Tests/MojitoTests/SymbolsDatabaseTests.swift
@@ -1,0 +1,41 @@
+import Testing
+@testable import Mojito
+
+/// SymbolsDatabase pins text-style presentation on scalars that would
+/// otherwise render in color on macOS — VS15 (U+FE0E) gets appended for
+/// any scalar with the Unicode `Emoji` property.
+struct SymbolsDatabaseTests {
+    private static let indexed = SymbolsDatabase.indexed()
+
+    private func entry(forCodepoint cp: UInt32) -> IndexedEmoji? {
+        let needle = String(format: "SYM_U%X", cp)
+        return Self.indexed.first(where: { $0.emoji.hexcode == needle })
+    }
+
+    @Test func emojiPropertyScalarGetsTextVariationSelector() {
+        // U+2648 ARIES has Emoji=true → must ship with trailing VS15.
+        let aries = entry(forCodepoint: 0x2648)
+        #expect(aries != nil)
+        let scalars = Array(aries!.emoji.character.unicodeScalars)
+        #expect(scalars.first?.value == 0x2648)
+        #expect(scalars.last?.value == 0xFE0E)
+    }
+
+    @Test func nonEmojiScalarIsLeftBare() {
+        // U+2318 PLACE OF INTEREST SIGN (⌘) has no Emoji property — must
+        // not get a trailing variation selector.
+        let cmd = SymbolsDatabaseTests.indexed.first(where: { $0.emoji.character.hasPrefix("⌘") })
+        #expect(cmd != nil)
+        let scalars = Array(cmd!.emoji.character.unicodeScalars)
+        #expect(scalars.count == 1)
+        #expect(scalars.first?.value == 0x2318)
+    }
+
+    @Test func curatedShortcodeStillResolves() {
+        // The character mutation must not break the existing shortcode-
+        // based lookup the curated aliases rely on.
+        let cmd = SymbolsDatabaseTests.indexed.first(where: { $0.emoji.shortcodes.contains("cmd") })
+        #expect(cmd != nil)
+        #expect(cmd?.emoji.character == "⌘")
+    }
+}


### PR DESCRIPTION
## Summary
- `SymbolsDatabase` was producing bare scalars for entries like ♈ (U+2648); macOS CoreText renders many of these in color by default.
- Append U+FE0E (VS15) to scalars carrying the Unicode `Emoji` property so the picker tile and inserted text both come out monochrome.
- Unit tests assert ♈ ships with VS15, ⌘ does not, and shortcode lookup still works.

Refs: W-205

## Test plan
- [ ] `scripts/run-tests.sh` green (covers the new `SymbolsDatabaseTests`).
- [ ] `::aries:` inserts the text form ♈︎ in TextEdit and Slack.
- [ ] `::cmd:` still inserts ⌘ (no visible change — the helper is a no-op here).
- [ ] Picker grid for matches like `aries`, `taurus`, `check_mark`, `tm` shows monochrome glyphs.