### PR TITLE
W-221: backfill unit tests for state machine + matcher gaps

### DIFF
--- a/Mojito.xcodeproj/project.pbxproj
+++ b/Mojito.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		06082A2DD9E20456D2D20F2C /* ExclusionStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625433055302CF9B9053F885 /* ExclusionStoreTests.swift */; };
 		06E493068FD409A2B795BC56 /* s01.bin in Resources */ = {isa = PBXBuildFile; fileRef = DF0A9FF25BC996BC640A35A0 /* s01.bin */; };
 		07238FD3052A35E9FB70AA93 /* Fireworks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C81578D7A36FB7EA31D1985 /* Fireworks.swift */; };
 		0821677DEC58AC2FCE0C3BBF /* v02.bin in Resources */ = {isa = PBXBuildFile; fileRef = E5E4119DFCFBCC4A92FEEB1C /* v02.bin */; };
@@ -41,6 +42,7 @@
 		4949BE63FAD5A5FC2573CFE1 /* DefaultExclusions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877AFBCD3CD8EE7B154C73BD /* DefaultExclusions.swift */; };
 		4AE8FF96950E4AD801A5D632 /* AnimatedGifView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31E41F813A67872400E4942 /* AnimatedGifView.swift */; };
 		4C024B6EA9665C5DFDB80CE7 /* WarpDrive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9658C9CF3396443D22FF4E28 /* WarpDrive.swift */; };
+		4F9E4BA7A275583B07011809 /* FuzzyMatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42FA18E36A4027D4CB96ADA5 /* FuzzyMatcherTests.swift */; };
 		505F6B7F84EC1D9EF7AB55C9 /* SolitaireWin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E63ABA27E65953D84162097 /* SolitaireWin.swift */; };
 		510035EDB98F94AD6098C122 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = FDE7F8DEA98F385943A30B78 /* Localizable.xcstrings */; };
 		527E2FD4617302A4202C22E2 /* v04.bin in Resources */ = {isa = PBXBuildFile; fileRef = 127F100886742DCE05A171B4 /* v04.bin */; };
@@ -118,6 +120,7 @@
 		D69A33630F4FD6D6EB950C67 /* UpdaterCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 702AC2870CD686AB17CC518E /* UpdaterCoordinator.swift */; };
 		D7FD72169491380D742F69BC /* ChooChooSound.swift in Sources */ = {isa = PBXBuildFile; fileRef = C060B27E6970531BEBA3673E /* ChooChooSound.swift */; };
 		DCE52DEE8C9CEC354443E7DB /* SettingsRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC142D2205F1C089F7524D2 /* SettingsRoot.swift */; };
+		DD501615C4A6623E5BA03369 /* EmojiDatabaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B842CBBD6C7466F9BA2786 /* EmojiDatabaseTests.swift */; };
 		DD75EE1DF9351238356F60E7 /* SkinTone.swift in Sources */ = {isa = PBXBuildFile; fileRef = B375DE27AC0AE1D8DE965403 /* SkinTone.swift */; };
 		DF4F5EB36D764A99CAB8CADB /* WilhelmScream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 088608D6A2243D8E95953095 /* WilhelmScream.swift */; };
 		E29AE211BD536EA5FD09BF0E /* v11.bin in Resources */ = {isa = PBXBuildFile; fileRef = D3C7F5A4189B7652C993C384 /* v11.bin */; };
@@ -131,6 +134,7 @@
 		ECC3936D06DC519BCE249F8D /* PermissionsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2027256AFD59D65C41FAA2AD /* PermissionsCoordinator.swift */; };
 		EF12FA0699114C96BC4FEFC2 /* s09.bin in Resources */ = {isa = PBXBuildFile; fileRef = 4678DF22D8E1B41FC8359CF1 /* s09.bin */; };
 		EF68C901592CF3ACF08A344B /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = 8B43031B38814AF859998A56 /* KeyboardShortcuts */; };
+		EFCA5419E2CE5D16F2DE7DB3 /* AmbientEmoticonTableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F36FC6BE9A109EAEE6A18CE1 /* AmbientEmoticonTableTests.swift */; };
 		F07DEA88DD7DFC70934988EF /* EffectDismisser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D64E06BE48B822A5BA55952 /* EffectDismisser.swift */; };
 		F438993077911C965697652C /* s08.bin in Resources */ = {isa = PBXBuildFile; fileRef = 5111A1AB2B4D546A7D073563 /* s08.bin */; };
 		F46B89A2E807D259981405E5 /* ConfettiRain.swift in Sources */ = {isa = PBXBuildFile; fileRef = C410F8B7AF8493C098EA2AF1 /* ConfettiRain.swift */; };
@@ -183,6 +187,7 @@
 		3188FF1FD6559BF8E64C19CC /* EasterEggTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EasterEggTracker.swift; sourceTree = "<group>"; };
 		36BF5C449E03B6F883693B87 /* EmojiRain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiRain.swift; sourceTree = "<group>"; };
 		392847FD44ED870B7154ED09 /* s03.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; path = s03.bin; sourceTree = "<group>"; };
+		42FA18E36A4027D4CB96ADA5 /* FuzzyMatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatcherTests.swift; sourceTree = "<group>"; };
 		4512D76E20BD99269775200B /* OnboardingRoot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingRoot.swift; sourceTree = "<group>"; };
 		463478D4F770642DDCBA5C8F /* Snowfall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Snowfall.swift; sourceTree = "<group>"; };
 		4678DF22D8E1B41FC8359CF1 /* s09.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; path = s09.bin; sourceTree = "<group>"; };
@@ -202,6 +207,7 @@
 		5B9E4C2183154C36F1883004 /* PickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickerViewModel.swift; sourceTree = "<group>"; };
 		5C9E01A82260E8A38DF8D7EA /* DebugReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugReport.swift; sourceTree = "<group>"; };
 		5FB7AB3DB0E63AF30880FE66 /* BrowserURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserURL.swift; sourceTree = "<group>"; };
+		625433055302CF9B9053F885 /* ExclusionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExclusionStoreTests.swift; sourceTree = "<group>"; };
 		6666150B793721D5095E72A8 /* SymbolsDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolsDatabase.swift; sourceTree = "<group>"; };
 		69CD38087938C1E258718C69 /* FzyScorerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FzyScorerTests.swift; sourceTree = "<group>"; };
 		6C69999E4AC7F8B8C054B395 /* DebugReportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugReportTests.swift; sourceTree = "<group>"; };
@@ -231,6 +237,7 @@
 		9C90F0A490BC13D9CC5ADF90 /* s05.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; path = s05.bin; sourceTree = "<group>"; };
 		9E0C646543028E968FB6287E /* SeasonalGatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeasonalGatesTests.swift; sourceTree = "<group>"; };
 		A0DE1B7DD5243E817418580C /* AudioBlob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioBlob.swift; sourceTree = "<group>"; };
+		A1B842CBBD6C7466F9BA2786 /* EmojiDatabaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiDatabaseTests.swift; sourceTree = "<group>"; };
 		A1DA7C9FD3286A7839BA642D /* AppInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfo.swift; sourceTree = "<group>"; };
 		A3781043056BF9F399D00EDD /* s02.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; path = s02.bin; sourceTree = "<group>"; };
 		A891A50B1E32BC1A8B549268 /* AppContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppContext.swift; sourceTree = "<group>"; };
@@ -284,6 +291,7 @@
 		ED8647D638A24D3741D78A59 /* s15.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; path = s15.bin; sourceTree = "<group>"; };
 		EE4174E56EEBEA3423926E2A /* v10.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; path = v10.bin; sourceTree = "<group>"; };
 		EF96A1DA7100EFFEEEEF8B7D /* Mojito.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Mojito.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		F36FC6BE9A109EAEE6A18CE1 /* AmbientEmoticonTableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmbientEmoticonTableTests.swift; sourceTree = "<group>"; };
 		F5C5BC5F015CABDD85262258 /* SeasonalGates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeasonalGates.swift; sourceTree = "<group>"; };
 		F5C937DB8C91F3847F55D8A6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		FACE9E8BAF08240551D5237A /* v06.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; path = v06.bin; sourceTree = "<group>"; };
@@ -308,8 +316,12 @@
 		02F05DB5E7247E1AE700004A /* MojitoTests */ = {
 			isa = PBXGroup;
 			children = (
+				F36FC6BE9A109EAEE6A18CE1 /* AmbientEmoticonTableTests.swift */,
 				6C69999E4AC7F8B8C054B395 /* DebugReportTests.swift */,
+				A1B842CBBD6C7466F9BA2786 /* EmojiDatabaseTests.swift */,
 				DBB27C78330DB1E6F05BDAE7 /* EmoticonTableTests.swift */,
+				625433055302CF9B9053F885 /* ExclusionStoreTests.swift */,
+				42FA18E36A4027D4CB96ADA5 /* FuzzyMatcherTests.swift */,
 				69CD38087938C1E258718C69 /* FzyScorerTests.swift */,
 				9E0C646543028E968FB6287E /* SeasonalGatesTests.swift */,
 				D74BDC060E2EAACF7A71A3A6 /* SkinToneTests.swift */,
@@ -882,8 +894,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EFCA5419E2CE5D16F2DE7DB3 /* AmbientEmoticonTableTests.swift in Sources */,
 				B878C3CC891907E89DE33158 /* DebugReportTests.swift in Sources */,
+				DD501615C4A6623E5BA03369 /* EmojiDatabaseTests.swift in Sources */,
 				9E9309E8AF1F9D8B44213729 /* EmoticonTableTests.swift in Sources */,
+				06082A2DD9E20456D2D20F2C /* ExclusionStoreTests.swift in Sources */,
+				4F9E4BA7A275583B07011809 /* FuzzyMatcherTests.swift in Sources */,
 				B32AE99482DA334BDD7CEEAC /* FzyScorerTests.swift in Sources */,
 				C025CD4AE30320C3FE69028A /* SeasonalGatesTests.swift in Sources */,
 				917B8512B30F3B6E8C9D2B8C /* SkinToneTests.swift in Sources */,

--- a/Sources/Mojito/Exclusions/ExclusionStore.swift
+++ b/Sources/Mojito/Exclusions/ExclusionStore.swift
@@ -53,14 +53,31 @@ final class ExclusionStore: ObservableObject {
         var built: [String: NSRegularExpression] = [:]
         for raw in patterns {
             let pattern = raw.lowercased()
-            guard pattern.contains("*") else { continue }
-            let regexPattern = "^" + NSRegularExpression.escapedPattern(for: pattern)
-                .replacingOccurrences(of: "\\*", with: "[^.]+") + "$"
-            if let regex = try? NSRegularExpression(pattern: regexPattern) {
+            if let regex = Self.compiledGlob(for: pattern) {
                 built[pattern] = regex
             }
         }
         compiledPatterns = built
+    }
+
+    /// Compile a wildcard host pattern. `*` matches exactly one subdomain
+    /// segment (`[^.]+`), anchored at both ends. Returns nil for patterns
+    /// with no wildcard — those are compared by equality.
+    nonisolated static func compiledGlob(for pattern: String) -> NSRegularExpression? {
+        guard pattern.contains("*") else { return nil }
+        let regexPattern = "^" + NSRegularExpression.escapedPattern(for: pattern)
+            .replacingOccurrences(of: "\\*", with: "[^.]+") + "$"
+        return try? NSRegularExpression(pattern: regexPattern)
+    }
+
+    /// Pure host/pattern decision. Equality unless the pattern carries a
+    /// `*` wildcard. Compiles on demand — the instance hot path uses the
+    /// `compiledPatterns` cache instead to avoid per-`:` recompilation.
+    nonisolated static func matches(host: String, pattern: String) -> Bool {
+        guard pattern.contains("*") else { return host == pattern }
+        guard let regex = compiledGlob(for: pattern) else { return false }
+        let range = NSRange(host.startIndex..., in: host)
+        return regex.firstMatch(in: host, range: range) != nil
     }
 
     func isExcluded(bundleID: String?, url: URL?) -> Bool {

--- a/Tests/MojitoTests/AmbientEmoticonTableTests.swift
+++ b/Tests/MojitoTests/AmbientEmoticonTableTests.swift
@@ -1,0 +1,53 @@
+import Testing
+@testable import Mojito
+
+/// Ambient emoticons need no leading `:`. Keys are full literal sequences,
+/// so case variants are distinct, and the fire timing depends on whether
+/// the sequence is punctuation-led (fire on completion) or letter/number-
+/// led (wait for a terminator so it can't eat into prose).
+struct AmbientEmoticonTableTests {
+
+    @Test func knownSequencesMapToEmoji() {
+        #expect(AmbientEmoticonTable.emoji(for: "<3") == "❤️")
+        #expect(AmbientEmoticonTable.emoji(for: "</3") == "💔")
+        #expect(AmbientEmoticonTable.emoji(for: "XD") == "😆")
+        #expect(AmbientEmoticonTable.emoji(for: "xD") == "😆")
+        #expect(AmbientEmoticonTable.emoji(for: ">:)") == "😈")
+        #expect(AmbientEmoticonTable.emoji(for: "B)") == "😎")
+    }
+
+    @Test func caseVariantsAreSeparateKeys() {
+        // "XD"/"xD" are registered; "Xd"/"xd" are not.
+        #expect(AmbientEmoticonTable.emoji(for: "Xd") == nil)
+        #expect(AmbientEmoticonTable.emoji(for: "xd") == nil)
+    }
+
+    @Test func unknownOrEmptyReturnsNil() {
+        #expect(AmbientEmoticonTable.emoji(for: "hello") == nil)
+        #expect(AmbientEmoticonTable.emoji(for: "") == nil)
+    }
+
+    @Test func punctuationLedFiresImmediately() {
+        #expect(AmbientEmoticonTable.shouldFireImmediately("<3"))
+        #expect(AmbientEmoticonTable.shouldFireImmediately("</3"))
+        #expect(AmbientEmoticonTable.shouldFireImmediately(">:)"))
+    }
+
+    @Test func letterOrNumberLedWaitsForTerminator() {
+        // Would otherwise eat into "XDog" / "Bobby".
+        #expect(!AmbientEmoticonTable.shouldFireImmediately("XD"))
+        #expect(!AmbientEmoticonTable.shouldFireImmediately("B)"))
+    }
+
+    @Test func incompleteSequenceDoesNotFire() {
+        #expect(!AmbientEmoticonTable.shouldFireImmediately("<"))
+        #expect(!AmbientEmoticonTable.shouldFireImmediately(">"))
+        #expect(!AmbientEmoticonTable.shouldFireImmediately(""))
+    }
+
+    @Test func colonContinuationPrefixesCoversAngleBracket() {
+        // `>` must be allowed to continue with `:` so `>:)` isn't hijacked
+        // by colon-capture.
+        #expect(AmbientEmoticonTable.colonContinuationPrefixes.contains(">"))
+    }
+}

--- a/Tests/MojitoTests/EmojiDatabaseTests.swift
+++ b/Tests/MojitoTests/EmojiDatabaseTests.swift
@@ -1,0 +1,46 @@
+import Testing
+@testable import Mojito
+
+/// Smoke + lookup invariants for the bundled emoji corpus. The test host
+/// bundles `emoji.json`, so `EmojiDatabase.shared` loads the real data.
+@MainActor
+struct EmojiDatabaseTests {
+
+    @Test func loadsTheFullCorpus() {
+        let db = EmojiDatabase.shared
+        // emojibase ships ~1.9k entries; guard against an empty/failed load.
+        #expect(db.all.count > 1000)
+        // Exactly one indexed entry per emoji.
+        #expect(db.indexed.count == db.all.count)
+    }
+
+    @Test func exactLookupResolvesKnownShortcode() {
+        #expect(EmojiDatabase.shared.exact("smile")?.character == "😄")
+    }
+
+    @Test func exactLookupIsCaseInsensitive() {
+        let db = EmojiDatabase.shared
+        let lower = db.exact("smile")
+        #expect(lower != nil)
+        #expect(db.exact("SMILE")?.hexcode == lower?.hexcode)
+        #expect(db.exact("Smile")?.hexcode == lower?.hexcode)
+    }
+
+    @Test func exactLookupUnknownReturnsNil() {
+        #expect(EmojiDatabase.shared.exact("definitely_not_a_shortcode_zzqx") == nil)
+    }
+
+    @Test func hexcodeIndexMatchesShortcodeIndex() throws {
+        let db = EmojiDatabase.shared
+        let smile = try #require(db.exact("smile"))
+        #expect(db.byHexcode[smile.hexcode]?.character == smile.character)
+    }
+
+    @Test func indexedHaystacksIncludeEveryShortcode() throws {
+        let db = EmojiDatabase.shared
+        let smile = try #require(db.exact("smile"))
+        let entry = try #require(db.indexed.first { $0.emoji.hexcode == smile.hexcode })
+        // Haystacks are pre-lowercased `[Character]` arrays — one per shortcode.
+        #expect(entry.haystacks.contains { $0.chars == Array("smile") })
+    }
+}

--- a/Tests/MojitoTests/ExclusionStoreTests.swift
+++ b/Tests/MojitoTests/ExclusionStoreTests.swift
@@ -1,0 +1,44 @@
+import Testing
+@testable import Mojito
+
+/// Host-pattern matching for URL exclusions. A `*` wildcard matches exactly
+/// one subdomain segment (`[^.]+`) and is anchored at both ends, so it can't
+/// span dots or match a suffix of a longer host. Patterns without a wildcard
+/// are compared by exact equality.
+struct ExclusionStoreTests {
+
+    @Test func plainPatternMatchesByEquality() {
+        #expect(ExclusionStore.matches(host: "mail.google.com", pattern: "mail.google.com"))
+        #expect(!ExclusionStore.matches(host: "mail.google.com", pattern: "google.com"))
+    }
+
+    @Test func wildcardMatchesOneSegment() {
+        #expect(ExclusionStore.matches(host: "mail.google.com", pattern: "*.google.com"))
+        #expect(ExclusionStore.matches(host: "drive.google.com", pattern: "*.google.com"))
+    }
+
+    @Test func wildcardDoesNotSpanDots() {
+        // `*` is a single segment — it must not match across `a.b`.
+        #expect(!ExclusionStore.matches(host: "a.mail.google.com", pattern: "*.google.com"))
+    }
+
+    @Test func wildcardRequiresANonEmptySegment() {
+        // `[^.]+` needs at least one char, so the bare apex doesn't match.
+        #expect(!ExclusionStore.matches(host: "google.com", pattern: "*.google.com"))
+    }
+
+    @Test func wildcardIsAnchoredAtBothEnds() {
+        #expect(!ExclusionStore.matches(host: "mail.google.com.evil.com", pattern: "*.google.com"))
+        #expect(!ExclusionStore.matches(host: "x.google.com", pattern: "*.google.co"))
+    }
+
+    @Test func dotsInPatternAreLiteralNotRegexWildcards() {
+        // The `.` must be escaped — "*Xgoogleycom" must not match "*.google.com".
+        #expect(!ExclusionStore.matches(host: "mailXgoogleYcom", pattern: "*.google.com"))
+    }
+
+    @Test func compiledGlobOnlyForWildcardPatterns() {
+        #expect(ExclusionStore.compiledGlob(for: "google.com") == nil)
+        #expect(ExclusionStore.compiledGlob(for: "*.google.com") != nil)
+    }
+}

--- a/Tests/MojitoTests/FuzzyMatcherTests.swift
+++ b/Tests/MojitoTests/FuzzyMatcherTests.swift
@@ -1,0 +1,101 @@
+import Testing
+@testable import Mojito
+
+/// `FuzzyMatcher.search` ranking behaviour, exercised against the real
+/// bundled corpus (the test host bundles `emoji.json`). Assertions are
+/// data-shape invariants — prefix-tier precedence, the frequency boost,
+/// corpus scoping, the result cap — not magic scores, so scoring tweaks
+/// don't force a rewrite. Easter-egg pinned rows are deliberately not
+/// exercised here (their triggers live only as hashes).
+@MainActor
+struct FuzzyMatcherTests {
+
+    private func search(
+        _ query: String,
+        corpus: SearchCorpus = .emojiOnly,
+        usage: [String: Int] = [:],
+        boost: Bool = false,
+        limit: Int = 12
+    ) -> [ScoredEmoji] {
+        FuzzyMatcher.search(
+            query: query,
+            in: EmojiDatabase.shared,
+            usage: usage,
+            corpus: corpus,
+            useFrequencyBoost: boost,
+            limit: limit
+        )
+    }
+
+    /// Real (non-pinned) results — pinned/sentinel rows carry group -1.
+    private func realResults(_ scored: [ScoredEmoji]) -> [ScoredEmoji] {
+        scored.filter { $0.emoji.group != -1 }
+    }
+
+    @Test func emptyQueryReturnsNothing() {
+        #expect(search("").isEmpty)
+    }
+
+    @Test func resultCapIsRespected() {
+        // "a" matches a huge slice of the corpus; the cap must still hold.
+        #expect(search("a", limit: 5).count <= 5)
+    }
+
+    @Test func commonQueryReturnsMatches() {
+        #expect(!search("smile").isEmpty)
+    }
+
+    @Test func prefixMatchesOutrankEmbedded() throws {
+        // "smile" has shortcodes that start with it (smile, smiley, …); the
+        // prefix tier sorts ahead of embedded matches, so the top real
+        // result's matched shortcode must begin with the query.
+        let results = realResults(search("smile"))
+        try #require(!results.isEmpty)
+        #expect(results.first!.matchedShortcode.lowercased().hasPrefix("smile"))
+    }
+
+    @Test func frequencyBoostPromotesUsedEmoji() throws {
+        // "smile" has several shortcodes that start with it, so the top
+        // results all sit in the prefix tier. The boost is capped at +5.0
+        // (about a full consecutive match), so heavily using a lower-ranked
+        // prefix result must lift it toward the front of that tier. Staying
+        // within one tier avoids the prefix-vs-embedded barrier, which no
+        // score boost can cross.
+        let base = realResults(search("smile", boost: true))
+        try #require(base.count >= 3)
+        let target = base[2].emoji.hexcode
+        let boosted = realResults(search("smile", usage: [target: 10_000], boost: true))
+        let boostedIdx = boosted.firstIndex { $0.emoji.hexcode == target }!
+        #expect(boostedIdx < 2)
+    }
+
+    @Test func frequencyBoostNeverDemotes() throws {
+        // With the boost off, usage counts must not change the order.
+        let unboosted = realResults(search("heart", boost: false))
+        try #require(unboosted.count >= 2)
+        let target = unboosted.last!.emoji.hexcode
+        let baseIdx = unboosted.firstIndex { $0.emoji.hexcode == target }!
+        let withUsageButNoBoost = realResults(
+            search("heart", usage: [target: 1000], boost: false)
+        )
+        let idx = withUsageButNoBoost.firstIndex { $0.emoji.hexcode == target }!
+        #expect(idx == baseIdx)
+    }
+
+    @Test func symbolsOnlyCorpusFindsCuratedSymbol() {
+        let results = search("cmd", corpus: .symbolsOnly)
+        #expect(results.contains { $0.emoji.character == "⌘" })
+    }
+
+    @Test func emojiOnlyCorpusExcludesSymbols() {
+        let results = search("cmd", corpus: .emojiOnly)
+        #expect(!results.contains { $0.emoji.character == "⌘" })
+    }
+
+    @Test func emojiAndSymbolsCorpusSpansBoth() {
+        // The combined corpus should surface emoji for an emoji query and
+        // symbols for a symbol query.
+        #expect(!search("smile", corpus: .emojiAndSymbols).isEmpty)
+        #expect(search("cmd", corpus: .emojiAndSymbols).contains { $0.emoji.character == "⌘" })
+    }
+}

--- a/Tests/MojitoTests/TriggerStateMachineTests.swift
+++ b/Tests/MojitoTests/TriggerStateMachineTests.swift
@@ -236,4 +236,230 @@ struct TriggerStateMachineTests {
         #expect(sm.state == .capturing(query: ""))
         #expect(out.action == .none)
     }
+
+    // MARK: GIF picker (:::)
+
+    /// Drive the machine into `.gifSearching` via three quick colons.
+    /// Colon #2 momentarily cancels capture back to idle, but the rolling
+    /// `recentColonTimes` window survives that, so colon #3 still trips the
+    /// GIF trigger — that's the behaviour this helper pins down.
+    private func enterGifSearching() -> TriggerStateMachine {
+        var sm = TriggerStateMachine()
+        _ = sm.handle(.colon)
+        _ = sm.handle(.colon)
+        _ = sm.handle(.colon)
+        return sm
+    }
+
+    @Test func tripleColonOpensGifPicker() {
+        var sm = TriggerStateMachine()
+        _ = sm.handle(.colon)
+        _ = sm.handle(.colon)
+        let out = sm.handle(.colon)
+        #expect(out.action == .openGifPicker)
+        // The colons stay in the focused app — deleted only when a GIF is picked.
+        #expect(out.consumesKey == false)
+        #expect(sm.state == .gifSearching(query: ""))
+    }
+
+    @Test func gifNameCharsRefreshQueryAndPassThrough() {
+        var sm = enterGifSearching()
+        _ = sm.handle(.nameChar("c"))
+        let out = sm.handle(.nameChar("a"))
+        #expect(out.action == .refreshGifPicker(query: "ca"))
+        // Mirrors emoji UX: query is echoed into the focused app too.
+        #expect(out.consumesKey == false)
+        #expect(sm.state == .gifSearching(query: "ca"))
+    }
+
+    @Test func gifQueryAcceptsSpacesAndColons() {
+        var sm = enterGifSearching()
+        _ = sm.handle(.nameChar("a"))
+        let space = sm.handle(.cancelChar(" "))
+        #expect(space.action == .refreshGifPicker(query: "a "))
+        // A colon mid-search is just part of the query, not a new trigger.
+        let colon = sm.handle(.colon)
+        #expect(colon.action == .refreshGifPicker(query: "a :"))
+        #expect(sm.state == .gifSearching(query: "a :"))
+    }
+
+    @Test func gifBackspacePeelsQueryThenClosesOnEmpty() {
+        var sm = enterGifSearching()
+        _ = sm.handle(.nameChar("h"))
+        let peel = sm.handle(.backspace)
+        #expect(peel.action == .refreshGifPicker(query: ""))
+        #expect(sm.state == .gifSearching(query: ""))
+        let close = sm.handle(.backspace)
+        #expect(close.action == .closeGifPicker)
+        #expect(close.consumesKey == false)
+        #expect(sm.state == .idle)
+    }
+
+    @Test func gifReturnPicksAndDeletesTripleColonPlusQuery() {
+        var sm = enterGifSearching()
+        for ch in "dog" { _ = sm.handle(.nameChar(ch)) }
+        let out = sm.handle(.returnKey)
+        // deleteCount = query.count (3) + the three colons typed through.
+        #expect(out.action == .pickGif(deleteCount: 6))
+        #expect(out.consumesKey == true)
+        #expect(sm.state == .idle)
+    }
+
+    @Test func gifTabAlsoPicksWithEmptyQuery() {
+        var sm = enterGifSearching()
+        let out = sm.handle(.tabKey)
+        #expect(out.action == .pickGif(deleteCount: 3))
+        #expect(out.consumesKey == true)
+    }
+
+    @Test func gifEscapeClosesAndConsumes() {
+        var sm = enterGifSearching()
+        let out = sm.handle(.escape)
+        #expect(out.action == .closeGifPicker)
+        #expect(out.consumesKey == true)
+        #expect(sm.state == .idle)
+    }
+
+    @Test func gifArrowsMoveSelectionAndConsume() {
+        var sm = enterGifSearching()
+        #expect(sm.handle(.arrowRight).action == .moveGifSelection(direction: .right))
+        #expect(sm.handle(.arrowLeft).action == .moveGifSelection(direction: .left))
+        #expect(sm.handle(.arrowDown).action == .moveGifSelection(direction: .down))
+        let up = sm.handle(.arrowUp)
+        #expect(up.action == .moveGifSelection(direction: .up))
+        #expect(up.consumesKey == true)
+        // Navigation never leaves the search state.
+        #expect(sm.state == .gifSearching(query: ""))
+    }
+
+    @Test func gifFocusChangeClosesWithoutConsuming() {
+        var sm = enterGifSearching()
+        let out = sm.handle(.focusChange)
+        #expect(out.action == .closeGifPicker)
+        #expect(out.consumesKey == false)
+        #expect(sm.state == .idle)
+    }
+
+    @Test func resumeGifSearchingReentersState() {
+        var sm = enterGifSearching()
+        _ = sm.handle(.returnKey)  // pickGif transitions to idle
+        #expect(sm.state == .idle)
+        // Engine calls this when the picker stayed open (e.g. "Load more").
+        sm.resumeGifSearching(query: "cats")
+        #expect(sm.state == .gifSearching(query: "cats"))
+        let out = sm.handle(.backspace)
+        #expect(out.action == .refreshGifPicker(query: "cat"))
+    }
+
+    // MARK: ambient emoticons (no leading colon)
+
+    @Test func ambientHeartFiresImmediately() {
+        // `<` is punctuation-led, so `<3` fires the moment it completes —
+        // no terminator needed.
+        var sm = TriggerStateMachine()
+        _ = sm.handle(.cancelChar("<"))
+        let out = sm.handle(.nameChar("3"))
+        #expect(out.action == .insertAmbientEmoticon(word: "<3"))
+        #expect(out.consumesKey == false)
+        #expect(sm.state == .idle)
+    }
+
+    @Test func ambientLetterLedWaitsForTerminator() {
+        // `XD` is letter-led — must wait for a terminator so it doesn't eat
+        // into prose like "XDog".
+        var sm = TriggerStateMachine()
+        _ = sm.handle(.nameChar("X"))
+        let mid = sm.handle(.nameChar("D"))
+        #expect(mid.action == .none)
+        let out = sm.handle(.cancelChar(" "))
+        #expect(out.action == .checkAmbientEmoticon(word: "XD", terminator: " "))
+        #expect(out.consumesKey == false)
+    }
+
+    @Test func ambientColonContinuationIsNotHijackedByCapture() {
+        // `>` is a colon-continuation prefix: the `:` after it must extend
+        // the ambient word (`>:)`), NOT start emoji capture.
+        var sm = TriggerStateMachine()
+        _ = sm.handle(.cancelChar(">"))
+        let colon = sm.handle(.colon)
+        #expect(colon.action == .none)
+        #expect(sm.state == .idle)
+        let out = sm.handle(.cancelChar(")"))
+        #expect(out.action == .insertAmbientEmoticon(word: ">:)"))
+    }
+
+    @Test func ambientTerminatorChecksWordThenResetsBuffer() {
+        var sm = TriggerStateMachine()
+        for ch in "hello" { _ = sm.handle(.nameChar(ch)) }
+        let out = sm.handle(.cancelChar(" "))
+        #expect(out.action == .checkAmbientEmoticon(word: "hello", terminator: " "))
+        // Buffer is cleared — a second terminator with nothing buffered
+        // just passes through.
+        let next = sm.handle(.cancelChar(" "))
+        #expect(next.action == .none)
+    }
+
+    // MARK: Cmd+Z
+
+    @Test func cmdZFromIdleRequestsUndo() {
+        var sm = TriggerStateMachine()
+        let out = sm.handle(.cmdZ)
+        #expect(out.action == .maybeUndoEmoticon)
+        #expect(out.consumesKey == false)
+    }
+
+    @Test func cmdZDuringCapturePassesThroughAndKeepsCapture() {
+        var sm = TriggerStateMachine()
+        _ = sm.handle(.colon)
+        _ = sm.handle(.nameChar("f"))
+        let out = sm.handle(.cmdZ)
+        #expect(out.action == .none)
+        #expect(out.consumesKey == false)
+        #expect(sm.state == .capturing(query: "f"))
+    }
+
+    // MARK: symbols-scope backspace demotion
+
+    @Test func symbolsScopeBackspaceDemotesToNormalWithoutEndingCapture() {
+        var sm = TriggerStateMachine()
+        sm.symbolsDoubleColonEnabled = true
+        _ = sm.handle(.colon)
+        _ = sm.handle(.colon)  // → symbolsOnly scope, capturing("")
+        // Backspace on the empty symbols query deletes the 2nd colon and
+        // demotes to normal scope — capture stays open.
+        let out = sm.handle(.backspace)
+        #expect(out.action == .closePicker)
+        // Now in normal scope: threshold rises back to 2, so a single char
+        // doesn't surface the picker.
+        let next = sm.handle(.nameChar("a"))
+        #expect(next.action == .none)
+    }
+
+    // MARK: non-ASCII single-char threshold
+
+    @Test func singleNonASCIICharOpensPickerImmediately() {
+        // A lone CJK/Devanagari/etc. char is a complete word — threshold
+        // drops to 1 so the picker opens on the first keystroke.
+        var sm = TriggerStateMachine()
+        _ = sm.handle(.colon)
+        let out = sm.handle(.nameChar("愛"))
+        #expect(out.action == .openPicker(query: "愛", scope: .normal))
+    }
+
+    // MARK: revival path is currently inert
+
+    @Test func backspaceAfterCancelDoesNotRevivePicker() {
+        // `revivableQuery` is read but never armed in the current source,
+        // so a backspace after a cancel char does NOT re-open the picker.
+        // This test documents the live behaviour; if revival is wired back
+        // up, update it to expect `.refreshPicker`.
+        var sm = TriggerStateMachine()
+        _ = sm.handle(.colon)
+        for ch in "foo" { _ = sm.handle(.nameChar(ch)) }
+        _ = sm.handle(.cancelChar(" "))  // ends capture → idle
+        #expect(sm.state == .idle)
+        let out = sm.handle(.backspace)
+        #expect(out.action == .none)
+        #expect(sm.state == .idle)
+    }
 }


### PR DESCRIPTION
## Summary
- Backfill pure-logic tests for surfaces that had drifted uncovered: the GIF-picker flow and ambient emoticons in `TriggerStateMachine`, plus `FuzzyMatcher` ranking, `AmbientEmoticonTable`, `EmojiDatabase`, and the `ExclusionStore` glob paths (all on CLAUDE.md's "worth testing" list).
- Extract `ExclusionStore`'s host-glob matcher into `nonisolated static` helpers so the regex paths are testable without the `@MainActor` singleton / UserDefaults. Behaviour-preserving — the instance hot path keeps its compiled-pattern cache.
- +69 tests passing (40 in `TriggerStateMachineTests`, 29 across the new suites).

Engine-level consume/passthrough logic (W-219, W-213) is intentionally left to manual testing — it needs a live AX/CGEvent environment. There is no UI/XCUITest target by design.

Surfaced a latent bug while doing this — `TriggerStateMachine.revivableQuery` is dead code (read but never armed). Tracked as W-234.

## Test plan
- [x] `scripts/run-tests.sh` (xcodegen + `xcodebuild test`) green
- [x] New suites run verbosely: 69 pass / 0 fail
- [x] pre-push hook (runs the suite) passed on push

Refs W-221