### PR TITLE
Add allowlist mode to exclusions

### DIFF
--- a/Sources/Mojito/Exclusions/ExclusionStore.swift
+++ b/Sources/Mojito/Exclusions/ExclusionStore.swift
@@ -1,12 +1,23 @@
 import Foundation
 import Combine
 
+enum ExclusionMode: String {
+    case denylist
+    case allowlist
+}
+
 @MainActor
 final class ExclusionStore: ObservableObject {
     static let shared = ExclusionStore()
 
+    @Published var mode: ExclusionMode
     @Published var bundleIDs: Set<String>
     @Published var urlPatterns: Set<String>
+    /// Active lists when `mode == .allowlist`. Kept separate from the deny
+    /// lists so flipping the mode doesn't repurpose the default denylist
+    /// (Slack, Discord, Notion…) as the user's allowlist.
+    @Published var allowedBundleIDs: Set<String>
+    @Published var allowedURLPatterns: Set<String>
 
     private let defaults = UserDefaults.standard
     private var cancellables = Set<AnyCancellable>()
@@ -14,6 +25,13 @@ final class ExclusionStore: ObservableObject {
     private var compiledPatterns: [String: NSRegularExpression] = [:]
 
     private init() {
+        if let raw = defaults.string(forKey: PrefsKey.exclusionMode),
+           let parsed = ExclusionMode(rawValue: raw) {
+            mode = parsed
+        } else {
+            mode = .denylist
+        }
+
         let initialBundles: Set<String>
         if let raw = defaults.array(forKey: PrefsKey.excludedBundleIDs) as? [String] {
             initialBundles = Set(raw)
@@ -22,6 +40,14 @@ final class ExclusionStore: ObservableObject {
             defaults.set(Array(initialBundles), forKey: PrefsKey.excludedBundleIDs)
         }
         bundleIDs = initialBundles
+
+        let initialAllowed: Set<String>
+        if let raw = defaults.array(forKey: PrefsKey.allowedBundleIDs) as? [String] {
+            initialAllowed = Set(raw)
+        } else {
+            initialAllowed = []
+        }
+        allowedBundleIDs = initialAllowed
 
         let initialURLs: Set<String>
         if let raw = defaults.array(forKey: PrefsKey.excludedURLPatterns) as? [String] {
@@ -32,23 +58,56 @@ final class ExclusionStore: ObservableObject {
         }
         urlPatterns = initialURLs
 
+        let initialAllowedURLs: Set<String>
+        if let raw = defaults.array(forKey: PrefsKey.allowedURLPatterns) as? [String] {
+            initialAllowedURLs = Set(raw)
+        } else {
+            initialAllowedURLs = []
+        }
+        allowedURLPatterns = initialAllowedURLs
+
+        $mode
+            .dropFirst()
+            .sink { [weak self] in self?.defaults.set($0.rawValue, forKey: PrefsKey.exclusionMode) }
+            .store(in: &cancellables)
+
         $bundleIDs
             .dropFirst()
             .sink { [weak self] in self?.defaults.set(Array($0), forKey: PrefsKey.excludedBundleIDs) }
             .store(in: &cancellables)
 
+        $allowedBundleIDs
+            .dropFirst()
+            .sink { [weak self] in self?.defaults.set(Array($0), forKey: PrefsKey.allowedBundleIDs) }
+            .store(in: &cancellables)
+
         // `.dropFirst()` below skips Combine's synthetic on-subscribe emit
         // so the cache rebuilds once at launch, not twice.
-        rebuildPatternCache(urlPatterns)
+        rebuildPatternCache(urlPatterns.union(allowedURLPatterns))
+        // `@Published` fires in willSet, so inside each sink the *other*
+        // set's `self` value is still current while the changed set arrives
+        // as the closure argument — union them to rebuild the shared cache.
         $urlPatterns
             .dropFirst()
             .sink { [weak self] patterns in
-                self?.defaults.set(Array(patterns), forKey: PrefsKey.excludedURLPatterns)
-                self?.rebuildPatternCache(patterns)
+                guard let self else { return }
+                self.defaults.set(Array(patterns), forKey: PrefsKey.excludedURLPatterns)
+                self.rebuildPatternCache(patterns.union(self.allowedURLPatterns))
+            }
+            .store(in: &cancellables)
+        $allowedURLPatterns
+            .dropFirst()
+            .sink { [weak self] patterns in
+                guard let self else { return }
+                self.defaults.set(Array(patterns), forKey: PrefsKey.allowedURLPatterns)
+                self.rebuildPatternCache(self.urlPatterns.union(patterns))
             }
             .store(in: &cancellables)
     }
 
+    /// Cache is keyed by pattern string, so one dictionary covers both the
+    /// deny and allow lists; whichever set is active at match time picks
+    /// which keys to consult.
     private func rebuildPatternCache(_ patterns: Set<String>) {
         var built: [String: NSRegularExpression] = [:]
         for raw in patterns {
@@ -64,18 +123,36 @@ final class ExclusionStore: ObservableObject {
     }
 
     func isExcluded(bundleID: String?, url: URL?) -> Bool {
-        if let bundleID, bundleIDs.contains(bundleID) { return true }
-        if let host = url?.host(percentEncoded: false)?.lowercased() {
-            for pattern in urlPatterns where matches(host: host, pattern: pattern.lowercased()) {
-                return true
+        switch mode {
+        case .denylist:
+            if let bundleID, bundleIDs.contains(bundleID) { return true }
+            if let host = url?.host(percentEncoded: false)?.lowercased() {
+                for pattern in urlPatterns where matches(host: host, pattern: pattern.lowercased()) {
+                    return true
+                }
             }
+            return false
+        case .allowlist:
+            // Allow if the app is allowlisted, OR if the focused URL matches
+            // an allowed site — the latter implicitly allows whatever browser
+            // is hosting it, so users don't have to allowlist Chrome to allow
+            // github.com. Everything else is blocked.
+            if let bundleID, allowedBundleIDs.contains(bundleID) { return false }
+            if let host = url?.host(percentEncoded: false)?.lowercased() {
+                for pattern in allowedURLPatterns where matches(host: host, pattern: pattern.lowercased()) {
+                    return false
+                }
+            }
+            return true
         }
-        return false
     }
 
     func resetToDefaults() {
+        mode = .denylist
         bundleIDs = Set(DefaultExclusions.bundleIDs)
+        allowedBundleIDs = []
         urlPatterns = Set(DefaultExclusions.urlPatterns)
+        allowedURLPatterns = []
     }
 
     /// `*` matches any single subdomain segment.

--- a/Sources/Mojito/Settings/ExclusionsSettings.swift
+++ b/Sources/Mojito/Settings/ExclusionsSettings.swift
@@ -12,51 +12,59 @@ struct ExclusionsSettingsView: View {
     @State private var showAddSheet = false
     @State private var newPattern: String = ""
 
+    private var activeBundleIDs: Set<String> {
+        store.mode == .allowlist ? store.allowedBundleIDs : store.bundleIDs
+    }
+
     private var visibleBundleIDs: [String] {
-        store.bundleIDs.sorted().filter {
+        activeBundleIDs.sorted().filter {
             NSWorkspace.shared.urlForApplication(withBundleIdentifier: $0) != nil
         }
     }
 
     private var sortedPatterns: [String] {
-        store.urlPatterns.sorted()
+        (store.mode == .allowlist ? store.allowedURLPatterns : store.urlPatterns).sorted()
+    }
+
+    private var appsHeader: LocalizedStringKey {
+        store.mode == .allowlist
+            ? "These apps will trigger \(AppInfo.displayName)."
+            : "These apps won't trigger \(AppInfo.displayName)."
+    }
+
+    private var sitesHeader: LocalizedStringKey {
+        store.mode == .allowlist
+            ? "These sites will trigger \(AppInfo.displayName).\n`*` matches a subdomain."
+            : "These sites won't trigger \(AppInfo.displayName).\n`*` matches a subdomain."
     }
 
     var body: some View {
         ScrollView {
             VStack(spacing: 20) {
+                modePicker
+
                 BoxedList(
-                    header: "Prevent \(AppInfo.displayName) from triggering inside these apps.",
+                    header: appsHeader,
                     items: visibleBundleIDs,
                     selected: $selectedApp,
                     onAdd: addApp,
-                    onRemove: {
-                        if let s = selectedApp {
-                            store.bundleIDs.remove(s)
-                            selectedApp = nil
-                        }
-                    },
+                    onRemove: removeSelectedApp,
                     row: appRow
                 )
 
                 BoxedList(
-                    header: "Prevent \(AppInfo.displayName) from triggering on these sites. `*` matches a subdomain.",
+                    header: sitesHeader,
                     items: sortedPatterns,
                     selected: $selectedPattern,
                     onAdd: { newPattern = ""; showAddSheet = true },
-                    onRemove: {
-                        if let s = selectedPattern {
-                            store.urlPatterns.remove(s)
-                            selectedPattern = nil
-                        }
-                    },
+                    onRemove: removeSelectedPattern,
                     row: siteRow
                 )
 
                 BoxedToggle(
-                    header: "GIF search bypass",
-                    title: "Let GIF search work in excluded apps",
-                    caption: "`:::` overrides the exclusion list.",
+                    header: "GIF search override",
+                    title: "Always let GIF search work",
+                    caption: "`:::` opens the GIF picker regardless of the lists above.",
                     isOn: $gifBypassExclusions
                 )
             }
@@ -64,11 +72,37 @@ struct ExclusionsSettingsView: View {
         }
         .sheet(isPresented: $showAddSheet) {
             AddWebsiteSheet(pattern: $newPattern) { trimmed in
-                store.urlPatterns.insert(trimmed)
+                insertPattern(trimmed)
                 showAddSheet = false
             } onCancel: {
                 showAddSheet = false
             }
+        }
+    }
+
+    // MARK: - Mode picker
+
+    private var modePicker: some View {
+        // Local binding keeps the selection drawn from `store.mode` so it
+        // updates whenever any other surface flips the mode.
+        let binding = Binding<ExclusionMode>(
+            get: { store.mode },
+            set: { newValue in
+                guard newValue != store.mode else { return }
+                store.mode = newValue
+                selectedApp = nil
+                selectedPattern = nil
+            }
+        )
+        return HStack(spacing: 6) {
+            Text("\(AppInfo.displayName) runs")
+            Picker("", selection: binding) {
+                Text("everywhere except the apps & sites below").tag(ExclusionMode.denylist)
+                Text("only in the apps & sites below").tag(ExclusionMode.allowlist)
+            }
+            .labelsHidden()
+            .fixedSize()
+            Spacer(minLength: 0)
         }
     }
 
@@ -127,8 +161,36 @@ struct ExclusionsSettingsView: View {
         panel.directoryURL = URL(fileURLWithPath: "/Applications")
         panel.allowsMultipleSelection = false
         if panel.runModal() == .OK, let url = panel.url, let bundle = Bundle(url: url), let id = bundle.bundleIdentifier {
-            store.bundleIDs.insert(id)
+            switch store.mode {
+            case .denylist:  store.bundleIDs.insert(id)
+            case .allowlist: store.allowedBundleIDs.insert(id)
+            }
         }
+    }
+
+    private func removeSelectedApp() {
+        guard let s = selectedApp else { return }
+        switch store.mode {
+        case .denylist:  store.bundleIDs.remove(s)
+        case .allowlist: store.allowedBundleIDs.remove(s)
+        }
+        selectedApp = nil
+    }
+
+    private func insertPattern(_ pattern: String) {
+        switch store.mode {
+        case .denylist:  store.urlPatterns.insert(pattern)
+        case .allowlist: store.allowedURLPatterns.insert(pattern)
+        }
+    }
+
+    private func removeSelectedPattern() {
+        guard let s = selectedPattern else { return }
+        switch store.mode {
+        case .denylist:  store.urlPatterns.remove(s)
+        case .allowlist: store.allowedURLPatterns.remove(s)
+        }
+        selectedPattern = nil
     }
 }
 

--- a/Sources/Mojito/Util/PrefsKey.swift
+++ b/Sources/Mojito/Util/PrefsKey.swift
@@ -10,6 +10,13 @@ enum PrefsKey {
     static let useFrequencyBoost     = "mojito.search.frequencyBoost"
     static let excludedBundleIDs     = "mojito.excludeBundleIDs"     // [String]
     static let excludedURLPatterns   = "mojito.excludeURLPatterns"   // [String]
+    /// `denylist` (default) = block apps/sites in the excluded lists.
+    /// `allowlist` = block everything except apps/sites in the allowed lists.
+    /// In allowlist mode a URL-pattern match implicitly allows the browser
+    /// hosting it, so users don't have to allowlist Chrome to allow github.com.
+    static let exclusionMode         = "mojito.exclusions.mode"      // String, ExclusionMode raw
+    static let allowedBundleIDs      = "mojito.allowBundleIDs"       // [String]
+    static let allowedURLPatterns    = "mojito.allowURLPatterns"     // [String]
     static let usageCounts           = "mojito.usageCounts"          // [String: Int]  (hexcode → count)
     /// Set once on first launch.
     static let firstLaunchDate       = "mojito.firstLaunchDate"


### PR DESCRIPTION
## Summary

The Exclusions settings only supported a **denylist** — apps/sites where Mojito stays out. This adds an **allowlist** mode: Mojito off everywhere *except* a curated set. A single inline pop-up picker flips the two lists' meaning:

> **Mojito runs** [ everywhere except the apps & sites below ▾ ]  ← default
> **Mojito runs** [ only in the apps & sites below ▾ ]

Both modes show the same two lists (apps + sites) and the GIF override toggle, so they look and behave symmetrically.

- **Allowlist + sites:** a URL-pattern match implicitly allows the browser hosting it, so allowlisting `github.com` works in any browser without also allowlisting the browser app.
- **GIF override** works in both modes — `:::` routes through `isExcluded`, so no Engine change was needed.
- Allow lists are stored separately from deny lists (`allowedBundleIDs` / `allowedURLPatterns`), so flipping modes never repurposes the default denylist (Slack, Discord, Notion…) as the allowlist.

New `PrefsKey`s: `exclusionMode`, `allowedBundleIDs`, `allowedURLPatterns`. Existing installs default to `denylist` with current behavior unchanged.

Localized-strings catalog intentionally left out — the headless sync reorders the entire file (~17k lines of churn). New UI strings fall back to their English keys; the catalog can sync in a follow-up.

## Test plan

- [ ] Allowlist, empty list → Mojito triggers nowhere.
- [ ] Allowlist + frontmost app added → works there, no-op elsewhere.
- [ ] Allowlist + only a site pattern added → works on that site in any browser, no-op on other tabs/apps.
- [ ] GIF override on, allowlist, non-allowed app → `:::` still opens the GIF picker.
- [ ] Flip back to denylist → original behavior; Slack/Discord/etc. defaults intact.

Refs: W-215