### PR TITLE
W-210: surface engine.active + triggerState in debug report

### DIFF
--- a/Sources/Mojito/App/Engine.swift
+++ b/Sources/Mojito/App/Engine.swift
@@ -9,6 +9,16 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
     @Published private(set) var isActive: Bool = false
     @Published var pausedUntil: Date?
 
+    /// State-machine label for diagnostic reports. Query contents are
+    /// elided so the value is anonymous.
+    var triggerStateLabel: String {
+        switch stateMachine.state {
+        case .idle:          return "idle"
+        case .capturing:     return "capturing"
+        case .gifSearching:  return "gifSearching"
+        }
+    }
+
     private let database: EmojiDatabase
     private let exclusions: ExclusionStore
     private let viewModel = PickerViewModel()

--- a/Sources/Mojito/Debug/DebugReport.swift
+++ b/Sources/Mojito/Debug/DebugReport.swift
@@ -35,10 +35,10 @@ enum DebugReport {
         return Date(timeIntervalSince1970: sec + usec)
     }
 
-    static func markdown(now: Date = Date()) -> String {
+    static func markdown(engine: Engine? = nil, now: Date = Date()) -> String {
         var out = ""
         out += "# Mojito debug report\n\n"
-        out += mojitoSection(now: now)
+        out += mojitoSection(engine: engine, now: now)
         out += "\n"
         out += buildSection()
         out += "\n"
@@ -68,7 +68,7 @@ enum DebugReport {
 
     // MARK: - Sections
 
-    private static func mojitoSection(now: Date) -> String {
+    private static func mojitoSection(engine: Engine?, now: Date) -> String {
         let info = Bundle.main.infoDictionary ?? [:]
         let bundleID = Bundle.main.bundleIdentifier ?? "—"
         let version = info["CFBundleShortVersionString"] as? String ?? "—"
@@ -90,6 +90,10 @@ enum DebugReport {
         s += "- paused: \(paused)\n"
         if paused, let pausedUntil {
             s += "- pausedRemaining: \(formatDuration(pausedUntil - now.timeIntervalSince1970))\n"
+        }
+        if let engine {
+            s += "- engine.active: \(engine.isActive)\n"
+            s += "- triggerState: \(engine.triggerStateLabel)\n"
         }
         return s
     }

--- a/Sources/Mojito/Settings/AboutSettings.swift
+++ b/Sources/Mojito/Settings/AboutSettings.swift
@@ -3,6 +3,7 @@ import AppKit
 import AVFoundation
 
 struct AboutSettingsView: View {
+    @EnvironmentObject private var engine: Engine
     @AppStorage(PrefsKey.donated) private var donated: Bool = false
     @State private var debugCopied: Bool = false
 
@@ -157,7 +158,7 @@ struct AboutSettingsView: View {
 
     private func copyDebugInfo() {
         NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(DebugReport.markdown(), forType: .string)
+        NSPasteboard.general.setString(DebugReport.markdown(engine: engine), forType: .string)
         debugCopied = true
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
             debugCopied = false


### PR DESCRIPTION
## Summary
- Add `engine.active` (true while the global key tap is running) and `triggerState` (idle / capturing / gifSearching) to the Mojito section of the debug report.
- Query contents are deliberately elided from the state label to preserve anonymity.

Refs: W-210

## Test plan
- [ ] `scripts/run-tests.sh` green.
- [ ] Copy Debug Info shows the two new fields when Engine is wired (About is in the regular settings window, so `@EnvironmentObject` resolves).