### PR TITLE
W-219: pass through Return/Tab when capture has no picker result

### DIFF
--- a/Sources/Mojito/App/Engine.swift
+++ b/Sources/Mojito/App/Engine.swift
@@ -328,13 +328,26 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
         }
 
         let output = stateMachine.handle(input)
+
+        // Return/Tab during capture resolves to `.fromPicker`, which the
+        // state machine marks consumed so the key selects the highlighted
+        // row. But a sub-threshold query like `:q` never surfaced the picker
+        // (and a no-match query surfaces it empty), so there's no row to
+        // select — `insert` will no-op on its `topResult` guard. Consuming
+        // anyway swallows the key and the host app needs a second press.
+        // Read the model before `apply`, since insertion resets it.
+        var consumesKey = output.consumesKey
+        if case .insertEmoji(_, .fromPicker, _) = output.action, viewModel.topResult == nil {
+            consumesKey = false
+        }
+
         apply(action: output.action)
         // In excluded apps `apply` suppresses the picker / insertion, but
         // returning a true `consumesKey` would still swallow the keystroke
         // (e.g. Return / Esc / arrows during an invisible capture) and break
         // the host app — see Vim in Terminal, where `:q<Enter>` needed two
         // Enters to quit.
-        return captureIsExcluded ? false : output.consumesKey
+        return captureIsExcluded ? false : consumesKey
     }
 
     private func apply(action: TriggerAction) {


### PR DESCRIPTION
## Summary
- Fixes Return/Tab being swallowed (requiring a second press) when capturing a query in a **non-excluded** app that never surfaced a picker row — e.g. `:q<Enter>` in TextEdit, or any ≥2-char query where fuzzy search returns zero results.
- Root cause: the state machine resolves Return/Tab during capture to `insertEmoji(.fromPicker)` with `consumesKey: true`, assuming a picker row exists. When `viewModel.topResult == nil`, `Engine.insert` no-ops on its guard, but the key was already reported consumed to the event tap, so the host app never sees it.
- Fix: in `Engine.handle`, downgrade `consumesKey` to `false` when the action is `insertEmoji(.fromPicker)` and `topResult == nil`. Read the model *before* `apply` runs, since insertion resets it.
- Complements #56 (W-213), which covered the excluded-app variant.

## Test plan
- [ ] `:q<Enter>` in TextEdit → `:q` stays, Enter registers on first press
- [ ] `:smile<Enter>` → still inserts 😄 and consumes the Enter (happy path unchanged)
- [ ] `:q<Tab>` → Tab registers on first press
- [ ] Excluded-app Vim `:q<Enter>` → still works (W-213 path intact)

Refs: W-219