### PR TITLE
About: pair byline rows side-by-side

### DIFF
--- a/Sources/Mojito/Settings/AboutSettings.swift
+++ b/Sources/Mojito/Settings/AboutSettings.swift
@@ -117,21 +117,26 @@ struct AboutSettingsView: View {
 
     private var byline: some View {
         VStack(spacing: 8) {
-            Button("Report an issue") {
-                NSWorkspace.shared.open(URL(string: "https://github.com/wr/mojito/issues/new")!)
+            HStack(spacing: 8) {
+                Button("Report an issue") {
+                    NSWorkspace.shared.open(URL(string: "https://github.com/wr/mojito/issues/new")!)
+                }
+                Button(debugCopied ? "Copied!" : "Copy debug info") {
+                    copyDebugInfo()
+                }
             }
 
-            Button(debugCopied ? "Copied!" : "Copy debug info") {
-                copyDebugInfo()
-            }
-
-            Link("Website", destination: URL(string: "https://github.com/wr/mojito")!)
-                .font(.callout)
-
-            if !copyright.isEmpty {
-                Text(copyright)
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
+            HStack(spacing: 8) {
+                Link("Website", destination: URL(string: "https://github.com/wr/mojito")!)
+                    .font(.callout)
+                if !copyright.isEmpty {
+                    Text(verbatim: "·")
+                        .font(.callout)
+                        .foregroundStyle(.tertiary)
+                    Text(copyright)
+                        .font(.callout)
+                        .foregroundStyle(.tertiary)
+                }
             }
         }
         .frame(maxWidth: .infinity)


### PR DESCRIPTION
## Summary
- Group `Report an issue` and `Copy debug info` into a single horizontal row.
- Group `Website` and the copyright line into a single horizontal row, separated by a middot.

## Test plan
- [ ] Open Settings → About; confirm both rows render horizontally with consistent spacing.