### PR TITLE
W-210: expand debug report for support workflows

### DIFF
--- a/Sources/Mojito/App/Engine.swift
+++ b/Sources/Mojito/App/Engine.swift
@@ -302,10 +302,15 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
         if case .idle = stateMachine.state, case .colon = input {
             let context = AppContextDetector.current()
             if context.focusedFieldIsSecure {
+                DebugRecorder.record(.engine, "secureFieldBlocked")
                 return false
             }
             captureContext = context
             captureIsExcluded = exclusions.isExcluded(bundleID: context.bundleID, url: context.url)
+            DebugRecorder.record(.engine, "colon", [
+                "excluded": "\(captureIsExcluded)",
+                "hasURL": "\(context.url != nil)",
+            ])
             // Snapshot now so the deferred picker show and any focus-change
             // notifications can detect movement out from under us.
             captureFocusSnapshot = FocusedElementCache.shared.element
@@ -565,6 +570,11 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
             corpus: corpusFor(scope: scope),
             useFrequencyBoost: useFrequencyBoost
         )
+        DebugRecorder.record(.picker, "search", [
+            "queryLen": "\(query.count)",
+            "results": "\(results.count)",
+            "scope": "\(scope)",
+        ])
         viewModel.update(query: query, results: results)
     }
 
@@ -957,6 +967,7 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
         let emojiLen = entry.emojiInserted.count
         TextInserter.replace(charactersToDelete: emojiLen, with: entry.originalText)
         pendingEmoticonUndo = nil
+        DebugRecorder.record(.emoticon, "undo")
         return true
     }
 

--- a/Sources/Mojito/Debug/DebugReport.swift
+++ b/Sources/Mojito/Debug/DebugReport.swift
@@ -1,5 +1,6 @@
 import AppKit
 import ApplicationServices
+import Carbon
 import Foundation
 import IOKit.hid
 
@@ -11,26 +12,45 @@ import IOKit.hid
 ///   `excludedURLPatterns`, `giphyApiKey` contents — only counts / booleans.
 /// - No absolute dates in the prefs section (relative "X days ago" only).
 ///   One UTC timestamp in the footer.
-/// - AX values are summarized structurally via `PickerContextStore`'s
-///   `summarize(_:)` — never raw contents.
-/// - Activity log values are clamped to 32 ASCII-printable chars at the
-///   recording site, not here.
+/// - AX values are summarized structurally — never raw contents.
+/// - Activity log values are clamped at the recording site.
 @MainActor
 enum DebugReport {
-    /// Maximum bytes emitted. Test enforces this; if a future addition
-    /// blows past it the test will fail and force a re-tightening.
-    static let maxSizeBytes = 8192
+    /// Hard cap. The bigger the report the more useful for diagnosis, but
+    /// it still needs to fit in a paste. 32 KB is comfortable for issue
+    /// bodies and LLM context windows.
+    static let maxSizeBytes = 32_768
+
+    /// Real process start time, fetched via `kinfo_proc` so it doesn't
+    /// drift like a lazy `Date()` would (a `static let` initializes on
+    /// first access, which here would be the *first* time someone clicks
+    /// Copy Debug Info — not at launch).
+    private static func processStart() -> Date? {
+        var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()]
+        var proc = kinfo_proc()
+        var size = MemoryLayout<kinfo_proc>.size
+        guard sysctl(&mib, UInt32(mib.count), &proc, &size, nil, 0) == 0 else { return nil }
+        let sec = TimeInterval(proc.kp_proc.p_starttime.tv_sec)
+        let usec = TimeInterval(proc.kp_proc.p_starttime.tv_usec) / 1_000_000
+        return Date(timeIntervalSince1970: sec + usec)
+    }
 
     static func markdown(now: Date = Date()) -> String {
         var out = ""
         out += "# Mojito debug report\n\n"
         out += mojitoSection(now: now)
         out += "\n"
+        out += buildSection()
+        out += "\n"
         out += prefsSection()
         out += "\n"
         out += systemSection()
         out += "\n"
-        out += lastPickerSection()
+        out += databaseSection()
+        out += "\n"
+        out += updaterSection(now: now)
+        out += "\n"
+        out += lastPickerSection(now: now)
         out += "\n"
         out += activitySection(now: now)
         out += "\n"
@@ -38,9 +58,6 @@ enum DebugReport {
         out += "\n"
         out += footer(now: now)
 
-        // Hard cap as a last line of defense — if some future
-        // contributor adds an unbounded loop the report still pastes
-        // into an issue without blowing it up.
         if out.utf8.count > maxSizeBytes {
             let cutoff = out.utf8.prefix(maxSizeBytes - 100)
             out = String(cutoff) ?? out
@@ -61,20 +78,36 @@ enum DebugReport {
         let inputMon = inputMonitoringGranted()
         let pausedUntil = UserDefaults.standard.object(forKey: PrefsKey.pausedUntil) as? TimeInterval
         let paused = (pausedUntil ?? 0) > now.timeIntervalSince1970
+        let uptime = processStart().map { formatDuration(now.timeIntervalSince($0)) } ?? "—"
 
         var s = "## Mojito\n"
         s += "- bundleID: \(bundleID)\n"
         s += "- version: \(version) (\(build))\n"
+        s += "- processUptime: \(uptime)\n"
         s += "- daysSinceFirstLaunch: \(daysSince)\n"
         s += "- permissions.accessibility: \(ax)\n"
         s += "- permissions.inputMonitoring: \(inputMon)\n"
         s += "- paused: \(paused)\n"
+        if paused, let pausedUntil {
+            s += "- pausedRemaining: \(formatDuration(pausedUntil - now.timeIntervalSince1970))\n"
+        }
+        return s
+    }
+
+    private static func buildSection() -> String {
+        var s = "## Build\n"
+        #if DEBUG
+        s += "- configuration: Debug\n"
+        #else
+        s += "- configuration: Release\n"
+        #endif
+        s += "- codeSigned: \(isCodeSigned())\n"
+        s += "- sandboxed: \(ProcessInfo.processInfo.environment["APP_SANDBOX_CONTAINER_ID"] != nil)\n"
         return s
     }
 
     private static func prefsSection() -> String {
         let d = UserDefaults.standard
-        // Sensitive collections — counts only.
         let usageTotal = ((d.dictionary(forKey: PrefsKey.usageCounts) as? [String: Int]) ?? [:])
             .values.reduce(0, +)
         let eggsCount = ((d.array(forKey: PrefsKey.easterEggsDiscovered) as? [String]) ?? []).count
@@ -108,29 +141,66 @@ enum DebugReport {
         let osv = pi.operatingSystemVersion
         let arch = isAppleSilicon() ? "Apple Silicon" : "Intel"
         let locale = Locale.current.identifier
+        let preferred = Locale.preferredLanguages.prefix(4).joined(separator: ", ")
         let appearance = (NSApp?.effectiveAppearance.name.rawValue) ?? "—"
         let screens = NSScreen.screens
-        let primary = screens.first?.frame ?? .zero
 
         var s = "## System\n"
         s += "- macOS: \(osv.majorVersion).\(osv.minorVersion).\(osv.patchVersion)\n"
         s += "- arch: \(arch)\n"
         s += "- locale: \(locale)\n"
+        s += "- preferredLanguages: \(preferred)\n"
+        s += "- inputSource: \(activeInputSourceID() ?? "—")\n"
         s += "- appearance: \(appearance)\n"
+        s += "- thermalState: \(thermalStateString(pi.thermalState))\n"
+        s += "- processorCount: \(pi.processorCount)\n"
+        s += "- physicalMemoryGB: \(pi.physicalMemory / 1_073_741_824)\n"
         s += "- screens: \(screens.count)\n"
-        s += "- primaryScreen: \(Int(primary.width))x\(Int(primary.height))\n"
+        for (i, screen) in screens.enumerated() {
+            let f = screen.frame
+            let scale = screen.backingScaleFactor
+            let refresh = screen.maximumFramesPerSecond
+            s += "  - screen[\(i)]: \(Int(f.width))x\(Int(f.height)) scale=\(scale) refresh=\(refresh)Hz\n"
+        }
         return s
     }
 
-    private static func lastPickerSection() -> String {
+    private static func databaseSection() -> String {
+        var s = "## Database\n"
+        s += "- emoji.count: \(EmojiDatabase.shared.all.count)\n"
+        s += "- symbols.count: \(SymbolsDatabase.indexed().count)\n"
+        return s
+    }
+
+    private static func updaterSection(now: Date) -> String {
+        // Sparkle stores these in our UserDefaults under stable keys
+        // documented in SUConstants.h (SULastCheckTimeKey etc.).
+        var s = "## Updater\n"
+        let lastCheck = UserDefaults.standard.object(forKey: "SULastCheckTime") as? Date
+        s += "- lastCheck: \(lastCheck.map { "-\(formatDuration(now.timeIntervalSince($0))) ago" } ?? "never")\n"
+        let interval = UserDefaults.standard.object(forKey: "SUScheduledCheckInterval") as? TimeInterval
+        s += "- checkInterval: \(interval.map { formatDuration($0) } ?? "default")\n"
+        let autoCheck = UserDefaults.standard.object(forKey: "SUEnableAutomaticChecks") as? Bool ?? true
+        s += "- automaticChecks: \(autoCheck)\n"
+        return s
+    }
+
+    private static func lastPickerSection(now: Date) -> String {
         guard let snap = PickerContextStore.latest else {
             return "## Last picker context\n- (no picker activity this session)\n"
         }
         var s = "## Last picker context\n"
+        s += "- capturedAt: -\(formatDuration(now.timeIntervalSince(snap.capturedAt))) ago\n"
         s += "- frontmostBundleID: \(snap.frontmostBundleID ?? "—")\n"
         s += "- frontmostAppVersion: \(snap.frontmostAppVersion ?? "—")\n"
         s += "- focusedRole: \(snap.focusedRole ?? "—")\n"
         s += "- focusedSubrole: \(snap.focusedSubrole ?? "—")\n"
+        if !snap.roleChain.isEmpty {
+            s += "- roleChain: \(snap.roleChain.joined(separator: " ← "))\n"
+        }
+        if let titleLen = snap.windowTitleLength {
+            s += "- windowTitleLength: \(titleLen)\n"
+        }
         s += "- caretOutcome: \(snap.caretOutcome)\n"
         if let frame = snap.elementFrame {
             s += "- elementFrame: \(Int(frame.origin.x)),\(Int(frame.origin.y)) \(Int(frame.size.width))x\(Int(frame.size.height))\n"
@@ -141,7 +211,7 @@ enum DebugReport {
         if let r = snap.resolvedCaret {
             s += "- resolvedCaret: \(Int(r.origin.x)),\(Int(r.origin.y)) \(Int(r.size.width))x\(Int(r.size.height))\n"
         }
-        s += "- AX attributes:\n"
+        s += "- curated attributes:\n"
         for attr in snap.attributes {
             let short = attr.name.replacingOccurrences(of: "AX", with: "").replacingOccurrences(of: "Attribute", with: "")
             if attr.present {
@@ -150,11 +220,17 @@ enum DebugReport {
                 s += "  - \(short): absent\n"
             }
         }
+        if !snap.allAttributeNames.isEmpty {
+            s += "- all attrs: \(snap.allAttributeNames.sorted().joined(separator: ", "))\n"
+        }
+        if !snap.allParameterizedAttributeNames.isEmpty {
+            s += "- all paramAttrs: \(snap.allParameterizedAttributeNames.sorted().joined(separator: ", "))\n"
+        }
         return s
     }
 
     private static func activitySection(now: Date) -> String {
-        let events = DebugRecorder.snapshot().suffix(50)
+        let events = DebugRecorder.snapshot().suffix(100)
         guard let oldest = events.first else {
             return "## Activity log\n- (empty)\n"
         }
@@ -183,6 +259,7 @@ enum DebugReport {
         var s = "## Now\n"
         s += "- frontmostBundleID: \(bundleID)\n"
         s += "- focusedRole: \(role)\n"
+        s += "- focusedElementCached: \(element != nil)\n"
         return s
     }
 
@@ -206,10 +283,6 @@ enum DebugReport {
     }
 
     private static func inputMonitoringGranted() -> Bool {
-        // Mirrors PermissionsCoordinator's check at a distance — kept
-        // here as a one-off read to avoid coupling the report to engine
-        // lifecycle. Returns true if the process is allowed to listen
-        // for HID input events.
         return IOHIDCheckAccess(kIOHIDRequestTypeListenEvent) == kIOHIDAccessTypeGranted
     }
 
@@ -220,5 +293,36 @@ enum DebugReport {
             return ret == 1
         }
         return false
+    }
+
+    private static func isCodeSigned() -> Bool {
+        var code: SecCode?
+        guard SecCodeCopySelf([], &code) == errSecSuccess, let code else { return false }
+        var staticCode: SecStaticCode?
+        guard SecCodeCopyStaticCode(code, [], &staticCode) == errSecSuccess, let staticCode else { return false }
+        return SecStaticCodeCheckValidity(staticCode, [], nil) == errSecSuccess
+    }
+
+    private static func activeInputSourceID() -> String? {
+        guard let source = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue() else { return nil }
+        guard let ptr = TISGetInputSourceProperty(source, kTISPropertyInputSourceID) else { return nil }
+        return Unmanaged<CFString>.fromOpaque(ptr).takeUnretainedValue() as String
+    }
+
+    private static func thermalStateString(_ s: ProcessInfo.ThermalState) -> String {
+        switch s {
+        case .nominal:  return "nominal"
+        case .fair:     return "fair"
+        case .serious:  return "serious"
+        case .critical: return "critical"
+        @unknown default: return "unknown"
+        }
+    }
+
+    private static func formatDuration(_ seconds: TimeInterval) -> String {
+        let s = Int(seconds.rounded())
+        if s < 60 { return "\(s)s" }
+        if s < 3600 { return "\(s / 60)m \(s % 60)s" }
+        return "\(s / 3600)h \((s % 3600) / 60)m"
     }
 }

--- a/Sources/Mojito/Debug/PickerContextSnapshot.swift
+++ b/Sources/Mojito/Debug/PickerContextSnapshot.swift
@@ -24,9 +24,20 @@ struct PickerContextSnapshot {
     let focusedRole: String?
     let focusedSubrole: String?
     let attributes: [AXAttribute]
+    /// Everything the focused element advertises, not just the curated set.
+    /// Useful when the curated set comes back mostly absent and we want to
+    /// see what *is* available without rebuilding a probe build.
+    let allAttributeNames: [String]
+    let allParameterizedAttributeNames: [String]
+    /// Focused → parent → … up to 4 levels (e.g. "AXTextArea ← AXScrollArea
+    /// ← AXSplitGroup ← AXWindow"). Length only, no titles.
+    let roleChain: [String]
+    /// Length of `kAXTitleAttribute` on the focused element's containing
+    /// window. Title text itself is never captured.
+    let windowTitleLength: Int?
     let elementFrame: CGRect?
     let mouseLocation: CGPoint?
-    let caretOutcome: String   // "axBounds" | "elementTopLeft" | "unavailable"
+    let caretOutcome: String   // "axBounds" | "elementTopLeft" | "elementTooTall" | "unavailable"
     let resolvedCaret: CGRect?
 }
 
@@ -54,9 +65,9 @@ enum PickerContextStore {
         // parameter, so presence is determined by enumerating the names
         // the element advertises. This is what distinguishes Ghostty
         // (advertises nothing) from TextEdit (advertises BoundsForRange).
-        let parameterizedNames: Set<String> = element.flatMap(parameterizedNames(of:)) ?? []
+        let paramSet: Set<String> = element.flatMap(parameterizedNames(of:)) ?? []
         let parameterized = parameterizedCaretAttributes.map { key -> PickerContextSnapshot.AXAttribute in
-            let present = parameterizedNames.contains(key)
+            let present = paramSet.contains(key)
             return .init(name: key, present: present, summary: present ? "<parameterized>" : nil)
         }
         let attrs = regular + parameterized
@@ -71,6 +82,18 @@ enum PickerContextStore {
             return CGRect(origin: origin, size: size)
         }()
 
+        let allAttrs = element.flatMap(allAttributeNames(of:)) ?? []
+        let allParamAttrs = Array(paramSet)
+        let chain = element.flatMap(roleChain(from:)) ?? []
+        let windowTitleLen: Int? = {
+            guard let element,
+                  let win = asAXUIElement(copy(element, kAXWindowAttribute as String)),
+                  let title = copy(win, kAXTitleAttribute as String) as? String else {
+                return nil
+            }
+            return title.count
+        }()
+
         latest = PickerContextSnapshot(
             capturedAt: Date(),
             frontmostBundleID: app?.bundleIdentifier,
@@ -78,6 +101,10 @@ enum PickerContextStore {
             focusedRole: focusedRole,
             focusedSubrole: focusedSubrole,
             attributes: attrs,
+            allAttributeNames: allAttrs,
+            allParameterizedAttributeNames: allParamAttrs,
+            roleChain: chain,
+            windowTitleLength: windowTitleLen,
             elementFrame: elementFrame,
             mouseLocation: NSEvent.mouseLocation,
             caretOutcome: caretOutcome,
@@ -120,6 +147,31 @@ enum PickerContextStore {
         guard AXUIElementCopyParameterizedAttributeNames(element, &names) == .success,
               let list = names as? [String] else { return [] }
         return Set(list)
+    }
+
+    private static func allAttributeNames(of element: AXUIElement) -> [String] {
+        var names: CFArray?
+        guard AXUIElementCopyAttributeNames(element, &names) == .success,
+              let list = names as? [String] else { return [] }
+        return list
+    }
+
+    /// Up to 4 levels of AX ancestry. Names only — no titles or values.
+    private static func roleChain(from element: AXUIElement) -> [String] {
+        var chain: [String] = []
+        var cursor: AXUIElement? = element
+        for _ in 0..<4 {
+            guard let current = cursor else { break }
+            let role = (copy(current, kAXRoleAttribute) as? String) ?? "?"
+            chain.append(role)
+            cursor = asAXUIElement(copy(current, kAXParentAttribute as String))
+        }
+        return chain
+    }
+
+    private static func asAXUIElement(_ value: AnyObject?) -> AXUIElement? {
+        guard let v = value, CFGetTypeID(v) == AXUIElementGetTypeID() else { return nil }
+        return (v as! AXUIElement)
     }
 
     /// Shape-only stringification. Never returns the raw value's contents.

--- a/Tests/MojitoTests/DebugReportTests.swift
+++ b/Tests/MojitoTests/DebugReportTests.swift
@@ -38,15 +38,21 @@ struct DebugReportTests {
         }
     }
 
-    @Test func reportFitsUnderEightKB() {
+    @Test func reportFitsUnderCap() {
         DebugRecorder.reset()
-        // Fill the recorder past the surfacing window (50 events) — the
-        // report should still stay capped.
-        for i in 0..<200 {
+        for i in 0..<300 {
             DebugRecorder.record(.picker, "open", ["outcome": "axBounds", "iter": "\(i)"])
         }
         let out = DebugReport.markdown()
         #expect(out.utf8.count < DebugReport.maxSizeBytes, "report is \(out.utf8.count) bytes")
+    }
+
+    @Test func includesNewSections() {
+        DebugRecorder.reset()
+        let out = DebugReport.markdown()
+        for section in ["## Mojito", "## Build", "## Prefs", "## System", "## Database", "## Updater", "## Last picker context", "## Activity log", "## Now"] {
+            #expect(out.contains(section), "missing section \(section)")
+        }
     }
 
     @Test func noAbsoluteDatesInPrefsSection() {


### PR DESCRIPTION
## Summary
- Add Build, Database, Updater sections. Build distinguishes Debug/Release + code-signed/sandboxed.
- Mojito section gains processUptime + pausedRemaining (when paused).
- System gains preferredLanguages, active input source ID, thermal state, processor + memory, per-screen size/scale/refresh.
- Last picker context now includes full advertised attribute name list, full parameterized attribute name list, role chain up to 4 levels, window title length. The curated set still leads the section.
- Activity log surface bumped from 50 → 100 events. Added recorder calls for `engine.colon`, `engine.secureFieldBlocked`, `picker.search` (queryLen + result count, no contents), `emoticon.undo`.
- Report cap bumped from 8 KB → 32 KB.

Anonymity invariants unchanged: no `usageCounts` / `excludeBundleIDs` / `excludeURLPatterns` / `giphyApiKey` / `easterEggsDiscovered` contents; no paths, URLs, emails; AX values structural only.

Refs: W-210

## Test plan
- [ ] `scripts/run-tests.sh` green (forbiddenStringsNeverAppear, reportFitsUnderCap, includesNewSections, activityLogClampsLongMetadataValues, noAbsoluteDatesInPrefsSection).
- [ ] Manual: About → Copy Debug Info; paste into a scratchpad; spot-check all 9 sections present and forbidden strings absent.
- [ ] Trigger picker in Ghostty + TextEdit; verify "Last picker context" shows distinct AX attribute sets between them.