### PR TITLE
W-208: drop un-renderable scalars from the symbols corpus

### DIFF
--- a/Sources/Mojito/EmojiDB/SymbolsDatabase.swift
+++ b/Sources/Mojito/EmojiDB/SymbolsDatabase.swift
@@ -1,3 +1,5 @@
+import AppKit
+import CoreText
 import Foundation
 
 /// Two layers: hand-picked aliases (`cmd` → ⌘) take precedence over the
@@ -34,6 +36,10 @@ enum SymbolsDatabase {
                 let char = textPresentation(String(scalar))
                 if seenCharacters.contains(char) { continue }
                 guard let name = scalar.properties.name, !name.isEmpty else { continue }
+                // Many scalars in these ranges have a Unicode name but no
+                // glyph anywhere in macOS's font cascade. Without this
+                // gate they show up in the picker as ?-tofu rows.
+                guard systemFontCanRender(char) else { continue }
 
                 let shortcode = name
                     .lowercased()
@@ -68,6 +74,33 @@ enum SymbolsDatabase {
             return s
         }
         return s + "\u{FE0E}"
+    }
+
+    /// Asks the actual rendering cascade whether anything but Apple's
+    /// `LastResort` fallback font handles `s`. LastResort is what draws
+    /// those `?`-in-a-box placeholder glyphs; non-zero glyphs from it
+    /// look rendered but read as tofu to the user. Real fonts in the
+    /// cascade (SF Pro, Apple Color Emoji, Apple Symbols, etc.) all
+    /// pass.
+    private static func systemFontCanRender(_ s: String) -> Bool {
+        guard let font = CTFontCreateUIFontForLanguage(.system, 13, nil) else {
+            return true
+        }
+        let attr = NSAttributedString(string: s, attributes: [.font: font])
+        let line = CTLineCreateWithAttributedString(attr)
+        guard let runs = CTLineGetGlyphRuns(line) as? [CTRun] else { return true }
+        for run in runs {
+            let n = CTRunGetGlyphCount(run)
+            guard n > 0 else { return false }
+            var glyphs = [CGGlyph](repeating: 0, count: n)
+            CTRunGetGlyphs(run, CFRange(location: 0, length: 0), &glyphs)
+            if glyphs.contains(0) { return false }
+            let attrs = CTRunGetAttributes(run) as NSDictionary
+            guard let runFont = attrs[kCTFontAttributeName as NSString] else { return false }
+            let name = CTFontCopyPostScriptName(runFont as! CTFont) as String
+            if name == "LastResort" { return false }
+        }
+        return true
     }
 
     private struct Alias {

--- a/Tests/MojitoTests/SymbolsDatabaseTests.swift
+++ b/Tests/MojitoTests/SymbolsDatabaseTests.swift
@@ -31,6 +31,14 @@ struct SymbolsDatabaseTests {
         #expect(scalars.first?.value == 0x2318)
     }
 
+    @Test func unrenderableScalarIsDroppedFromCorpus() {
+        // U+2BE8 STAR WITH LEFT HALF BLACK is in the swept range and has a
+        // Unicode name, but no font on macOS 14/15 carries a glyph for it.
+        // The Core Text cascade gate should excise it.
+        let hex = String(format: "SYM_U%X", 0x2BE8)
+        #expect(!SymbolsDatabaseTests.indexed.contains(where: { $0.emoji.hexcode == hex }))
+    }
+
     @Test func curatedShortcodeStillResolves() {
         // The character mutation must not break the existing shortcode-
         // based lookup the curated aliases rely on.


### PR DESCRIPTION
## Summary
- Some scalars in the swept ranges (e.g. `U+2BE8 STAR WITH LEFT HALF BLACK`) have Unicode names but no real glyph in any macOS font. The text cascade routes them to Apple's `LastResort` font, which draws box-outline placeholders — appears as `?`-tofu in the symbol picker.
- Added a Core Text gate during the programmatic sweep: drop entries whose rendering run resolves to `LastResort`. Real cascade fallbacks (SF Pro, Apple Color Emoji, Apple Symbols, …) pass.
- Pairs with W-205's text-presentation fix; the gate runs *after* `textPresentation()` so chars with a trailing VS15 are evaluated as they'll actually render.

Refs: W-208

## Test plan
- [ ] `scripts/run-tests.sh` green (`unrenderableScalarIsDroppedFromCorpus` covers U+2BE8 directly).
- [ ] `::star_with_left_half` produces no `?`-tofu rows.
- [ ] Legitimate symbols still surface: ⌘, ←, π, aries, etc.
- [ ] No noticeable cold-start latency on first symbol-corpus search.