### PR TITLE
W-209: add anonymized debug report to About

### DIFF
--- a/Mojito.xcodeproj/project.pbxproj
+++ b/Mojito.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		6A8EC5B13FA4A0AC0F338875 /* ConfettiSound.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB589505841013FF5EF5500 /* ConfettiSound.swift */; };
 		6B48E883C3B324C8ABB16C93 /* AmbientEmoticonTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE7D78A4736AA53650D60DC /* AmbientEmoticonTable.swift */; };
 		6F9314FB48040BE582D87716 /* BlueScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD72EE1D10D399387F1DD1C8 /* BlueScreen.swift */; };
+		74CED6225633C087A96D7E9C /* DebugRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2928BC07BE26CF9B15F23D70 /* DebugRecorder.swift */; };
 		75008F5E9E8750E55512283C /* FzyScorer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5EDBB8F234B21B8D4A3324 /* FzyScorer.swift */; };
 		751B7D80FF9EA3BA8B30B8FC /* EasterEggsSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA756B434C9FED6B691D07B8 /* EasterEggsSettings.swift */; };
 		7525CC4DDD1EDE4BE0FADC03 /* s15.bin in Resources */ = {isa = PBXBuildFile; fileRef = ED8647D638A24D3741D78A59 /* s15.bin */; };
@@ -76,6 +77,7 @@
 		87F16A28F58C4854576DD450 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22B06D1C751C2161A7A99DA1 /* AppDelegate.swift */; };
 		881B726A6871BA37651B06B0 /* GifClipboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19FC0DC96883A143602E6668 /* GifClipboard.swift */; };
 		89AB6401CC7F94BCBF0D3437 /* s16.bin in Resources */ = {isa = PBXBuildFile; fileRef = E87A9C3A9251B8908CFB056A /* s16.bin */; };
+		8DC058D738EC5E540C69BE61 /* PickerContextSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB3CE6896B4FB11651A14AD /* PickerContextSnapshot.swift */; };
 		8EE9F3A928A7AFDB16C6D9A2 /* OnboardingRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4512D76E20BD99269775200B /* OnboardingRoot.swift */; };
 		917B8512B30F3B6E8C9D2B8C /* SkinToneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74BDC060E2EAACF7A71A3A6 /* SkinToneTests.swift */; };
 		91A5F2A800EA1FC0700394EA /* SymbolsDatabaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25EC50F4D58E03E218947DF /* SymbolsDatabaseTests.swift */; };
@@ -83,6 +85,7 @@
 		9CB4AA2C8D9DE6B788068AA9 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = EB2F085FF2A8206D2905DF27 /* Sparkle */; };
 		9CCEA0B70EEB77F988521DDB /* AppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1DA7C9FD3286A7839BA642D /* AppInfo.swift */; };
 		9E9309E8AF1F9D8B44213729 /* EmoticonTableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBB27C78330DB1E6F05BDAE7 /* EmoticonTableTests.swift */; };
+		9F45015A816323AF275F23ED /* DebugReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C9E01A82260E8A38DF8D7EA /* DebugReport.swift */; };
 		A9A15B339C05195BB45CC09F /* MyLegSound.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C4C16E01184684E33C3437 /* MyLegSound.swift */; };
 		A9CDDCEBAC41BF8676B8F2EC /* EasterEggTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3188FF1FD6559BF8E64C19CC /* EasterEggTracker.swift */; };
 		ABF54441D03140C8174E13A9 /* PrefsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C66984ECCB4DB6B1A018452 /* PrefsKey.swift */; };
@@ -94,6 +97,7 @@
 		B33E18A7CE2409FEE3367728 /* LaunchAtLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC763FD3C4773231C72CFDD /* LaunchAtLogin.swift */; };
 		B43E634B3FAB6B7FBF2CFC6C /* AboutSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100317FDEDAED8905256B964 /* AboutSettings.swift */; };
 		B520161A0B158BFFC5C33440 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6BDC5E636ADC61D8671950 /* main.swift */; };
+		B878C3CC891907E89DE33158 /* DebugReportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C69999E4AC7F8B8C054B395 /* DebugReportTests.swift */; };
 		BA163217ADDEBAF751D5ABA2 /* PrideWave.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8792D3A9CA964FE06B29F30F /* PrideWave.swift */; };
 		BAD1B39F1DD2FD627281164D /* CRTPowerOff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 151DC25F7CEE4F3BE8F23650 /* CRTPowerOff.swift */; };
 		BB81EE5FC4005052735E097D /* s14.bin in Resources */ = {isa = PBXBuildFile; fileRef = D05EB6710B1D2B6310DE45AC /* s14.bin */; };
@@ -169,9 +173,11 @@
 		2027256AFD59D65C41FAA2AD /* PermissionsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsCoordinator.swift; sourceTree = "<group>"; };
 		22B06D1C751C2161A7A99DA1 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		2361376F2801DB575F27B480 /* DialupSound.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialupSound.swift; sourceTree = "<group>"; };
+		2928BC07BE26CF9B15F23D70 /* DebugRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugRecorder.swift; sourceTree = "<group>"; };
 		2C4CF18CE5AC46767EFCA557 /* v03.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; path = v03.bin; sourceTree = "<group>"; };
 		2C66984ECCB4DB6B1A018452 /* PrefsKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefsKey.swift; sourceTree = "<group>"; };
 		2D64E06BE48B822A5BA55952 /* EffectDismisser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EffectDismisser.swift; sourceTree = "<group>"; };
+		2DB3CE6896B4FB11651A14AD /* PickerContextSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickerContextSnapshot.swift; sourceTree = "<group>"; };
 		2F21A9938263FE3EE577F03D /* s06.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; path = s06.bin; sourceTree = "<group>"; };
 		300590ABBE9E070A97FCFF92 /* SosumiSound.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SosumiSound.swift; sourceTree = "<group>"; };
 		3188FF1FD6559BF8E64C19CC /* EasterEggTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EasterEggTracker.swift; sourceTree = "<group>"; };
@@ -194,9 +200,11 @@
 		5A80F3946EA93F8F8A25774E /* TriggerStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerStateMachine.swift; sourceTree = "<group>"; };
 		5A8851906565F70B7815640F /* FuzzyMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatcher.swift; sourceTree = "<group>"; };
 		5B9E4C2183154C36F1883004 /* PickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickerViewModel.swift; sourceTree = "<group>"; };
+		5C9E01A82260E8A38DF8D7EA /* DebugReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugReport.swift; sourceTree = "<group>"; };
 		5FB7AB3DB0E63AF30880FE66 /* BrowserURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserURL.swift; sourceTree = "<group>"; };
 		6666150B793721D5095E72A8 /* SymbolsDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolsDatabase.swift; sourceTree = "<group>"; };
 		69CD38087938C1E258718C69 /* FzyScorerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FzyScorerTests.swift; sourceTree = "<group>"; };
+		6C69999E4AC7F8B8C054B395 /* DebugReportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugReportTests.swift; sourceTree = "<group>"; };
 		6E2009C3B36DF9228B873244 /* EmoticonTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmoticonTable.swift; sourceTree = "<group>"; };
 		6EE7D78A4736AA53650D60DC /* AmbientEmoticonTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmbientEmoticonTable.swift; sourceTree = "<group>"; };
 		702AC2870CD686AB17CC518E /* UpdaterCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdaterCoordinator.swift; sourceTree = "<group>"; };
@@ -300,6 +308,7 @@
 		02F05DB5E7247E1AE700004A /* MojitoTests */ = {
 			isa = PBXGroup;
 			children = (
+				6C69999E4AC7F8B8C054B395 /* DebugReportTests.swift */,
 				DBB27C78330DB1E6F05BDAE7 /* EmoticonTableTests.swift */,
 				69CD38087938C1E258718C69 /* FzyScorerTests.swift */,
 				9E0C646543028E968FB6287E /* SeasonalGatesTests.swift */,
@@ -376,6 +385,7 @@
 			children = (
 				ABDF9E60F36CAC7A465AC7B3 /* App */,
 				18DF0B1E60F36983A1C5C7C6 /* Context */,
+				4BBA47A36F86A6BF873E0BFE /* Debug */,
 				D822FEA7909C200A1E98FE7E /* EmojiDB */,
 				96D2222BAC28DB7F4A46101E /* Exclusions */,
 				BBBEA9AAC00A3FC4C7CF88F9 /* GifPicker */,
@@ -416,6 +426,16 @@
 				5A80F3946EA93F8F8A25774E /* TriggerStateMachine.swift */,
 			);
 			path = KeyMonitor;
+			sourceTree = "<group>";
+		};
+		4BBA47A36F86A6BF873E0BFE /* Debug */ = {
+			isa = PBXGroup;
+			children = (
+				2928BC07BE26CF9B15F23D70 /* DebugRecorder.swift */,
+				5C9E01A82260E8A38DF8D7EA /* DebugReport.swift */,
+				2DB3CE6896B4FB11651A14AD /* PickerContextSnapshot.swift */,
+			);
+			path = Debug;
 			sourceTree = "<group>";
 		};
 		65E49BD5A468F951A2A3E38E /* Sources */ = {
@@ -776,6 +796,8 @@
 				D7FD72169491380D742F69BC /* ChooChooSound.swift in Sources */,
 				F46B89A2E807D259981405E5 /* ConfettiRain.swift in Sources */,
 				6A8EC5B13FA4A0AC0F338875 /* ConfettiSound.swift in Sources */,
+				74CED6225633C087A96D7E9C /* DebugRecorder.swift in Sources */,
+				9F45015A816323AF275F23ED /* DebugReport.swift in Sources */,
 				4949BE63FAD5A5FC2573CFE1 /* DefaultExclusions.swift in Sources */,
 				55C7BE736206664DE37166E2 /* DialupSound.swift in Sources */,
 				3D91FC131565306ABD82887E /* DiscoveryFanfare.swift in Sources */,
@@ -821,6 +843,7 @@
 				30C268985E8FC43E95617345 /* OnboardingWindowController.swift in Sources */,
 				54BE766E1C8E447D04D3F02C /* ParticlePanel.swift in Sources */,
 				ECC3936D06DC519BCE249F8D /* PermissionsCoordinator.swift in Sources */,
+				8DC058D738EC5E540C69BE61 /* PickerContextSnapshot.swift in Sources */,
 				304C8571D431917AC25596C3 /* PickerView.swift in Sources */,
 				31277ED14E13ADDE2816BB69 /* PickerViewModel.swift in Sources */,
 				BE6D39677A64B5D4AC31B03B /* PickerWindow.swift in Sources */,
@@ -859,6 +882,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B878C3CC891907E89DE33158 /* DebugReportTests.swift in Sources */,
 				9E9309E8AF1F9D8B44213729 /* EmoticonTableTests.swift in Sources */,
 				B32AE99482DA334BDD7CEEAC /* FzyScorerTests.swift in Sources */,
 				C025CD4AE30320C3FE69028A /* SeasonalGatesTests.swift in Sources */,

--- a/Sources/Mojito/App/Engine.swift
+++ b/Sources/Mojito/App/Engine.swift
@@ -78,6 +78,7 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
         }
 
         gifPickerWindow.onGifInserted = { [weak self] in
+            DebugRecorder.record(.gif, "insert")
             self?.recordGifInserted()
         }
 
@@ -167,6 +168,7 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
         captureFocusSnapshot = nil
         captureFocusPID = nil
         captureIsExcluded = false
+        DebugRecorder.record(.picker, "cancel")
     }
 
     func attach(permissions: PermissionsCoordinator) {
@@ -195,12 +197,14 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
     func pause(until date: Date) {
         pausedUntil = date
         UserDefaults.standard.set(date.timeIntervalSince1970, forKey: PrefsKey.pausedUntil)
+        DebugRecorder.record(.engine, "pause")
         reconcile()
     }
 
     func resume() {
         pausedUntil = nil
         UserDefaults.standard.removeObject(forKey: PrefsKey.pausedUntil)
+        DebugRecorder.record(.engine, "resume")
         reconcile()
     }
 
@@ -472,6 +476,8 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
                 let anchor = CaretLocator.caretRect()
+                PickerContextStore.capture(caretOutcome: CaretLocator.lastOutcome, resolvedCaret: anchor)
+                DebugRecorder.record(.gif, "open", ["outcome": CaretLocator.lastOutcome])
                 self.gifPickerWindow.show(near: anchor)
             }
 
@@ -521,6 +527,11 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
                 return
             }
             let anchor = CaretLocator.caretRect()
+            PickerContextStore.capture(caretOutcome: CaretLocator.lastOutcome, resolvedCaret: anchor)
+            DebugRecorder.record(.picker, "open", [
+                "outcome": CaretLocator.lastOutcome,
+                "resultCount": "\(self.viewModel.results.count)",
+            ])
             self.pickerWindow.show(near: anchor)
         }
     }
@@ -591,6 +602,7 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
             // focused app. User explicitly picked a row, including special
             // rows (🎁 ???, 🎲).
             guard let scored = viewModel.topResult else { return }
+            DebugRecorder.record(.insert, "fromPicker", ["scope": "\(scope)"])
             let charsToDelete = query.count + leadingColons
             if triggerEasterEgg(hexcode: scored.emoji.hexcode, deleteCount: charsToDelete) {
                 return
@@ -608,6 +620,7 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
             // Typed text is `:query:` (or `::query:`). Delete only if
             // something resolves; otherwise leave the text alone.
             let key = query.lowercased()
+            DebugRecorder.record(.insert, "exactMatch", ["scope": "\(scope)"])
             let charsToDelete = query.count + leadingColons + 1  // + trailing colon
 
             // `::query:`: top-1 fuzzy against symbols, exact label only.
@@ -865,6 +878,7 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
             pendingEmoticonUndo = nil
             return
         }
+        DebugRecorder.record(.emoticon, "convert", ["consumesTerminator": "\(match.consumesTerminator)"])
         // App reads `:<query><terminator>` — delete all three. Restore the
         // terminator after the emoji unless it was part of the emoticon.
         let charsToDelete = 1 + query.count + 1
@@ -890,6 +904,7 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
             pendingEmoticonUndo = nil
             return
         }
+        DebugRecorder.record(.emoticon, "ambientImmediate")
         TextInserter.replace(charactersToDelete: word.count, with: emoji)
 
         pendingEmoticonUndo = EmoticonUndo(
@@ -908,6 +923,7 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
             pendingEmoticonUndo = nil
             return
         }
+        DebugRecorder.record(.emoticon, "ambient")
         // Ambient entries are letter/punct sequences with no trailing
         // whitespace, so the terminator always survives the conversion.
         let charsToDelete = word.count + 1

--- a/Sources/Mojito/Context/FocusedElementCache.swift
+++ b/Sources/Mojito/Context/FocusedElementCache.swift
@@ -68,6 +68,7 @@ final class FocusedElementCache {
         )
         element = status == .success ? (ref as! AXUIElement) : nil
         focusedPID = pid
+        DebugRecorder.record(.focus, "app", ["bundleID": app.bundleIdentifier ?? "—"])
         onFocusChange?()
 
         // C function pointer — no captures allowed, route via refcon.

--- a/Sources/Mojito/Debug/DebugRecorder.swift
+++ b/Sources/Mojito/Debug/DebugRecorder.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Categories that surface in the debug report. Keep the set small —
+/// bug categories tend to cluster, and a tight enum makes the report
+/// easy to skim.
+enum DebugCategory: String {
+    case engine
+    case picker
+    case insert
+    case emoticon
+    case gif
+    case keyMonitor
+    case permissions
+    case focus
+}
+
+struct DebugEvent {
+    let timestamp: Date
+    let category: DebugCategory
+    let kind: String
+    let metadata: [String: String]
+}
+
+/// In-memory, app-lifetime ring buffer. Never persisted. Backs the
+/// "Activity log" section of `DebugReport`. Sites call `record(_:_:_:)`
+/// at meaningful state transitions — picker open, insert, permission
+/// flip, etc.
+///
+/// Anonymization is enforced on the way *in*: kind is clamped to 24
+/// ASCII chars and each metadata value to 32. Callers can't accidentally
+/// leak free-form text (queries, URLs, emoji content) into the buffer.
+@MainActor
+enum DebugRecorder {
+    private static let capacity = 200
+    private static let kindMaxLen = 24
+    private static let valueMaxLen = 32
+    private static var buffer: [DebugEvent] = []
+
+    static func record(
+        _ category: DebugCategory,
+        _ kind: String,
+        _ metadata: [String: String] = [:]
+    ) {
+        let event = DebugEvent(
+            timestamp: Date(),
+            category: category,
+            kind: clamp(kind, max: kindMaxLen),
+            metadata: metadata.mapValues { clamp($0, max: valueMaxLen) }
+        )
+        buffer.append(event)
+        if buffer.count > capacity {
+            buffer.removeFirst(buffer.count - capacity)
+        }
+    }
+
+    /// Newest-last; callers (DebugReport) take the tail.
+    static func snapshot() -> [DebugEvent] { buffer }
+
+    static func reset() { buffer.removeAll() }
+
+    /// Drops non-printable ASCII and caps length. Keeps the buffer free
+    /// of multibyte payloads that could smuggle out user text.
+    private static func clamp(_ s: String, max: Int) -> String {
+        let filtered = s.unicodeScalars.lazy
+            .filter { (0x20...0x7E).contains($0.value) }
+            .prefix(max)
+        return String(String.UnicodeScalarView(filtered))
+    }
+}

--- a/Sources/Mojito/Debug/DebugReport.swift
+++ b/Sources/Mojito/Debug/DebugReport.swift
@@ -1,0 +1,224 @@
+import AppKit
+import ApplicationServices
+import Foundation
+import IOKit.hid
+
+/// Markdown debug report copied via About → "Copy debug info".
+///
+/// **Anonymization invariants** (also covered by `DebugReportTests`):
+/// - No file paths, usernames, hostnames, MAC addresses, IPs.
+/// - Never reads `usageCounts`, `easterEggsDiscovered`, `excludedBundleIDs`,
+///   `excludedURLPatterns`, `giphyApiKey` contents — only counts / booleans.
+/// - No absolute dates in the prefs section (relative "X days ago" only).
+///   One UTC timestamp in the footer.
+/// - AX values are summarized structurally via `PickerContextStore`'s
+///   `summarize(_:)` — never raw contents.
+/// - Activity log values are clamped to 32 ASCII-printable chars at the
+///   recording site, not here.
+@MainActor
+enum DebugReport {
+    /// Maximum bytes emitted. Test enforces this; if a future addition
+    /// blows past it the test will fail and force a re-tightening.
+    static let maxSizeBytes = 8192
+
+    static func markdown(now: Date = Date()) -> String {
+        var out = ""
+        out += "# Mojito debug report\n\n"
+        out += mojitoSection(now: now)
+        out += "\n"
+        out += prefsSection()
+        out += "\n"
+        out += systemSection()
+        out += "\n"
+        out += lastPickerSection()
+        out += "\n"
+        out += activitySection(now: now)
+        out += "\n"
+        out += nowSection()
+        out += "\n"
+        out += footer(now: now)
+
+        // Hard cap as a last line of defense — if some future
+        // contributor adds an unbounded loop the report still pastes
+        // into an issue without blowing it up.
+        if out.utf8.count > maxSizeBytes {
+            let cutoff = out.utf8.prefix(maxSizeBytes - 100)
+            out = String(cutoff) ?? out
+            out += "\n\n[truncated]\n"
+        }
+        return out
+    }
+
+    // MARK: - Sections
+
+    private static func mojitoSection(now: Date) -> String {
+        let info = Bundle.main.infoDictionary ?? [:]
+        let bundleID = Bundle.main.bundleIdentifier ?? "—"
+        let version = info["CFBundleShortVersionString"] as? String ?? "—"
+        let build = info["CFBundleVersion"] as? String ?? "—"
+        let daysSince = daysSinceFirstLaunch(now: now)
+        let ax = AXIsProcessTrusted()
+        let inputMon = inputMonitoringGranted()
+        let pausedUntil = UserDefaults.standard.object(forKey: PrefsKey.pausedUntil) as? TimeInterval
+        let paused = (pausedUntil ?? 0) > now.timeIntervalSince1970
+
+        var s = "## Mojito\n"
+        s += "- bundleID: \(bundleID)\n"
+        s += "- version: \(version) (\(build))\n"
+        s += "- daysSinceFirstLaunch: \(daysSince)\n"
+        s += "- permissions.accessibility: \(ax)\n"
+        s += "- permissions.inputMonitoring: \(inputMon)\n"
+        s += "- paused: \(paused)\n"
+        return s
+    }
+
+    private static func prefsSection() -> String {
+        let d = UserDefaults.standard
+        // Sensitive collections — counts only.
+        let usageTotal = ((d.dictionary(forKey: PrefsKey.usageCounts) as? [String: Int]) ?? [:])
+            .values.reduce(0, +)
+        let eggsCount = ((d.array(forKey: PrefsKey.easterEggsDiscovered) as? [String]) ?? []).count
+        let bundleExcl = ((d.array(forKey: PrefsKey.excludedBundleIDs) as? [String]) ?? []).count
+        let urlExcl = ((d.array(forKey: PrefsKey.excludedURLPatterns) as? [String]) ?? []).count
+        let giphySet = !((d.string(forKey: PrefsKey.giphyApiKey)) ?? "").isEmpty
+
+        var s = "## Prefs\n"
+        s += "- usageCounts.total: \(usageTotal)\n"
+        s += "- easterEggs.discoveredCount: \(eggsCount)\n"
+        s += "- exclusions.bundleIDCount: \(bundleExcl)\n"
+        s += "- exclusions.urlPatternCount: \(urlExcl)\n"
+        s += "- giphyApiKey.set: \(giphySet)\n"
+        s += "- useFrequencyBoost: \(bool(PrefsKey.useFrequencyBoost, default: true))\n"
+        s += "- symbolsEnabled: \(bool(PrefsKey.symbolsEnabled, default: false))\n"
+        s += "- symbolsRequireDoubleColon: \(bool(PrefsKey.symbolsRequireDoubleColon, default: false))\n"
+        s += "- emoticonsEnabled: \(bool(PrefsKey.emoticonsEnabled, default: true))\n"
+        s += "- gifSearchEnabled: \(bool(PrefsKey.gifSearchEnabled, default: true))\n"
+        s += "- gifBypassExclusions: \(bool(PrefsKey.gifBypassExclusions, default: true))\n"
+        s += "- launchAtLogin: \(bool(PrefsKey.launchAtLogin, default: false))\n"
+        s += "- showMenuBarIcon: \(bool(PrefsKey.showMenuBarIcon, default: true))\n"
+        s += "- skinTone: \(d.string(forKey: PrefsKey.skinTone) ?? "default")\n"
+        s += "- totals.emojiInserted: \(d.integer(forKey: PrefsKey.totalEmojiInserted))\n"
+        s += "- totals.symbolInserted: \(d.integer(forKey: PrefsKey.totalSymbolInserted))\n"
+        s += "- totals.gifInserted: \(d.integer(forKey: PrefsKey.totalGifInserted))\n"
+        return s
+    }
+
+    private static func systemSection() -> String {
+        let pi = ProcessInfo.processInfo
+        let osv = pi.operatingSystemVersion
+        let arch = isAppleSilicon() ? "Apple Silicon" : "Intel"
+        let locale = Locale.current.identifier
+        let appearance = (NSApp?.effectiveAppearance.name.rawValue) ?? "—"
+        let screens = NSScreen.screens
+        let primary = screens.first?.frame ?? .zero
+
+        var s = "## System\n"
+        s += "- macOS: \(osv.majorVersion).\(osv.minorVersion).\(osv.patchVersion)\n"
+        s += "- arch: \(arch)\n"
+        s += "- locale: \(locale)\n"
+        s += "- appearance: \(appearance)\n"
+        s += "- screens: \(screens.count)\n"
+        s += "- primaryScreen: \(Int(primary.width))x\(Int(primary.height))\n"
+        return s
+    }
+
+    private static func lastPickerSection() -> String {
+        guard let snap = PickerContextStore.latest else {
+            return "## Last picker context\n- (no picker activity this session)\n"
+        }
+        var s = "## Last picker context\n"
+        s += "- frontmostBundleID: \(snap.frontmostBundleID ?? "—")\n"
+        s += "- frontmostAppVersion: \(snap.frontmostAppVersion ?? "—")\n"
+        s += "- focusedRole: \(snap.focusedRole ?? "—")\n"
+        s += "- focusedSubrole: \(snap.focusedSubrole ?? "—")\n"
+        s += "- caretOutcome: \(snap.caretOutcome)\n"
+        if let frame = snap.elementFrame {
+            s += "- elementFrame: \(Int(frame.origin.x)),\(Int(frame.origin.y)) \(Int(frame.size.width))x\(Int(frame.size.height))\n"
+        }
+        if let m = snap.mouseLocation {
+            s += "- mouseLocation: \(Int(m.x)),\(Int(m.y))\n"
+        }
+        if let r = snap.resolvedCaret {
+            s += "- resolvedCaret: \(Int(r.origin.x)),\(Int(r.origin.y)) \(Int(r.size.width))x\(Int(r.size.height))\n"
+        }
+        s += "- AX attributes:\n"
+        for attr in snap.attributes {
+            let short = attr.name.replacingOccurrences(of: "AX", with: "").replacingOccurrences(of: "Attribute", with: "")
+            if attr.present {
+                s += "  - \(short): \(attr.summary ?? "<present>")\n"
+            } else {
+                s += "  - \(short): absent\n"
+            }
+        }
+        return s
+    }
+
+    private static func activitySection(now: Date) -> String {
+        let events = DebugRecorder.snapshot().suffix(50)
+        guard let oldest = events.first else {
+            return "## Activity log\n- (empty)\n"
+        }
+        var s = "## Activity log (last \(events.count))\n"
+        for event in events {
+            let dt = event.timestamp.timeIntervalSince(oldest.timestamp)
+            let meta = event.metadata
+                .sorted { $0.key < $1.key }
+                .map { "\($0.key)=\($0.value)" }
+                .joined(separator: " ")
+            let metaPart = meta.isEmpty ? "" : " \(meta)"
+            s += "- [+\(String(format: "%.2fs", dt))] \(event.category.rawValue).\(event.kind)\(metaPart)\n"
+        }
+        return s
+    }
+
+    private static func nowSection() -> String {
+        let bundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? "—"
+        let element = FocusedElementCache.shared.element
+        let role: String = {
+            guard let element else { return "—" }
+            var ref: AnyObject?
+            let st = AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &ref)
+            return (st == .success ? (ref as? String) : nil) ?? "—"
+        }()
+        var s = "## Now\n"
+        s += "- frontmostBundleID: \(bundleID)\n"
+        s += "- focusedRole: \(role)\n"
+        return s
+    }
+
+    private static func footer(now: Date) -> String {
+        let fmt = DateFormatter()
+        fmt.dateFormat = "yyyy-MM-dd HH:mm"
+        fmt.timeZone = TimeZone(identifier: "UTC")
+        return "_Generated \(fmt.string(from: now)) UTC_\n"
+    }
+
+    // MARK: - Helpers
+
+    private static func bool(_ key: String, default defaultValue: Bool) -> Bool {
+        UserDefaults.standard.object(forKey: key) as? Bool ?? defaultValue
+    }
+
+    private static func daysSinceFirstLaunch(now: Date) -> Int {
+        let ts = UserDefaults.standard.object(forKey: PrefsKey.firstLaunchDate) as? TimeInterval ?? now.timeIntervalSince1970
+        let delta = now.timeIntervalSince1970 - ts
+        return max(0, Int(delta / 86_400))
+    }
+
+    private static func inputMonitoringGranted() -> Bool {
+        // Mirrors PermissionsCoordinator's check at a distance — kept
+        // here as a one-off read to avoid coupling the report to engine
+        // lifecycle. Returns true if the process is allowed to listen
+        // for HID input events.
+        return IOHIDCheckAccess(kIOHIDRequestTypeListenEvent) == kIOHIDAccessTypeGranted
+    }
+
+    private static func isAppleSilicon() -> Bool {
+        var ret: Int32 = 0
+        var size = MemoryLayout<Int32>.size
+        if sysctlbyname("hw.optional.arm64", &ret, &size, nil, 0) == 0 {
+            return ret == 1
+        }
+        return false
+    }
+}

--- a/Sources/Mojito/Debug/PickerContextSnapshot.swift
+++ b/Sources/Mojito/Debug/PickerContextSnapshot.swift
@@ -1,0 +1,155 @@
+import AppKit
+import ApplicationServices
+
+/// Snapshot of the focused-element AX surface at the moment Mojito's
+/// picker opens. Lives only in memory for this app session — the next
+/// picker open overwrites it, and process exit clears it.
+///
+/// The report surfaces this as section 4 ("Last picker context"). It
+/// answers the "what did the picker actually see?" question that
+/// caret-positioning bugs need ground truth on. Values are summarized
+/// structurally — for AX `kAXValue` we record `<string, length=N>`, not
+/// the actual buffer text.
+struct PickerContextSnapshot {
+    struct AXAttribute {
+        let name: String
+        let present: Bool
+        /// Shape-only summary, never raw contents. `nil` when `present == false`.
+        let summary: String?
+    }
+
+    let capturedAt: Date
+    let frontmostBundleID: String?
+    let frontmostAppVersion: String?
+    let focusedRole: String?
+    let focusedSubrole: String?
+    let attributes: [AXAttribute]
+    let elementFrame: CGRect?
+    let mouseLocation: CGPoint?
+    let caretOutcome: String   // "axBounds" | "elementTopLeft" | "unavailable"
+    let resolvedCaret: CGRect?
+}
+
+@MainActor
+enum PickerContextStore {
+    private(set) static var latest: PickerContextSnapshot?
+
+    /// Called by Engine in the picker-open branches. Reads the focused
+    /// element via `FocusedElementCache` (already main-thread, no IPC
+    /// stall) plus a handful of caret-related AX attributes.
+    static func capture(caretOutcome: String, resolvedCaret: CGRect?) {
+        let app = NSWorkspace.shared.frontmostApplication
+        let element = FocusedElementCache.shared.element
+
+        let focusedRole = element.flatMap { copy($0, kAXRoleAttribute) as? String }
+        let focusedSubrole = element.flatMap { copy($0, kAXSubroleAttribute) as? String }
+
+        let regular = caretAttributes.map { key -> PickerContextSnapshot.AXAttribute in
+            guard let element, let value = copy(element, key) else {
+                return .init(name: key, present: false, summary: nil)
+            }
+            return .init(name: key, present: true, summary: summarize(value))
+        }
+        // Parameterized attributes can't be fetched without a valid
+        // parameter, so presence is determined by enumerating the names
+        // the element advertises. This is what distinguishes Ghostty
+        // (advertises nothing) from TextEdit (advertises BoundsForRange).
+        let parameterizedNames: Set<String> = element.flatMap(parameterizedNames(of:)) ?? []
+        let parameterized = parameterizedCaretAttributes.map { key -> PickerContextSnapshot.AXAttribute in
+            let present = parameterizedNames.contains(key)
+            return .init(name: key, present: present, summary: present ? "<parameterized>" : nil)
+        }
+        let attrs = regular + parameterized
+
+        let elementFrame: CGRect? = {
+            guard let element,
+                  let posRef = copy(element, kAXPositionAttribute),
+                  let sizeRef = copy(element, kAXSizeAttribute) else { return nil }
+            var origin = CGPoint.zero, size = CGSize.zero
+            AXValueGetValue((posRef as! AXValue), .cgPoint, &origin)
+            AXValueGetValue((sizeRef as! AXValue), .cgSize, &size)
+            return CGRect(origin: origin, size: size)
+        }()
+
+        latest = PickerContextSnapshot(
+            capturedAt: Date(),
+            frontmostBundleID: app?.bundleIdentifier,
+            frontmostAppVersion: app?.bundleURL.flatMap { Bundle(url: $0)?.infoDictionary?["CFBundleShortVersionString"] as? String },
+            focusedRole: focusedRole,
+            focusedSubrole: focusedSubrole,
+            attributes: attrs,
+            elementFrame: elementFrame,
+            mouseLocation: NSEvent.mouseLocation,
+            caretOutcome: caretOutcome,
+            resolvedCaret: resolvedCaret
+        )
+    }
+
+    static func reset() { latest = nil }
+
+    /// Regular (non-parameterized) AX attributes we probe at picker open.
+    private static let caretAttributes: [String] = [
+        kAXSelectedTextRangeAttribute as String,
+        kAXInsertionPointLineNumberAttribute as String,
+        kAXNumberOfCharactersAttribute as String,
+        kAXVisibleCharacterRangeAttribute as String,
+        kAXPositionAttribute as String,
+        kAXSizeAttribute as String,
+    ]
+
+    /// Parameterized AX attributes — these need
+    /// `AXUIElementCopyParameterizedAttributeValue` plus a valid
+    /// parameter to fetch. For a presence-only diagnostic check, ask
+    /// the element which parameterized attributes it advertises.
+    /// `BoundsForRange` is the one that distinguishes a working caret
+    /// app (TextEdit) from a broken one (Ghostty).
+    private static let parameterizedCaretAttributes: [String] = [
+        kAXBoundsForRangeParameterizedAttribute as String,
+        kAXRangeForPositionParameterizedAttribute as String,
+        kAXRangeForIndexParameterizedAttribute as String,
+        kAXRangeForLineParameterizedAttribute as String,
+    ]
+
+    private static func copy(_ element: AXUIElement, _ key: String) -> AnyObject? {
+        var ref: AnyObject?
+        return AXUIElementCopyAttributeValue(element, key as CFString, &ref) == .success ? ref : nil
+    }
+
+    private static func parameterizedNames(of element: AXUIElement) -> Set<String> {
+        var names: CFArray?
+        guard AXUIElementCopyParameterizedAttributeNames(element, &names) == .success,
+              let list = names as? [String] else { return [] }
+        return Set(list)
+    }
+
+    /// Shape-only stringification. Never returns the raw value's contents.
+    private static func summarize(_ value: AnyObject) -> String {
+        if let s = value as? String {
+            return "<string, length=\(s.count)>"
+        }
+        if let n = value as? NSNumber {
+            // Bools come through as NSNumber too; distinguish via type encoding.
+            if String(cString: n.objCType) == "c" {
+                return "<bool, \(n.boolValue)>"
+            }
+            return "<number>"
+        }
+        if let arr = value as? [Any] {
+            return "<array, count=\(arr.count)>"
+        }
+        if let dict = value as? [String: Any] {
+            return "<dict, keys=\(dict.count)>"
+        }
+        if CFGetTypeID(value) == AXValueGetTypeID() {
+            let axValue = value as! AXValue
+            switch AXValueGetType(axValue) {
+            case .cgPoint:    return "<AXValue cgPoint>"
+            case .cgSize:     return "<AXValue cgSize>"
+            case .cgRect:     return "<AXValue cgRect>"
+            case .cfRange:    return "<AXValue cfRange>"
+            default:          return "<AXValue>"
+            }
+        }
+        return "<opaque>"
+    }
+}

--- a/Sources/Mojito/KeyMonitor/KeyMonitor.swift
+++ b/Sources/Mojito/KeyMonitor/KeyMonitor.swift
@@ -49,6 +49,7 @@ final class KeyMonitor {
         self.eventTap = tap
         self.runLoopSource = source
         self.isRunning = true
+        DebugRecorder.record(.keyMonitor, "tapStart")
         return true
     }
 
@@ -64,6 +65,7 @@ final class KeyMonitor {
         eventTap = nil
         runLoopSource = nil
         isRunning = false
+        DebugRecorder.record(.keyMonitor, "tapStop")
     }
 
     private func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
@@ -76,6 +78,7 @@ final class KeyMonitor {
         // The system auto-disables the tap if it takes too long.
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
             if let tap = eventTap { CGEvent.tapEnable(tap: tap, enable: true) }
+            DebugRecorder.record(.keyMonitor, "tapLost", ["reason": type == .tapDisabledByTimeout ? "timeout" : "userInput"])
             delegate?.keyMonitorDidLoseTap(self)
             return Unmanaged.passUnretained(event)
         }

--- a/Sources/Mojito/Permissions/PermissionsCoordinator.swift
+++ b/Sources/Mojito/Permissions/PermissionsCoordinator.swift
@@ -62,8 +62,14 @@ final class PermissionsCoordinator: ObservableObject {
     func refresh() {
         let ax = AXIsProcessTrusted()
         let im = checkInputMonitoring()
-        if ax != accessibility { accessibility = ax }
-        if im != inputMonitoring { inputMonitoring = im }
+        if ax != accessibility {
+            accessibility = ax
+            DebugRecorder.record(.permissions, ax ? "axGranted" : "axRevoked")
+        }
+        if im != inputMonitoring {
+            inputMonitoring = im
+            DebugRecorder.record(.permissions, im ? "inputGranted" : "inputRevoked")
+        }
         if accessibility && inputMonitoring {
             stopMonitoring()
         }

--- a/Sources/Mojito/Picker/CaretLocator.swift
+++ b/Sources/Mojito/Picker/CaretLocator.swift
@@ -5,6 +5,10 @@ import os.log
 @MainActor
 enum CaretLocator {
     private static let log = OSLog(subsystem: "ee.wells.Mojito", category: "CaretLocator")
+    /// Set by `caretRect()` so the debug-report snapshot can record which
+    /// branch resolved this call. Values: `axBounds`, `elementTopLeft`,
+    /// `unavailable`.
+    private(set) static var lastOutcome: String = "unavailable"
 
     /// Screen-space (bottom-left origin) caret rect, or nil.
     ///
@@ -26,6 +30,7 @@ enum CaretLocator {
 
         if let rect = caretBounds(of: focused), isPlausibleCaret(rect, withinElementFrame: elementFrame) {
             os_log("caret via AX bounds: %{public}@", log: log, type: .info, "\(rect)")
+            lastOutcome = "axBounds"
             return rect
         }
 
@@ -38,6 +43,7 @@ enum CaretLocator {
             // callers fall back to mouse position instead.
             guard frame.height <= 160 else {
                 os_log("caret unavailable — element too tall for top-left estimate (%{public}.0f pt)", log: log, type: .info, frame.height)
+                lastOutcome = "elementTooTall"
                 return nil
             }
             let caretHeight: CGFloat = max(16, min(frame.height, 22))
@@ -48,10 +54,12 @@ enum CaretLocator {
                 height: caretHeight
             )
             os_log("caret via element fallback: %{public}@ (frame %{public}@)", log: log, type: .info, "\(rect)", "\(frame)")
+            lastOutcome = "elementTopLeft"
             return rect
         }
 
         os_log("caret unavailable — no AX bounds and no usable element frame", log: log, type: .info)
+        lastOutcome = "unavailable"
         return nil
     }
 

--- a/Sources/Mojito/Settings/AboutSettings.swift
+++ b/Sources/Mojito/Settings/AboutSettings.swift
@@ -4,6 +4,7 @@ import AVFoundation
 
 struct AboutSettingsView: View {
     @AppStorage(PrefsKey.donated) private var donated: Bool = false
+    @State private var debugCopied: Bool = false
 
     private let rowPadding: CGFloat = 2
 
@@ -119,6 +120,10 @@ struct AboutSettingsView: View {
                 NSWorkspace.shared.open(URL(string: "https://github.com/wr/mojito/issues/new")!)
             }
 
+            Button(debugCopied ? "Copied!" : "Copy debug info") {
+                copyDebugInfo()
+            }
+
             Link("Website", destination: URL(string: "https://github.com/wr/mojito")!)
                 .font(.callout)
 
@@ -148,6 +153,15 @@ struct AboutSettingsView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+    }
+
+    private func copyDebugInfo() {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(DebugReport.markdown(), forType: .string)
+        debugCopied = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+            debugCopied = false
+        }
     }
 
     private func sayThankYou() {

--- a/Tests/MojitoTests/DebugReportTests.swift
+++ b/Tests/MojitoTests/DebugReportTests.swift
@@ -1,0 +1,78 @@
+import Testing
+@testable import Mojito
+import Foundation
+
+/// Anonymization + shape invariants for the About → Copy Debug Info
+/// output. The tests stay loud about what the report MUST NOT contain so
+/// future additions can't silently leak.
+@MainActor
+struct DebugReportTests {
+    @Test func forbiddenStringsNeverAppear() {
+        DebugRecorder.reset()
+        // Drive the recorder through one of every category so the
+        // generated report exercises real code paths.
+        DebugRecorder.record(.picker, "open", ["outcome": "axBounds", "resultCount": "12"])
+        DebugRecorder.record(.insert, "fromPicker", ["scope": "normal"])
+        DebugRecorder.record(.emoticon, "convert", ["consumesTerminator": "true"])
+        DebugRecorder.record(.gif, "open", ["outcome": "elementTopLeft"])
+        DebugRecorder.record(.keyMonitor, "tapStart")
+        DebugRecorder.record(.permissions, "axGranted")
+        DebugRecorder.record(.focus, "app", ["bundleID": "com.apple.TextEdit"])
+        DebugRecorder.record(.engine, "pause")
+
+        let out = DebugReport.markdown()
+
+        // Sensitive raw pref keys never appear (we surface counts only).
+        for forbidden in [
+            PrefsKey.usageCounts,
+            PrefsKey.excludedBundleIDs,
+            PrefsKey.excludedURLPatterns,
+            PrefsKey.giphyApiKey,
+            PrefsKey.easterEggsDiscovered,
+        ] {
+            #expect(!out.contains(forbidden), "report leaks \(forbidden)")
+        }
+        // Path / network / email-like surface.
+        for substring in ["/Users/", "http://", "https://", "@"] {
+            #expect(!out.contains(substring), "report leaks substring '\(substring)'")
+        }
+    }
+
+    @Test func reportFitsUnderEightKB() {
+        DebugRecorder.reset()
+        // Fill the recorder past the surfacing window (50 events) — the
+        // report should still stay capped.
+        for i in 0..<200 {
+            DebugRecorder.record(.picker, "open", ["outcome": "axBounds", "iter": "\(i)"])
+        }
+        let out = DebugReport.markdown()
+        #expect(out.utf8.count < DebugReport.maxSizeBytes, "report is \(out.utf8.count) bytes")
+    }
+
+    @Test func noAbsoluteDatesInPrefsSection() {
+        DebugRecorder.reset()
+        let out = DebugReport.markdown()
+        // Isolate the prefs section.
+        let prefsRange = out.range(of: "## Prefs")
+        let nextSection = out.range(of: "## System")
+        #expect(prefsRange != nil)
+        #expect(nextSection != nil)
+        guard let start = prefsRange?.upperBound, let end = nextSection?.lowerBound else { return }
+        let prefs = String(out[start..<end])
+        // YYYY-MM-DD anywhere in the prefs block fails.
+        let regex = try! NSRegularExpression(pattern: #"\d{4}-\d{2}-\d{2}"#)
+        let range = NSRange(prefs.startIndex..., in: prefs)
+        #expect(regex.firstMatch(in: prefs, range: range) == nil, "prefs leaks an absolute date")
+    }
+
+    @Test func activityLogClampsLongMetadataValues() {
+        DebugRecorder.reset()
+        let huge = String(repeating: "X", count: 1024)
+        DebugRecorder.record(.picker, "open", ["leak": huge])
+        let out = DebugReport.markdown()
+        // The recorder clamps to 32 chars on input; the report includes
+        // metadata verbatim from there. Assert no run of >32 Xs survives.
+        let bigRun = String(repeating: "X", count: 33)
+        #expect(!out.contains(bigRun))
+    }
+}


### PR DESCRIPTION
## Summary
- About → "Copy debug info" button writes a markdown report to the clipboard.
- General-purpose: covers any class of bug (positioning, keystroke, picker, search, emoticons, GIF, updater) via a 200-event ring buffer (`DebugRecorder`) plus snapshots.
- Anonymization invariants documented in `DebugReport.swift` and enforced by tests: never includes `usageCounts` / `excludedBundleIDs` / `excludedURLPatterns` / `giphyApiKey` / `easterEggsDiscovered` contents; no paths, URLs, or emails; report capped at 8 KB; AX values summarized structurally (`<string, length=N>`) — never raw contents.
- Includes a "Last picker context" snapshot of focused-element AX surface at picker-open time. This is the unblock data for W-196 (Ghostty/cmux caret bug).

Refs: W-209

## Test plan
- [ ] `scripts/run-tests.sh` green (4 new assertions in `DebugReportTests`).
- [ ] In TextEdit type `:wave`, dismiss, then About → Copy Debug Info. Paste into a scratchpad. Verify 6 sections present, no PII, capped size, only structural metadata in the activity log.
- [ ] In Ghostty (the W-196 reproducer): same flow. The "Last picker context" section should name `com.mitchellh.ghostty` and the AX attribute map answers what we get to work with.