### PR TITLE
W-264: fix flaky Accessibility permission detection + revoke-time keyboard freeze

### DIFF
--- a/Mojito.xcodeproj/project.pbxproj
+++ b/Mojito.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		2D020B1589F05DA6D532FAD5 /* EggStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F7DB616A5940BE3DE17B77 /* EggStrings.swift */; };
 		304C8571D431917AC25596C3 /* PickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E3A3B5079FC9275F5947104 /* PickerView.swift */; };
 		30C268985E8FC43E95617345 /* OnboardingWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1F4596F8DFA66A87D50D02 /* OnboardingWindowController.swift */; };
+		30D00DD970495E218C74C279 /* AppRelauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B08003428CEFA7AECC2E66 /* AppRelauncher.swift */; };
 		31277ED14E13ADDE2816BB69 /* PickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9E4C2183154C36F1883004 /* PickerViewModel.swift */; };
 		32C650C3EEA85B4276EDB33B /* s10.bin in Resources */ = {isa = PBXBuildFile; fileRef = 73FCCFD6A9499FB84B690194 /* s10.bin */; };
 		340DAC1A3E1A94B6CB4C21D1 /* TextInserter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F34180D15CF8B53F58B2A2 /* TextInserter.swift */; };
@@ -229,6 +230,7 @@
 		7E63ABA27E65953D84162097 /* SolitaireWin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SolitaireWin.swift; sourceTree = "<group>"; };
 		7EB589505841013FF5EF5500 /* ConfettiSound.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfettiSound.swift; sourceTree = "<group>"; };
 		7EE0400354B7B76C1E28F725 /* MojitoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MojitoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		80B08003428CEFA7AECC2E66 /* AppRelauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRelauncher.swift; sourceTree = "<group>"; };
 		83366C0C02EF9F599EC2B65A /* VideoBlob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoBlob.swift; sourceTree = "<group>"; };
 		8616DAC09008096A70541CEE /* v12.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; path = v12.bin; sourceTree = "<group>"; };
 		877AFBCD3CD8EE7B154C73BD /* DefaultExclusions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultExclusions.swift; sourceTree = "<group>"; };
@@ -614,6 +616,7 @@
 			isa = PBXGroup;
 			children = (
 				A1DA7C9FD3286A7839BA642D /* AppInfo.swift */,
+				80B08003428CEFA7AECC2E66 /* AppRelauncher.swift */,
 				A0DE1B7DD5243E817418580C /* AudioBlob.swift */,
 				74DB9192DF20F83CAD8A820C /* ImageBlob.swift */,
 				2C66984ECCB4DB6B1A018452 /* PrefsKey.swift */,
@@ -810,6 +813,7 @@
 				3FDBEFA3636F345D917BE553 /* AppContext.swift in Sources */,
 				87F16A28F58C4854576DD450 /* AppDelegate.swift in Sources */,
 				9CCEA0B70EEB77F988521DDB /* AppInfo.swift in Sources */,
+				30D00DD970495E218C74C279 /* AppRelauncher.swift in Sources */,
 				E41E62A3741D084E3630FDEC /* AudioBlob.swift in Sources */,
 				6F9314FB48040BE582D87716 /* BlueScreen.swift in Sources */,
 				E5C85B09298DAB6F6594B181 /* BouncingDVD.swift in Sources */,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1,13055 +1,13020 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "" : {
-
-    },
-    "%@ couldn't reach the update server." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تعذّر على %@ الوصول إلى خادم التحديثات."
+  "sourceLanguage": "en",
+  "strings": {
+    "": {},
+    "%@ couldn't reach the update server.": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعذّر على %@ الوصول إلى خادم التحديثات."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ konnte den Update-Server nicht erreichen."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ konnte den Update-Server nicht erreichen."
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ couldn't reach the update server."
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ couldn't reach the update server."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ no pudo conectar con el servidor de actualizaciones."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ no pudo conectar con el servidor de actualizaciones."
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ no pudo conectar con el servidor de actualizaciones."
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ no pudo conectar con el servidor de actualizaciones."
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏%@ نتوانست به سرور به‌روزرسانی متصل شود."
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏%@ نتوانست به سرور به‌روزرسانی متصل شود."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ n'a pas pu joindre le serveur de mises à jour."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ n'a pas pu joindre le serveur de mises à jour."
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏%@ לא הצליח להתחבר לשרת העדכונים."
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏%@ לא הצליח להתחבר לשרת העדכונים."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ अपडेट सर्वर तक नहीं पहुँच सका।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ अपडेट सर्वर तक नहीं पहुँच सका।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ non è riuscito a raggiungere il server degli aggiornamenti."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ non è riuscito a raggiungere il server degli aggiornamenti."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ はアップデートサーバーに接続できませんでした。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ はアップデートサーバーに接続できませんでした。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@이(가) 업데이트 서버에 연결할 수 없습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@이(가) 업데이트 서버에 연결할 수 없습니다."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ kon de update-server niet bereiken."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kon de update-server niet bereiken."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ nie mógł połączyć się z serwerem aktualizacji."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ nie mógł połączyć się z serwerem aktualizacji."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ não conseguiu acessar o servidor de atualizações."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ não conseguiu acessar o servidor de atualizações."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ не удалось связаться с сервером обновлений."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ не удалось связаться с сервером обновлений."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 无法连接到更新服务器。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 无法连接到更新服务器。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 無法連線到更新伺服器。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 無法連線到更新伺服器。"
           }
         }
       }
     },
-    "%@ is built to respect your privacy. Here's how." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "صُمِّم %@ لاحترام خصوصيتك. إليك كيف."
+    "%@ is built to respect your privacy. Here's how.": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "صُمِّم %@ لاحترام خصوصيتك. إليك كيف."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ ist auf den Schutz deiner Privatsphäre ausgelegt. So funktioniert's."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ist auf den Schutz deiner Privatsphäre ausgelegt. So funktioniert's."
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ is built to respect your privacy. Here's how."
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ is built to respect your privacy. Here's how."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ está hecho para respetar tu privacidad. Así lo hace."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ está hecho para respetar tu privacidad. Así lo hace."
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ está hecho para respetar tu privacidad. Así lo hace."
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ está hecho para respetar tu privacidad. Así lo hace."
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏%@ برای احترام به حریم خصوصی شما ساخته شده است. به این صورت:"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏%@ برای احترام به حریم خصوصی شما ساخته شده است. به این صورت:"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ est conçu pour respecter votre vie privée. Voici comment."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ est conçu pour respecter votre vie privée. Voici comment."
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏%@ נבנה תוך כיבוד הפרטיות שלך. כך זה עובד."
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏%@ נבנה תוך כיבוד הפרטיות שלך. כך זה עובד."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ आपकी निजता का सम्मान करने के लिए बनाया गया है। यह इस तरह काम करता है।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ आपकी निजता का सम्मान करने के लिए बनाया गया है। यह इस तरह काम करता है।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ è progettato per rispettare la tua privacy. Ecco come."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ è progettato per rispettare la tua privacy. Ecco come."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ はあなたのプライバシーを尊重するように作られています。その仕組みをご紹介します。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ はあなたのプライバシーを尊重するように作られています。その仕組みをご紹介します。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@은(는) 사용자의 개인정보를 존중하도록 만들어졌습니다. 그 방법은 다음과 같습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@은(는) 사용자의 개인정보를 존중하도록 만들어졌습니다. 그 방법은 다음과 같습니다."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ is gebouwd met respect voor je privacy. Zo werkt het."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ is gebouwd met respect voor je privacy. Zo werkt het."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ został zaprojektowany z myślą o twojej prywatności. Oto jak."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ został zaprojektowany z myślą o twojej prywatności. Oto jak."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ foi feito para respeitar sua privacidade. Veja como."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ foi feito para respeitar sua privacidade. Veja como."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ создан с уважением к вашей конфиденциальности. Вот как именно."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ создан с уважением к вашей конфиденциальности. Вот как именно."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 在设计时充分尊重你的隐私。以下是具体方式。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 在设计时充分尊重你的隐私。以下是具体方式。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 設計時就以保護你的隱私為前提。以下是做法。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 設計時就以保護你的隱私為前提。以下是做法。"
           }
         }
       }
     },
-    "%@ is forever free, but your support helps fund future projects. Thank you!" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏%@ مجاني إلى الأبد، لكن دعمك يساعد على تمويل المشاريع المستقبلية. شكراً لك!"
+    "%@ is forever free, but your support helps fund future projects. Thank you!": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏%@ مجاني إلى الأبد، لكن دعمك يساعد على تمويل المشاريع المستقبلية. شكراً لك!"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ bleibt für immer kostenlos – deine Unterstützung hilft aber, zukünftige Projekte zu finanzieren. Danke!"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ bleibt für immer kostenlos – deine Unterstützung hilft aber, zukünftige Projekte zu finanzieren. Danke!"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ is forever free, but your support helps fund future projects. Thank you!"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ is forever free, but your support helps fund future projects. Thank you!"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ es siempre gratis, pero tu apoyo ayuda a financiar futuros proyectos. ¡Gracias!"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ es siempre gratis, pero tu apoyo ayuda a financiar futuros proyectos. ¡Gracias!"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ es siempre gratis, pero tu apoyo ayuda a financiar futuros proyectos. ¡Gracias!"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ es siempre gratis, pero tu apoyo ayuda a financiar futuros proyectos. ¡Gracias!"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏%@ همیشه رایگان است، اما حمایت شما به تأمین مالی پروژه‌های آینده کمک می‌کند. ممنون!"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏%@ همیشه رایگان است، اما حمایت شما به تأمین مالی پروژه‌های آینده کمک می‌کند. ممنون!"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ est gratuit pour toujours, mais votre soutien aide à financer les projets futurs. Merci !"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ est gratuit pour toujours, mais votre soutien aide à financer les projets futurs. Merci !"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏%@ חינמי לתמיד, אבל התמיכה שלך עוזרת לממן פרויקטים עתידיים. תודה!"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏%@ חינמי לתמיד, אבל התמיכה שלך עוזרת לממן פרויקטים עתידיים. תודה!"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ हमेशा मुफ़्त है, लेकिन आपका सहयोग भविष्य की परियोजनाओं को बनाने में मदद करता है। धन्यवाद!"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ हमेशा मुफ़्त है, लेकिन आपका सहयोग भविष्य की परियोजनाओं को बनाने में मदद करता है। धन्यवाद!"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ è gratis per sempre, ma il tuo supporto aiuta a finanziare progetti futuri. Grazie!"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ è gratis per sempre, ma il tuo supporto aiuta a finanziare progetti futuri. Grazie!"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ はずっと無料ですが、あなたのご支援は今後のプロジェクトの資金になります。ありがとうございます！"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ はずっと無料ですが、あなたのご支援は今後のプロジェクトの資金になります。ありがとうございます！"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@은(는) 영원히 무료지만, 후원해 주시면 앞으로의 프로젝트에 큰 힘이 됩니다. 감사합니다!"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@은(는) 영원히 무료지만, 후원해 주시면 앞으로의 프로젝트에 큰 힘이 됩니다. 감사합니다!"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ is voor altijd gratis, maar je steun helpt om toekomstige projecten te financieren. Bedankt!"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ is voor altijd gratis, maar je steun helpt om toekomstige projecten te financieren. Bedankt!"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ jest darmowy na zawsze, ale twoje wsparcie pomaga finansować przyszłe projekty. Dziękuję!"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ jest darmowy na zawsze, ale twoje wsparcie pomaga finansować przyszłe projekty. Dziękuję!"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ é grátis para sempre, mas seu apoio ajuda a financiar projetos futuros. Obrigado!"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ é grátis para sempre, mas seu apoio ajuda a financiar projetos futuros. Obrigado!"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ навсегда бесплатен, но ваша поддержка помогает финансировать будущие проекты. Спасибо!"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ навсегда бесплатен, но ваша поддержка помогает финансировать будущие проекты. Спасибо!"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 永久免费,但你的支持能帮助资助未来的项目。谢谢!"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 永久免费,但你的支持能帮助资助未来的项目。谢谢!"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 永遠免費,但你的支持能幫助贊助未來的專案。謝謝!"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 永遠免費,但你的支持能幫助贊助未來的專案。謝謝!"
           }
         }
       }
     },
-    "%@ is off" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏%@ متوقّف"
+    "%@ is off": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏%@ متوقّف"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ ist aus"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ist aus"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ is off"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ is off"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ está desactivado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ está desactivado"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ está desactivado"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ está desactivado"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏%@ خاموش است"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏%@ خاموش است"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ est désactivé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ est désactivé"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏%@ כבוי"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏%@ כבוי"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ बंद है"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ बंद है"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ è disattivato"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ è disattivato"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ はオフです"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ はオフです"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@이(가) 꺼져 있음"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@이(가) 꺼져 있음"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ is uit"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ is uit"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ jest wyłączony"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ jest wyłączony"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ está desativado"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ está desativado"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ выключен"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ выключен"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 已关闭"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 已关闭"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 已關閉"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 已關閉"
           }
         }
       }
     },
-    "%@ is on" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏%@ مُشغَّل"
+    "%@ is on": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏%@ مُشغَّل"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ ist an"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ist an"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ is on"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ is on"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ está activado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ está activado"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ está activado"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ está activado"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏%@ روشن است"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏%@ روشن است"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ est activé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ est activé"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏%@ פועל"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏%@ פועל"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ चालू है"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ चालू है"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ è attivo"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ è attivo"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ はオンです"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ はオンです"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@이(가) 켜져 있음"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@이(가) 켜져 있음"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ is aan"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ is aan"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ jest włączony"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ jest włączony"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ está ativado"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ está ativado"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ включён"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ включён"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 已开启"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 已开启"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 已開啟"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 已開啟"
           }
         }
       }
     },
-    "%@ is paused" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏%@ موقوف مؤقّتاً"
+    "%@ is paused": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏%@ موقوف مؤقّتاً"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ ist pausiert"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ist pausiert"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ is paused"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ is paused"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ está en pausa"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ está en pausa"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ está en pausa"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ está en pausa"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏%@ متوقّف شده است"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏%@ متوقّف شده است"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ est en pause"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ est en pause"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏%@ מושהה"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏%@ מושהה"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ रोका गया है"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ रोका गया है"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ è in pausa"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ è in pausa"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ は一時停止中です"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ は一時停止中です"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@이(가) 일시 중지됨"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@이(가) 일시 중지됨"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ is gepauzeerd"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ is gepauzeerd"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ jest wstrzymany"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ jest wstrzymany"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ está pausado"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ está pausado"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ приостановлен"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ приостановлен"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 已暂停"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 已暂停"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 已暫停"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 已暫停"
           }
         }
       }
     },
-    "%@ is running 🏃‍♂️" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏%@ يعمل 🏃‍♂️"
+    "%@ is running 🏃‍♂️": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏%@ يعمل 🏃‍♂️"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ läuft 🏃‍♂️"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ läuft 🏃‍♂️"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ is running 🏃‍♂️"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ is running 🏃‍♂️"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ está en marcha 🏃‍♂️"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ está en marcha 🏃‍♂️"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ está en marcha 🏃‍♂️"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ está en marcha 🏃‍♂️"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏%@ در حال اجراست 🏃‍♂️"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏%@ در حال اجراست 🏃‍♂️"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ tourne 🏃‍♂️"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ tourne 🏃‍♂️"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏%@ פועל 🏃‍♂️"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏%@ פועל 🏃‍♂️"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ चल रहा है 🏃‍♂️"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ चल रहा है 🏃‍♂️"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ è in esecuzione 🏃‍♂️"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ è in esecuzione 🏃‍♂️"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ は動作中です 🏃‍♂️"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ は動作中です 🏃‍♂️"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 실행 중 🏃‍♂️"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 실행 중 🏃‍♂️"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ draait 🏃‍♂️"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ draait 🏃‍♂️"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ działa 🏃‍♂️"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ działa 🏃‍♂️"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ está rodando 🏃‍♂️"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ está rodando 🏃‍♂️"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ работает 🏃‍♂️"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ работает 🏃‍♂️"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 正在运行 🏃‍♂️"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 正在运行 🏃‍♂️"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 正在執行 🏃‍♂️"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 正在執行 🏃‍♂️"
           }
         }
       }
     },
-    "%@ lives in your menu bar. Try typing `:tada:` in any text field." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "يعيش %@ في شريط القوائم لديك. جرّب كتابة `:tada:` في أي حقل نصي."
+    "%@ lives in your menu bar. Try typing `:tada:` in any text field.": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يعيش %@ في شريط القوائم لديك. جرّب كتابة `:tada:` في أي حقل نصي."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ wohnt in deiner Menüleiste. Tippe `:tada:` in ein beliebiges Textfeld."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ wohnt in deiner Menüleiste. Tippe `:tada:` in ein beliebiges Textfeld."
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ lives in your menu bar. Try typing `:tada:` in any text field."
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ lives in your menu bar. Try typing `:tada:` in any text field."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ vive en tu barra de menús. Prueba a escribir `:tada:` en cualquier campo de texto."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ vive en tu barra de menús. Prueba a escribir `:tada:` en cualquier campo de texto."
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ vive en tu barra de menús. Probá escribir `:tada:` en cualquier campo de texto."
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ vive en tu barra de menús. Probá escribir `:tada:` en cualquier campo de texto."
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏%@ در نوار منوی شما زندگی می‌کند. در هر فیلد متنی `:tada:` را امتحان کنید."
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏%@ در نوار منوی شما زندگی می‌کند. در هر فیلد متنی `:tada:` را امتحان کنید."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ vit dans votre barre de menus. Essayez de taper `:tada:` dans n'importe quel champ."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ vit dans votre barre de menus. Essayez de taper `:tada:` dans n'importe quel champ."
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏%@ גר בשורת התפריטים שלך. נסה להקליד `:tada:` בכל שדה טקסט."
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏%@ גר בשורת התפריטים שלך. נסה להקליד `:tada:` בכל שדה טקסט."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ आपके मेन्यू बार में रहता है। किसी भी टेक्स्ट फ़ील्ड में `:tada:` टाइप करके देखें।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ आपके मेन्यू बार में रहता है। किसी भी टेक्स्ट फ़ील्ड में `:tada:` टाइप करके देखें।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ vive nella tua barra dei menu. Prova a digitare `:tada:` in un campo di testo."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ vive nella tua barra dei menu. Prova a digitare `:tada:` in un campo di testo."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ はメニューバーに常駐します。任意のテキストフィールドで `:tada:` と入力してみてください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ はメニューバーに常駐します。任意のテキストフィールドで `:tada:` と入力してみてください。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@은(는) 메뉴 막대에서 작동합니다. 아무 텍스트 필드에 `:tada:` 를 입력해 보세요."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@은(는) 메뉴 막대에서 작동합니다. 아무 텍스트 필드에 `:tada:` 를 입력해 보세요."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ woont in je menubalk. Probeer `:tada:` te typen in een tekstveld."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ woont in je menubalk. Probeer `:tada:` te typen in een tekstveld."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ mieszka na pasku menu. Wpisz `:tada:` w dowolne pole tekstowe."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ mieszka na pasku menu. Wpisz `:tada:` w dowolne pole tekstowe."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ mora na sua barra de menus. Experimente digitar `:tada:` em qualquer campo de texto."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ mora na sua barra de menus. Experimente digitar `:tada:` em qualquer campo de texto."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ живёт в строке меню. Попробуйте ввести `:tada:` в любом текстовом поле."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ живёт в строке меню. Попробуйте ввести `:tada:` в любом текстовом поле."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 就在你的菜单栏里。在任何文本框中尝试输入 `:tada:`。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 就在你的菜单栏里。在任何文本框中尝试输入 `:tada:`。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 就在你的選單列裡。在任何文字輸入框試試輸入 `:tada:`。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 就在你的選單列裡。在任何文字輸入框試試輸入 `:tada:`。"
           }
         }
       }
     },
-    "%@ needs permission" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "يحتاج %@ إلى إذن"
+    "%@ needs permission": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يحتاج %@ إلى إذن"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ benötigt eine Berechtigung"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ benötigt eine Berechtigung"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ needs permission"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ needs permission"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ necesita permisos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ necesita permisos"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ necesita permisos"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ necesita permisos"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏%@ به اجازه نیاز دارد"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏%@ به اجازه نیاز دارد"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ a besoin d'une autorisation"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ a besoin d'une autorisation"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏%@ זקוק להרשאה"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏%@ זקוק להרשאה"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ को अनुमति चाहिए"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ को अनुमति चाहिए"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ necessita di permessi"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ necessita di permessi"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ には権限が必要です"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ には権限が必要です"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@에 권한이 필요합니다"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@에 권한이 필요합니다"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ heeft toestemming nodig"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ heeft toestemming nodig"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ wymaga uprawnień"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ wymaga uprawnień"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ precisa de permissão"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ precisa de permissão"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ требуются разрешения"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ требуются разрешения"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 需要权限"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 需要权限"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 需要權限"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 需要權限"
           }
         }
       }
     },
-    "%@ needs permission to work with your keyboard." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "يحتاج %@ إلى إذن للعمل مع لوحة المفاتيح."
+    "%@ needs permission to work with your keyboard.": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يحتاج %@ إلى إذن للعمل مع لوحة المفاتيح."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ benötigt eine Berechtigung, um mit deiner Tastatur zu arbeiten."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ benötigt eine Berechtigung, um mit deiner Tastatur zu arbeiten."
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ needs permission to work with your keyboard."
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ needs permission to work with your keyboard."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ necesita permisos para funcionar con tu teclado."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ necesita permisos para funcionar con tu teclado."
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ necesita permisos para funcionar con tu teclado."
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ necesita permisos para funcionar con tu teclado."
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏%@ برای کار با صفحه‌کلید شما به اجازه نیاز دارد."
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏%@ برای کار با صفحه‌کلید شما به اجازه نیاز دارد."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ a besoin d'une autorisation pour fonctionner avec votre clavier."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ a besoin d'une autorisation pour fonctionner avec votre clavier."
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏%@ זקוק להרשאה כדי לפעול עם המקלדת שלך."
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏%@ זקוק להרשאה כדי לפעול עם המקלדת שלך."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "आपके कीबोर्ड के साथ काम करने के लिए %@ को अनुमति चाहिए।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आपके कीबोर्ड के साथ काम करने के लिए %@ को अनुमति चाहिए।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ necessita di permessi per funzionare con la tua tastiera."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ necessita di permessi per funzionare con la tua tastiera."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ がキーボードと連携するには権限が必要です。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ がキーボードと連携するには権限が必要です。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@이(가) 키보드와 함께 작동하려면 권한이 필요합니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@이(가) 키보드와 함께 작동하려면 권한이 필요합니다."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ heeft toestemming nodig om met je toetsenbord te werken."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ heeft toestemming nodig om met je toetsenbord te werken."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ wymaga uprawnień do pracy z twoją klawiaturą."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ wymaga uprawnień do pracy z twoją klawiaturą."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ precisa de permissão para funcionar com seu teclado."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ precisa de permissão para funcionar com seu teclado."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ требуются разрешения для работы с клавиатурой."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ требуются разрешения для работы с клавиатурой."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 需要权限才能与键盘配合工作。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 需要权限才能与键盘配合工作。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 需要權限才能與鍵盤搭配運作。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 需要權限才能與鍵盤搭配運作。"
           }
         }
       }
     },
-    "%lld of %lld" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld من %2$lld"
+    "%lld of %lld": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld من %2$lld"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld von %2$lld"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld von %2$lld"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$lld of %2$lld"
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$lld of %2$lld"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld of %2$lld"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld of %2$lld"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld de %2$lld"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld de %2$lld"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld de %2$lld"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld de %2$lld"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld از %2$lld"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld از %2$lld"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld sur %2$lld"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld sur %2$lld"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld מתוך %2$lld"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld מתוך %2$lld"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%2$lld में से %1$lld"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$lld में से %1$lld"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld su %2$lld"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld su %2$lld"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%2$lld 中 %1$lld"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$lld 中 %1$lld"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%2$lld개 중 %1$lld개"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$lld개 중 %1$lld개"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld van %2$lld"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld van %2$lld"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld z %2$lld"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld z %2$lld"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld de %2$lld"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld de %2$lld"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld из %2$lld"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld из %2$lld"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%2$lld 中的 %1$lld"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$lld 中的 %1$lld"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%2$lld 中的 %1$lld"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$lld 中的 %1$lld"
           }
         }
       }
     },
-    "???" : {
-      "comment" : "Placeholder shown in About → Easter eggs for an entry the user hasn't discovered yet. Should stay short and visually act as 'three unknowns'.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "؟؟؟"
+    "???": {
+      "comment": "Placeholder shown in About → Easter eggs for an entry the user hasn't discovered yet. Should stay short and visually act as 'three unknowns'.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "؟؟؟"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "???"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "???"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "???"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "???"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "???"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "???"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "???"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "???"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "؟؟؟"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "؟؟؟"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "???"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "???"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "???"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "???"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "???"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "???"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "???"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "???"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "???"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "???"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "???"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "???"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "???"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "???"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "???"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "???"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "???"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "???"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "???"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "???"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "???"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "???"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "???"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "???"
           }
         }
       }
     },
-    "About" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "حول"
+    "About": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حول"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Über"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Über"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "About"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "About"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acerca de"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acerca de"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acerca de"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acerca de"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "درباره"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "درباره"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "À propos"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "À propos"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "אודות"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אודות"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "बारे में"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बारे में"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Informazioni"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informazioni"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "情報"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "情報"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "정보"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "정보"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Over"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Over"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Informacje"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informacje"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sobre"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sobre"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "О программе"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "О программе"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "关于"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关于"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "關於"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "關於"
           }
         }
       }
     },
-    "Accessibility" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إمكانية الوصول"
+    "Accessibility": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إمكانية الوصول"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bedienungshilfen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bedienungshilfen"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accessibility"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accessibility"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accesibilidad"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accesibilidad"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accesibilidad"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accesibilidad"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "دسترس‌پذیری"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "دسترس‌پذیری"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accessibilité"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accessibilité"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "נגישות"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "נגישות"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ऐक्सेसिबिलिटी"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ऐक्सेसिबिलिटी"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accessibilità"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accessibilità"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アクセシビリティ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アクセシビリティ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "손쉬운 사용"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "손쉬운 사용"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toegankelijkheid"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toegankelijkheid"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dostępność"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dostępność"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acessibilidade"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acessibilidade"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Универсальный доступ"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Универсальный доступ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "辅助功能"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "辅助功能"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "輔助使用"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輔助使用"
           }
         }
       }
     },
-    "Acknowledgements" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "شُكر وتقدير"
+    "Acknowledgements": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "شُكر وتقدير"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Danksagungen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Danksagungen"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acknowledgements"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acknowledgements"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agradecimientos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agradecimientos"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agradecimientos"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agradecimientos"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تقدیر و تشکر"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تقدیر و تشکر"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remerciements"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remerciements"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "תודות"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "תודות"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "आभार"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आभार"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ringraziamenti"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ringraziamenti"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "謝辞"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "謝辞"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "감사의 말"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "감사의 말"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Met dank aan"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Met dank aan"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Podziękowania"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Podziękowania"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agradecimentos"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agradecimentos"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Благодарности"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Благодарности"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "鸣谢"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鸣谢"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "致謝"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "致謝"
           }
         }
       }
     },
-    "Add" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إضافة"
+    "Add": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إضافة"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hinzufügen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hinzufügen"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Añadir"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Añadir"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agregar"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "افزودن"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "افزودن"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajouter"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajouter"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "הוסף"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הוסף"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "जोड़ें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "जोड़ें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiungi"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiungi"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "追加"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "追加"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "추가"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "추가"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voeg toe"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voeg toe"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dodaj"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dodaj"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adicionar"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicionar"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Добавить"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Добавить"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "添加"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "加入"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "加入"
           }
         }
       }
     },
-    "Add a Giphy API key to enable GIF search." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "أضف مفتاح Giphy API لتفعيل البحث عن GIF."
+    "Add a Giphy API key to enable GIF search.": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أضف مفتاح Giphy API لتفعيل البحث عن GIF."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Füge einen Giphy-API-Schlüssel hinzu, um die GIF-Suche zu aktivieren."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Füge einen Giphy-API-Schlüssel hinzu, um die GIF-Suche zu aktivieren."
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add a Giphy API key to enable GIF search."
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add a Giphy API key to enable GIF search."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Añade una clave de la API de Giphy para activar la búsqueda de GIF."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Añade una clave de la API de Giphy para activar la búsqueda de GIF."
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agregá una clave de la API de Giphy para activar la búsqueda de GIF."
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregá una clave de la API de Giphy para activar la búsqueda de GIF."
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "برای فعال‌سازی جست‌وجوی GIF، یک کلید API Giphy اضافه کنید."
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "برای فعال‌سازی جست‌وجوی GIF، یک کلید API Giphy اضافه کنید."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajoute une clé d'API Giphy pour activer la recherche de GIF."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajoute une clé d'API Giphy pour activer la recherche de GIF."
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "הוסף מפתח Giphy API כדי להפעיל חיפוש GIF."
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הוסף מפתח Giphy API כדי להפעיל חיפוש GIF."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF खोज सक्षम करने के लिए Giphy API कुंजी जोड़ें।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF खोज सक्षम करने के लिए Giphy API कुंजी जोड़ें।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiungi una chiave API di Giphy per attivare la ricerca di GIF."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiungi una chiave API di Giphy per attivare la ricerca di GIF."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF 検索を有効にするには、Giphy の API キーを追加してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF 検索を有効にするには、Giphy の API キーを追加してください。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF 검색을 사용하려면 Giphy API 키를 추가하세요."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF 검색을 사용하려면 Giphy API 키를 추가하세요."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voeg een Giphy API-sleutel toe om GIF-zoeken aan te zetten."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voeg een Giphy API-sleutel toe om GIF-zoeken aan te zetten."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dodaj klucz API Giphy, aby włączyć wyszukiwanie GIF-ów."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dodaj klucz API Giphy, aby włączyć wyszukiwanie GIF-ów."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adicione uma chave da API do Giphy para ativar a busca de GIF."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicione uma chave da API do Giphy para ativar a busca de GIF."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Добавьте ключ API Giphy, чтобы включить поиск GIF."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Добавьте ключ API Giphy, чтобы включить поиск GIF."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "添加 Giphy API 密钥以启用 GIF 搜索。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加 Giphy API 密钥以启用 GIF 搜索。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "新增 Giphy API 金鑰以啟用 GIF 搜尋。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新增 Giphy API 金鑰以啟用 GIF 搜尋。"
           }
         }
       }
     },
-    "Add website" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إضافة موقع"
+    "Add website": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إضافة موقع"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Website hinzufügen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Website hinzufügen"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add website"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add website"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Añadir sitio web"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Añadir sitio web"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agregar sitio web"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar sitio web"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "افزودن وب‌سایت"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "افزودن وب‌سایت"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajouter un site web"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajouter un site web"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "הוסף אתר"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הוסף אתר"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "वेबसाइट जोड़ें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "वेबसाइट जोड़ें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiungi sito web"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiungi sito web"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ウェブサイトを追加"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ウェブサイトを追加"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "웹사이트 추가"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "웹사이트 추가"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Website toevoegen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Website toevoegen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dodaj witrynę"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dodaj witrynę"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adicionar site"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicionar site"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Добавить сайт"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Добавить сайт"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "添加网站"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加网站"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "加入網站"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "加入網站"
           }
         }
       }
     },
-    "All the code is on GitHub. Read it, build it, fork it." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "كل الكود موجود على GitHub. اقرأه، اِبنه، فُرّعه."
+    "All the code is on GitHub. Read it, build it, fork it.": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "كل الكود موجود على GitHub. اقرأه، اِبنه، فُرّعه."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der gesamte Code liegt auf GitHub. Lies ihn, baue ihn, forke ihn."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der gesamte Code liegt auf GitHub. Lies ihn, baue ihn, forke ihn."
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "All the code is on GitHub. Read it, build it, fork it."
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All the code is on GitHub. Read it, build it, fork it."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Todo el código está en GitHub. Léelo, compílalo, bifúrcalo."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todo el código está en GitHub. Léelo, compílalo, bifúrcalo."
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Todo el código está en GitHub. Leelo, compilalo, bifurcalo."
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todo el código está en GitHub. Leelo, compilalo, bifurcalo."
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "همهٔ کد در GitHub است. بخوانید، بسازید، فورک کنید."
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "همهٔ کد در GitHub است. بخوانید، بسازید، فورک کنید."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tout le code est sur GitHub. Lisez-le, compilez-le, forkez-le."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout le code est sur GitHub. Lisez-le, compilez-le, forkez-le."
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "כל הקוד נמצא ב-GitHub. קרא, בנה, פצל לפורק."
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "כל הקוד נמצא ב-GitHub. קרא, בנה, פצל לפורק."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "सारा कोड GitHub पर है। पढ़ें, बिल्ड करें, फ़ोर्क करें।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सारा कोड GitHub पर है। पढ़ें, बिल्ड करें, फ़ोर्क करें।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tutto il codice è su GitHub. Leggilo, compilalo, fai un fork."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tutto il codice è su GitHub. Leggilo, compilalo, fai un fork."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "すべてのコードは GitHub にあります。読んで、ビルドして、フォークしてください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべてのコードは GitHub にあります。読んで、ビルドして、フォークしてください。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "모든 코드는 GitHub에 있습니다. 읽고, 빌드하고, 포크하세요."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모든 코드는 GitHub에 있습니다. 읽고, 빌드하고, 포크하세요."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alle code staat op GitHub. Lees het, bouw het, fork het."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle code staat op GitHub. Lees het, bouw het, fork het."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cały kod jest na GitHubie. Czytaj, buduj, forkuj."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cały kod jest na GitHubie. Czytaj, buduj, forkuj."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Todo o código está no GitHub. Leia, compile, faça um fork."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todo o código está no GitHub. Leia, compile, faça um fork."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Весь код — на GitHub. Читайте, собирайте, форкайте."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Весь код — на GitHub. Читайте, собирайте, форкайте."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "所有代码都在 GitHub 上。读它、构建它、fork 它。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所有代码都在 GitHub 上。读它、构建它、fork 它。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "所有原始碼都在 GitHub 上。閱讀、建置、fork 隨你便。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所有原始碼都在 GitHub 上。閱讀、建置、fork 隨你便。"
           }
         }
       }
     },
-    "Allow" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "السماح"
+    "Allow": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "السماح"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erlauben"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erlauben"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allow"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اجازه دادن"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اجازه دادن"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autoriser"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autoriser"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "אפשר"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אפשר"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "अनुमति दें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अनुमति दें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Consenti"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consenti"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "許可"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "許可"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "허용"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "허용"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sta toe"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sta toe"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zezwól"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zezwól"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Разрешить"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разрешить"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "允许"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "允许"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "允許"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "允許"
           }
         }
       }
     },
-    "Already allowed but still not detected?" : {
-
-    },
-    "Anchors the picker next to your text cursor." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "يثبّت أداة الاختيار بجوار مؤشر النص."
+    "Anchors the picker next to your text cursor.": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يثبّت أداة الاختيار بجوار مؤشر النص."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verankert den Picker neben deinem Textcursor."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verankert den Picker neben deinem Textcursor."
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anchors the picker next to your text cursor."
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anchors the picker next to your text cursor."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ancla el selector junto al cursor de texto."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ancla el selector junto al cursor de texto."
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ancla el selector junto al cursor de texto."
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ancla el selector junto al cursor de texto."
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "انتخابگر را کنار مکان‌نمای متن قرار می‌دهد."
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "انتخابگر را کنار مکان‌نمای متن قرار می‌دهد."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ancre le sélecteur à côté de votre curseur de texte."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ancre le sélecteur à côté de votre curseur de texte."
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "מעגן את הבורר ליד סמן הטקסט."
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מעגן את הבורר ליד סמן הטקסט."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "पिकर को आपके टेक्स्ट कर्सर के बगल में जोड़ता है।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पिकर को आपके टेक्स्ट कर्सर के बगल में जोड़ता है।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Àncora il selettore accanto al cursore di testo."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Àncora il selettore accanto al cursore di testo."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ピッカーをテキストカーソルの隣に固定します。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ピッカーをテキストカーソルの隣に固定します。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "선택기를 텍스트 커서 옆에 고정합니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택기를 텍스트 커서 옆에 고정합니다."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verankert de kiezer naast je tekstcursor."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verankert de kiezer naast je tekstcursor."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Umieszcza okno wyboru obok kursora tekstu."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Umieszcza okno wyboru obok kursora tekstu."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ancora o seletor ao lado do cursor de texto."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ancora o seletor ao lado do cursor de texto."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Закрепляет окно подбора рядом с текстовым курсором."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Закрепляет окно подбора рядом с текстовым курсором."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将选取器锚定在文本光标旁。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将选取器锚定在文本光标旁。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "將選取器固定在文字游標旁邊。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "將選取器固定在文字游標旁邊。"
           }
         }
       }
     },
-    "Autocomplete `:emoji:` everywhere." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الإكمال التلقائي لـ `:emoji:` في كل مكان."
+    "Autocomplete `:emoji:` everywhere.": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الإكمال التلقائي لـ `:emoji:` في كل مكان."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "`:emoji:` überall automatisch vervollständigen."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "`:emoji:` überall automatisch vervollständigen."
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autocomplete `:emoji:` everywhere."
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autocomplete `:emoji:` everywhere."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autocompleta `:emoji:` en todas partes."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autocompleta `:emoji:` en todas partes."
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autocompleta `:emoji:` en todas partes."
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autocompleta `:emoji:` en todas partes."
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تکمیل خودکار `:emoji:` همه‌جا."
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تکمیل خودکار `:emoji:` همه‌جا."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autocomplétez `:emoji:` partout."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autocomplétez `:emoji:` partout."
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "השלמה אוטומטית של `:emoji:` בכל מקום."
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "השלמה אוטומטית של `:emoji:` בכל מקום."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "हर जगह `:emoji:` ऑटोकम्प्लीट करें।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हर जगह `:emoji:` ऑटोकम्प्लीट करें।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Completamento automatico di `:emoji:` ovunque."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Completamento automatico di `:emoji:` ovunque."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "どこでも `:emoji:` を自動補完。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "どこでも `:emoji:` を自動補完。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "어디서나 `:emoji:` 자동 완성."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "어디서나 `:emoji:` 자동 완성."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autocomplete `:emoji:` overal."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autocomplete `:emoji:` overal."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autouzupełnianie `:emoji:` wszędzie."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autouzupełnianie `:emoji:` wszędzie."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autocompletar `:emoji:` em qualquer lugar."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autocompletar `:emoji:` em qualquer lugar."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Автодополнение `:emoji:` где угодно."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Автодополнение `:emoji:` где угодно."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "随处自动补全 `:emoji:`。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "随处自动补全 `:emoji:`。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "到處都能自動完成 `:emoji:`。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "到處都能自動完成 `:emoji:`。"
           }
         }
       }
     },
-    "Automatic updates" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "التحديثات التلقائية"
+    "Automatic updates": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التحديثات التلقائية"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatische Updates"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatische Updates"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatic updates"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatic updates"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actualizaciones automáticas"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizaciones automáticas"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actualizaciones automáticas"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizaciones automáticas"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "به‌روزرسانی خودکار"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "به‌روزرسانی خودکار"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mises à jour automatiques"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mises à jour automatiques"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "עדכונים אוטומטיים"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "עדכונים אוטומטיים"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "स्वचालित अपडेट"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "स्वचालित अपडेट"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiornamenti automatici"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiornamenti automatici"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自動アップデート"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動アップデート"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "자동 업데이트"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "자동 업데이트"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatische updates"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatische updates"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatyczne aktualizacje"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatyczne aktualizacje"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atualizações automáticas"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizações automáticas"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Автоматические обновления"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Автоматические обновления"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自动更新"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动更新"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自動更新"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動更新"
           }
         }
       }
     },
-    "Back" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "رجوع"
+    "Back": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "رجوع"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zurück"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zurück"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Back"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Back"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atrás"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atrás"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atrás"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atrás"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "بازگشت"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بازگشت"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retour"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retour"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "חזרה"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "חזרה"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "पीछे"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पीछे"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Indietro"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indietro"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "戻る"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "戻る"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "뒤로"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "뒤로"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terug"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terug"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wstecz"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wstecz"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voltar"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voltar"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Назад"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Назад"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "返回"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "返回"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "返回"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "返回"
           }
         }
       }
     },
-    "Cancel" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إلغاء"
+    "Cancel": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إلغاء"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abbrechen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abbrechen"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لغو"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لغو"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuler"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuler"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ביטול"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ביטול"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "रद्द करें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "रद्द करें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annulla"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annulla"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "キャンセル"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャンセル"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "취소"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "취소"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuleer"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuleer"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anuluj"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anuluj"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отмена"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отмена"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
           }
         }
       }
     },
-    "Check for Updates…" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "التحقّق من التحديثات…"
+    "Check for Updates…": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التحقّق من التحديثات…"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auf Updates prüfen…"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auf Updates prüfen…"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Check for Updates…"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check for Updates…"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscar actualizaciones…"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar actualizaciones…"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscar actualizaciones…"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar actualizaciones…"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "بررسی به‌روزرسانی‌ها…"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بررسی به‌روزرسانی‌ها…"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rechercher les mises à jour…"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher les mises à jour…"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "בדוק עדכונים…"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "בדוק עדכונים…"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "अपडेट देखें…"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अपडेट देखें…"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cerca aggiornamenti…"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerca aggiornamenti…"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アップデートを確認…"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップデートを確認…"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "업데이트 확인…"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "업데이트 확인…"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zoek naar updates…"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zoek naar updates…"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sprawdź aktualizacje…"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprawdź aktualizacje…"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificar atualizações…"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificar atualizações…"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Проверить обновления…"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверить обновления…"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "检查更新…"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查更新…"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "檢查更新…"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "檢查更新…"
           }
         }
       }
     },
-    "Check now" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "التحقّق الآن"
+    "Check now": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التحقّق الآن"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jetzt prüfen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jetzt prüfen"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Check now"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check now"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscar ahora"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar ahora"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscar ahora"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar ahora"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "بررسی کن"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بررسی کن"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vérifier maintenant"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérifier maintenant"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "בדוק עכשיו"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "בדוק עכשיו"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "अभी देखें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अभी देखें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cerca ora"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerca ora"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "今すぐ確認"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今すぐ確認"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "지금 확인"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지금 확인"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Controleer nu"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Controleer nu"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sprawdź teraz"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprawdź teraz"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificar agora"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificar agora"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Проверить сейчас"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверить сейчас"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "立即检查"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "立即检查"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "立即檢查"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "立即檢查"
           }
         }
       }
     },
-    "Clear all emoji usage stats?" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "هل تريد مسح كل إحصاءات استخدام الإيموجي؟"
+    "Clear all emoji usage stats?": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "هل تريد مسح كل إحصاءات استخدام الإيموجي؟"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alle Emoji-Nutzungsstatistiken löschen?"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle Emoji-Nutzungsstatistiken löschen?"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clear all emoji usage stats?"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear all emoji usage stats?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Borrar todas las estadísticas de uso de emoji?"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Borrar todas las estadísticas de uso de emoji?"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Borrar todas las estadísticas de uso de emojis?"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Borrar todas las estadísticas de uso de emojis?"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "همهٔ آمار استفاده از ایموجی پاک شود؟"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "همهٔ آمار استفاده از ایموجی پاک شود؟"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Effacer toutes les statistiques d'utilisation des emoji ?"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effacer toutes les statistiques d'utilisation des emoji ?"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "לנקות את כל סטטיסטיקות השימוש באימוג'י?"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "לנקות את כל סטטיסטיקות השימוש באימוג'י?"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "क्या सभी इमोजी उपयोग आँकड़े हटा दें?"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "क्या सभी इमोजी उपयोग आँकड़े हटा दें?"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vuoi cancellare tutte le statistiche di utilizzo delle emoji?"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vuoi cancellare tutte le statistiche di utilizzo delle emoji?"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "すべての絵文字使用統計を削除しますか?"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべての絵文字使用統計を削除しますか?"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "모든 이모지 사용 통계를 지울까요?"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모든 이모지 사용 통계를 지울까요?"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alle emoji-statistieken wissen?"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle emoji-statistieken wissen?"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wyczyścić wszystkie statystyki użycia emoji?"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wyczyścić wszystkie statystyki użycia emoji?"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apagar todas as estatísticas de uso de emoji?"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apagar todas as estatísticas de uso de emoji?"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Очистить всю статистику использования эмодзи?"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Очистить всю статистику использования эмодзи?"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "清除所有 emoji 使用统计?"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除所有 emoji 使用统计?"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "清除所有 emoji 使用統計?"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除所有 emoji 使用統計?"
           }
         }
       }
     },
-    "Clear stats" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "مسح الإحصاءات"
+    "Clear stats": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مسح الإحصاءات"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Statistiken löschen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistiken löschen"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clear stats"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear stats"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Borrar estadísticas"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar estadísticas"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Borrar estadísticas"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar estadísticas"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "پاک‌کردن آمار"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پاک‌کردن آمار"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Effacer les stats"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effacer les stats"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "נקה סטטיסטיקות"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "נקה סטטיסטיקות"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "आँकड़े हटाएँ"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आँकड़े हटाएँ"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancella statistiche"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancella statistiche"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "統計を削除"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "統計を削除"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "통계 지우기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "통계 지우기"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wis statistieken"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wis statistieken"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wyczyść statystyki"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wyczyść statystyki"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apagar estatísticas"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apagar estatísticas"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Очистить статистику"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Очистить статистику"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "清除统计"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除统计"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "清除統計"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除統計"
           }
         }
       }
     },
-    "Clear stats..." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "مسح الإحصاءات…"
+    "Clear stats...": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مسح الإحصاءات…"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Statistiken löschen…"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistiken löschen…"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clear stats…"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear stats…"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Borrar estadísticas…"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar estadísticas…"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Borrar estadísticas…"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar estadísticas…"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "پاک‌کردن آمار…"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پاک‌کردن آمار…"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Effacer les stats…"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effacer les stats…"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "נקה סטטיסטיקות…"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "נקה סטטיסטיקות…"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "आँकड़े हटाएँ…"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आँकड़े हटाएँ…"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancella statistiche…"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancella statistiche…"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "統計を削除…"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "統計を削除…"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "통계 지우기…"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "통계 지우기…"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wis statistieken…"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wis statistieken…"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wyczyść statystyki…"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wyczyść statystyki…"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apagar estatísticas…"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apagar estatísticas…"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Очистить статистику…"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Очистить статистику…"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "清除统计…"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除统计…"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "清除統計…"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除統計…"
           }
         }
       }
-    },
-    "Close" : {
-
     },
-    "Continue" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "متابعة"
+    "Continue": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "متابعة"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weiter"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weiter"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continue"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continuar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuar"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continuar"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuar"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ادامه"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ادامه"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continuer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuer"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "המשך"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "המשך"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "जारी रखें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "जारी रखें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continua"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continua"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "続ける"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "続ける"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "계속"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "계속"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ga door"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ga door"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kontynuuj"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kontynuuj"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continuar"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuar"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Продолжить"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Продолжить"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "继续"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "继续"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "繼續"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "繼續"
           }
         }
       }
     },
-    "Convert emoticons (`:D` → 😃)" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تحويل الرموز التعبيرية النصّية (`:D` → 😃)"
+    "Convert emoticons (`:D` → 😃)": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تحويل الرموز التعبيرية النصّية (`:D` → 😃)"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Emoticons umwandeln (`:D` → 😃)"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoticons umwandeln (`:D` → 😃)"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Convert emoticons (`:D` → 😃)"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Convert emoticons (`:D` → 😃)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Convertir emoticonos (`:D` → 😃)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Convertir emoticonos (`:D` → 😃)"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Convertir emoticones (`:D` → 😃)"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Convertir emoticones (`:D` → 😃)"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تبدیل شکلک‌ها (`:D` → 😃)"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تبدیل شکلک‌ها (`:D` → 😃)"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Convertir les émoticônes (`:D` → 😃)"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Convertir les émoticônes (`:D` → 😃)"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "המר אמוטיקונים (`:D` → 😃)"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "המר אמוטיקונים (`:D` → 😃)"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "इमोटिकॉन बदलें (`:D` → 😃)"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "इमोटिकॉन बदलें (`:D` → 😃)"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Converti le emoticon (`:D` → 😃)"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Converti le emoticon (`:D` → 😃)"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "顔文字を変換 (`:D` → 😃)"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顔文字を変換 (`:D` → 😃)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이모티콘 변환 (`:D` → 😃)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이모티콘 변환 (`:D` → 😃)"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zet emoticons om (`:D` → 😃)"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zet emoticons om (`:D` → 😃)"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konwertuj emotikony (`:D` → 😃)"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konwertuj emotikony (`:D` → 😃)"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Converter emoticons (`:D` → 😃)"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Converter emoticons (`:D` → 😃)"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Преобразовывать эмотиконы (`:D` → 😃)"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Преобразовывать эмотиконы (`:D` → 😃)"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "转换颜文字 (`:D` → 😃)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "转换颜文字 (`:D` → 😃)"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "轉換顏文字 (`:D` → 😃)"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "轉換顏文字 (`:D` → 😃)"
           }
         }
       }
     },
-    "Copied!" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تم النسخ!"
+    "Copied!": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تم النسخ!"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kopiert!"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiert!"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copied!"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copied!"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¡Copiado!"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¡Copiado!"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¡Copiado!"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¡Copiado!"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "کپی شد!"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کپی شد!"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copié !"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copié !"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "הועתק!"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הועתק!"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "कॉपी हो गया!"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कॉपी हो गया!"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copiato!"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiato!"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "コピーしました!"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コピーしました!"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "복사됨!"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "복사됨!"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gekopieerd!"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gekopieerd!"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skopiowano!"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skopiowano!"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copiado!"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiado!"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Скопировано!"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скопировано!"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已复制!"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已复制!"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已複製!"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已複製!"
           }
         }
       }
     },
-    "Copy" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "نسخ"
+    "Copy": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسخ"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kopieren"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopieren"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copy"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copiar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copiar"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "کپی"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کپی"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copier"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copier"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "העתק"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "העתק"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "कॉपी करें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कॉपी करें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copia"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copia"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "コピー"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コピー"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "복사"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "복사"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kopieer"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopieer"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kopiuj"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiuj"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copiar"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Копировать"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Копировать"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "复制"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "複製"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製"
           }
         }
       }
     },
-    "Copy debug info" : {
-
-    },
-    "Couldn't reach Giphy." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تعذّر الوصول إلى Giphy."
+    "Couldn't reach Giphy.": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعذّر الوصول إلى Giphy."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy nicht erreichbar."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy nicht erreichbar."
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't reach Giphy."
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't reach Giphy."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo conectar con Giphy."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo conectar con Giphy."
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo conectar con Giphy."
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo conectar con Giphy."
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اتصال به Giphy ممکن نشد."
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اتصال به Giphy ممکن نشد."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible de joindre Giphy."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de joindre Giphy."
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "לא ניתן להתחבר ל-Giphy."
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "לא ניתן להתחבר ל-Giphy."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy तक नहीं पहुँचा जा सका।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy तक नहीं पहुँचा जा सका।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossibile raggiungere Giphy."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile raggiungere Giphy."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy に接続できませんでした。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy に接続できませんでした。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy에 연결할 수 없습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy에 연결할 수 없습니다."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kon Giphy niet bereiken."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kon Giphy niet bereiken."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nie udało się połączyć z Giphy."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie udało się połączyć z Giphy."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Não foi possível acessar o Giphy."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não foi possível acessar o Giphy."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не удалось связаться с Giphy."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось связаться с Giphy."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法连接到 Giphy。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法连接到 Giphy。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無法連線到 Giphy。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法連線到 Giphy。"
           }
         }
       }
     },
-    "Danger zone" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "منطقة الخطر"
+    "Danger zone": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "منطقة الخطر"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gefahrenzone"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gefahrenzone"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Danger zone"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Danger zone"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zona peligrosa"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zona peligrosa"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zona peligrosa"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zona peligrosa"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "منطقهٔ خطر"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "منطقهٔ خطر"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zone à risque"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zone à risque"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "אזור מסוכן"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אזור מסוכן"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ख़तरे का क्षेत्र"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ख़तरे का क्षेत्र"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zona pericolosa"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zona pericolosa"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "危険な操作"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "危険な操作"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "주의 영역"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "주의 영역"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gevaarlijke zone"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gevaarlijke zone"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Strefa ryzyka"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Strefa ryzyka"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zona de risco"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zona de risco"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Опасная зона"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Опасная зона"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "危险区域"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "危险区域"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "危險區域"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "危險區域"
           }
         }
       }
     },
-    "Donate" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تبرّع"
+    "Donate": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تبرّع"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spenden"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spenden"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Donate"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Donate"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Donar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Donar"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Donar"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Donar"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "حمایت"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حمایت"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Faire un don"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Faire un don"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "תרום"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "תרום"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "दान करें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "दान करें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dona"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dona"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "寄付する"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "寄付する"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "후원"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "후원"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Doneer"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Doneer"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wpłać"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wpłać"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Doar"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Doar"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Поддержать"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поддержать"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "捐赠"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "捐赠"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "贊助"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "贊助"
           }
         }
       }
     },
-    "Done" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تم"
+    "Done": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تم"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fertig"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fertig"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Done"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Done"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hecho"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hecho"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Listo"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Listo"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تمام"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تمام"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminé"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "סיום"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "סיום"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "हो गया"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हो गया"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fatto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fatto"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "完了"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完了"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "완료"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "완료"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Klaar"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klaar"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gotowe"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gotowe"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Concluído"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Concluído"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Готово"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Готово"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "完成"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完成"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "完成"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完成"
           }
         }
       }
     },
-    "Easter egg discovered" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تم اكتشاف بيضة مفاجِئة"
+    "Easter egg discovered": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تم اكتشاف بيضة مفاجِئة"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Easter Egg entdeckt"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Easter Egg entdeckt"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Easter egg discovered"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Easter egg discovered"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Huevo de pascua descubierto"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Huevo de pascua descubierto"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Huevo de pascua descubierto"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Huevo de pascua descubierto"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تخم‌مرغ نوروزی پیدا شد"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تخم‌مرغ نوروزی پیدا شد"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Easter egg découvert"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Easter egg découvert"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "התגלתה ביצת פסחא"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "התגלתה ביצת פסחא"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ईस्टर एग मिला"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ईस्टर एग मिला"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Easter egg scoperto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Easter egg scoperto"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "イースターエッグを発見"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "イースターエッグを発見"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이스터에그 발견"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이스터에그 발견"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Easter egg gevonden"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Easter egg gevonden"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Odkryto easter egg"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odkryto easter egg"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Easter egg descoberto"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Easter egg descoberto"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Найдена пасхалка"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Найдена пасхалка"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "发现彩蛋"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "发现彩蛋"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "發現彩蛋"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "發現彩蛋"
           }
         }
       }
     },
-    "Easter eggs" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "بيوض مفاجِئة"
+    "Easter eggs": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بيوض مفاجِئة"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Easter Eggs"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Easter Eggs"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Easter eggs"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Easter eggs"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Huevos de pascua"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Huevos de pascua"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Huevos de pascua"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Huevos de pascua"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تخم‌مرغ‌های نوروزی"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تخم‌مرغ‌های نوروزی"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Easter eggs"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Easter eggs"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ביצי פסחא"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ביצי פסחא"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ईस्टर एग"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ईस्टर एग"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Easter egg"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Easter egg"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "イースターエッグ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "イースターエッグ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이스터에그"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이스터에그"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Easter eggs"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Easter eggs"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Easter eggs"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Easter eggs"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Easter eggs"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Easter eggs"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Пасхалки"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пасхалки"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "彩蛋"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "彩蛋"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "彩蛋"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "彩蛋"
           }
         }
       }
     },
-    "Emoji" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إيموجي"
+    "Emoji": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إيموجي"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Emoji"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Emoji"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Emoji"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Emoji"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ایموجی"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ایموجی"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Émoji"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Émoji"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "אימוג'י"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אימוג'י"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "इमोजी"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "इमोजी"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Emoji"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "絵文字"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "絵文字"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이모지"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이모지"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Emoji"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Emoji"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Emoji"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Эмодзи"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Эмодзи"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Emoji"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Emoji"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
           }
         }
       }
     },
-    "Emoji autocompleted" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إيموجي تمّ إكمالها تلقائياً"
+    "Emoji autocompleted": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إيموجي تمّ إكمالها تلقائياً"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vervollständigte Emoji"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vervollständigte Emoji"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Emoji autocompleted"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji autocompleted"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Emoji autocompletados"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji autocompletados"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Emojis autocompletados"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emojis autocompletados"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ایموجی‌های تکمیل‌شده"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ایموجی‌های تکمیل‌شده"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Émoji autocomplétés"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Émoji autocomplétés"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "אימוג'י שהושלמו"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אימוג'י שהושלמו"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ऑटोकम्प्लीट किए गए इमोजी"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ऑटोकम्प्लीट किए गए इमोजी"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Emoji completati"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji completati"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自動補完した絵文字"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動補完した絵文字"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "자동 완성된 이모지"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "자동 완성된 이모지"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aangevulde emoji"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aangevulde emoji"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uzupełnione emoji"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uzupełnione emoji"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Emoji autocompletados"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji autocompletados"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Эмодзи добавлено"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Эмодзи добавлено"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已自动补全 emoji"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已自动补全 emoji"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已自動完成 emoji"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已自動完成 emoji"
           }
         }
       }
     },
-    "Exclusions" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الاستثناءات"
+    "Exclusions": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الاستثناءات"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ausnahmen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausnahmen"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exclusions"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exclusions"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exclusiones"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exclusiones"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exclusiones"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exclusiones"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "موارد مستثنا"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "موارد مستثنا"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exclusions"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exclusions"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "החרגות"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "החרגות"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "अपवर्जन"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अपवर्जन"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esclusioni"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esclusioni"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "除外"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "除外"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "제외 항목"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제외 항목"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uitsluitingen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uitsluitingen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wykluczenia"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wykluczenia"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exclusões"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exclusões"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Исключения"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Исключения"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "排除项"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "排除项"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "排除項目"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "排除項目"
           }
         }
       }
     },
-    "Funded by donations" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تموَّل من التبرّعات"
+    "Funded by donations": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تموَّل من التبرّعات"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Durch Spenden finanziert"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Durch Spenden finanziert"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Funded by donations"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Funded by donations"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Financiado con donaciones"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Financiado con donaciones"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Financiado con donaciones"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Financiado con donaciones"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "با حمایت‌های مردمی"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "با حمایت‌های مردمی"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Financé par les dons"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Financé par les dons"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ממומן בתרומות"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ממומן בתרומות"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "दान से वित्तपोषित"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "दान से वित्तपोषित"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finanziato dalle donazioni"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finanziato dalle donazioni"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "寄付で支えられています"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "寄付で支えられています"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "후원으로 운영"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "후원으로 운영"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gefinancierd door donaties"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gefinancierd door donaties"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finansowane z wpłat"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finansowane z wpłat"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Financiado por doações"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Financiado por doações"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Существует на пожертвования"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Существует на пожертвования"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "由捐赠资助"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "由捐赠资助"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "由贊助支持"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "由贊助支持"
           }
         }
       }
     },
-    "GIF search" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "البحث عن GIF"
+    "GIF search": {
+      "localizations": {
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF search"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF-Suche"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF-Suche"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF search"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Búsqueda de GIF"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Búsqueda de GIF"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Búsqueda de GIF"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Búsqueda de GIF"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recherche de GIF"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "جست‌وجوی GIF"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ricerca GIF"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recherche de GIF"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Busca de GIF"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "חיפוש GIF"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF 検索"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF खोज"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF 搜索"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ricerca GIF"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF 搜尋"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF 検索"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF 검색"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF 검색"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF खोज"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF-zoeken"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поиск GIF"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wyszukiwanie GIF-ów"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wyszukiwanie GIF-ów"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Busca de GIF"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF-zoeken"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Поиск GIF"
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "البحث عن GIF"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF 搜索"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جست‌وجوی GIF"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF 搜尋"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "חיפוש GIF"
           }
         }
       }
     },
-    "GIF search bypass" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "استثناء البحث عن GIF"
+    "GIF search bypass": {
+      "localizations": {
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF search bypass"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF-Suche ohne Ausschlüsse"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF-Suche ohne Ausschlüsse"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF search bypass"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excepción para búsqueda de GIF"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Excepción para búsqueda de GIF"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excepción para búsqueda de GIF"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Excepción para búsqueda de GIF"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exception pour la recherche de GIF"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "استثنای جست‌وجوی GIF"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eccezione per la ricerca di GIF"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exception pour la recherche de GIF"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exceção para a busca de GIF"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "חריגה לחיפוש GIF"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF 検索の例外"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF खोज अपवाद"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF 搜索例外"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eccezione per la ricerca di GIF"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF 搜尋例外"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF 検索の例外"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF 검색 예외"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF 검색 예외"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF खोज अपवाद"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF-zoeken uitzondering"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Исключение для поиска GIF"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wyjątek dla wyszukiwania GIF"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wyjątek dla wyszukiwania GIF"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exceção para a busca de GIF"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF-zoeken uitzondering"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Исключение для поиска GIF"
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استثناء البحث عن GIF"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF 搜索例外"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استثنای جست‌وجوی GIF"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF 搜尋例外"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "חריגה לחיפוש GIF"
           }
         }
       }
     },
-    "GIFs and Symbols" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "صور GIF والرموز"
+    "GIFs and Symbols": {
+      "localizations": {
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIFs and Symbols"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIFs und Symbole"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIFs und Symbole"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIFs and Symbols"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF y símbolos"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF y símbolos"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF y símbolos"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF y símbolos"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF et symboles"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "گیف‌ها و نمادها"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF e simboli"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF et symboles"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIFs e símbolos"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF-ים וסמלים"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF と記号"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF और प्रतीक"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF 和符号"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF e simboli"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF 與符號"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF と記号"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF 및 기호"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF 및 기호"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF और प्रतीक"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIFs en symbolen"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF и символы"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF-y i symbole"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF-y i symbole"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIFs e símbolos"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIFs en symbolen"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF и символы"
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "صور GIF والرموز"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF 和符号"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "گیف‌ها و نمادها"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF 與符號"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF-ים וסמלים"
           }
         }
       }
     },
-    "General" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "عام"
+    "General": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عام"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allgemein"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allgemein"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "General"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "General"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "General"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "General"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "General"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "General"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "عمومی"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عمومی"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Général"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Général"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "כללי"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "כללי"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "सामान्य"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सामान्य"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Generali"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generali"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一般"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一般"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "일반"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일반"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Algemeen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Algemeen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ogólne"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ogólne"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geral"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geral"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Основные"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Основные"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "通用"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通用"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一般"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一般"
           }
         }
       }
     },
-    "Get started" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ابدأ"
+    "Get started": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ابدأ"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Los geht's"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los geht's"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Get started"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Get started"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Empezar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empezar"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Empezar"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empezar"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "شروع کنید"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "شروع کنید"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Commencer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commencer"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "התחל"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "התחל"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "शुरू करें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "शुरू करें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inizia"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inizia"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "はじめる"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "はじめる"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "시작하기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시작하기"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aan de slag"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aan de slag"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rozpocznij"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozpocznij"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Começar"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Começar"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Начать"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Начать"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "开始使用"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开始使用"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "開始使用"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開始使用"
           }
         }
       }
     },
-    "Giphy rejected the API key." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "رفض Giphy مفتاح API."
+    "Giphy rejected the API key.": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "رفض Giphy مفتاح API."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy hat den API-Schlüssel abgelehnt."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy hat den API-Schlüssel abgelehnt."
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy rejected the API key."
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy rejected the API key."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy rechazó la clave de la API."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy rechazó la clave de la API."
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy rechazó la clave de la API."
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy rechazó la clave de la API."
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏Giphy کلید API را رد کرد."
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏Giphy کلید API را رد کرد."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy a refusé la clé d'API."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy a refusé la clé d'API."
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏Giphy דחתה את מפתח ה-API."
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏Giphy דחתה את מפתח ה-API."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy ने API कुंजी अस्वीकार कर दी।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy ने API कुंजी अस्वीकार कर दी।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy ha rifiutato la chiave API."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy ha rifiutato la chiave API."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy が API キーを拒否しました。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy が API キーを拒否しました。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy가 API 키를 거부했습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy가 API 키를 거부했습니다."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy weigerde de API-sleutel."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy weigerde de API-sleutel."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy odrzuciło klucz API."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy odrzuciło klucz API."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O Giphy rejeitou a chave da API."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Giphy rejeitou a chave da API."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy отклонил ключ API."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy отклонил ключ API."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy 拒绝了 API 密钥。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy 拒绝了 API 密钥。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy 拒絕了 API 金鑰。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy 拒絕了 API 金鑰。"
           }
         }
       }
     },
-    "Giphy responded with an unexpected result." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ردّ Giphy بنتيجة غير متوقعة."
+    "Giphy responded with an unexpected result.": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ردّ Giphy بنتيجة غير متوقعة."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy hat unerwartet geantwortet."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy hat unerwartet geantwortet."
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy responded with an unexpected result."
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy responded with an unexpected result."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy respondió con un resultado inesperado."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy respondió con un resultado inesperado."
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy respondió con un resultado inesperado."
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy respondió con un resultado inesperado."
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏Giphy پاسخی غیرمنتظره برگرداند."
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏Giphy پاسخی غیرمنتظره برگرداند."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy a répondu avec un résultat inattendu."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy a répondu avec un résultat inattendu."
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏Giphy החזירה תוצאה לא צפויה."
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏Giphy החזירה תוצאה לא צפויה."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy से अप्रत्याशित प्रतिक्रिया मिली।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy से अप्रत्याशित प्रतिक्रिया मिली।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy ha risposto con un risultato inatteso."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy ha risposto con un risultato inatteso."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy から予期しない応答が返されました。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy から予期しない応答が返されました。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy가 예상치 못한 응답을 보냈습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy가 예상치 못한 응답을 보냈습니다."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy gaf een onverwacht resultaat."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy gaf een onverwacht resultaat."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy zwróciło nieoczekiwany wynik."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy zwróciło nieoczekiwany wynik."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O Giphy retornou um resultado inesperado."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Giphy retornou um resultado inesperado."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy вернул неожиданный ответ."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy вернул неожиданный ответ."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy 返回了意外的结果。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy 返回了意外的结果。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy 回傳了預期外的結果。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy 回傳了預期外的結果。"
           }
         }
       }
     },
-    "Grant accessibility permissions" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "منح أذونات إمكانية الوصول"
+    "Grant accessibility permissions": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "منح أذونات إمكانية الوصول"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bedienungshilfen-Berechtigungen erteilen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bedienungshilfen-Berechtigungen erteilen"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Grant accessibility permissions"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grant accessibility permissions"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conceder permisos de accesibilidad"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conceder permisos de accesibilidad"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Otorgar permisos de accesibilidad"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otorgar permisos de accesibilidad"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اعطای دسترسی به دسترس‌پذیری"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اعطای دسترسی به دسترس‌پذیری"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accorder les autorisations d'accessibilité"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accorder les autorisations d'accessibilité"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "אשר הרשאות נגישות"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אשר הרשאות נגישות"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ऐक्सेसिबिलिटी अनुमतियाँ दें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ऐक्सेसिबिलिटी अनुमतियाँ दें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Concedi i permessi di accessibilità"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Concedi i permessi di accessibilità"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アクセシビリティの権限を許可"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アクセシビリティの権限を許可"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "손쉬운 사용 권한 허용"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "손쉬운 사용 권한 허용"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geef toegankelijkheidstoestemmingen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geef toegankelijkheidstoestemmingen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Udziel uprawnień dostępności"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Udziel uprawnień dostępności"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conceder permissões de acessibilidade"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conceder permissões de acessibilidade"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Предоставьте разрешения универсального доступа"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Предоставьте разрешения универсального доступа"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "授予辅助功能权限"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "授予辅助功能权限"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "授予輔助使用權限"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "授予輔助使用權限"
           }
         }
       }
     },
-    "Hide Details" : {
-
-    },
-    "I donated" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لقد تبرّعت"
+    "I donated": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لقد تبرّعت"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ich habe gespendet"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ich habe gespendet"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "I donated"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I donated"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ya he donado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ya he donado"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ya doné"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ya doné"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "حمایت کردم"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حمایت کردم"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "J'ai fait un don"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "J'ai fait un don"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "תרמתי"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "תרמתי"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "मैंने दान किया"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मैंने दान किया"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ho donato"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ho donato"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "寄付しました"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "寄付しました"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "후원했어요"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "후원했어요"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ik heb gedoneerd"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ik heb gedoneerd"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wpłaciłem(-am)"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wpłaciłem(-am)"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eu doei"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eu doei"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Я поддержал"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Я поддержал"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "我已捐赠"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "我已捐赠"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "我已贊助"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "我已贊助"
           }
         }
       }
     },
-    "If the icon doesn't appear in the menu bar, check **System Settings → Menu Bar → \"Allow in the Menu Bar\"**." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إذا لم تظهر الأيقونة في شريط القوائم، تحقّق من **إعدادات النظام ← شريط القوائم ← \"السماح في شريط القوائم\"**."
+    "If the icon doesn't appear in the menu bar, check **System Settings → Menu Bar → \"Allow in the Menu Bar\"**.": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إذا لم تظهر الأيقونة في شريط القوائم، تحقّق من **إعدادات النظام ← شريط القوائم ← \"السماح في شريط القوائم\"**."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falls das Symbol nicht in der Menüleiste erscheint, prüfe **Systemeinstellungen → Menüleiste → „In der Menüleiste erlauben\"**."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falls das Symbol nicht in der Menüleiste erscheint, prüfe **Systemeinstellungen → Menüleiste → „In der Menüleiste erlauben\"**."
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "If the icon doesn't appear in the menu bar, check **System Settings → Menu Bar → \"Allow in the Menu Bar\"**."
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "If the icon doesn't appear in the menu bar, check **System Settings → Menu Bar → \"Allow in the Menu Bar\"**."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Si el icono no aparece en la barra de menús, revisa **Ajustes del sistema → Barra de menús → \"Permitir en la barra de menús\"**."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si el icono no aparece en la barra de menús, revisa **Ajustes del sistema → Barra de menús → \"Permitir en la barra de menús\"**."
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Si el ícono no aparece en la barra de menús, revisá **Ajustes del sistema → Barra de menús → \"Permitir en la barra de menús\"**."
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si el ícono no aparece en la barra de menús, revisá **Ajustes del sistema → Barra de menús → \"Permitir en la barra de menús\"**."
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اگر آیکون در نوار منو ظاهر نشد، **تنظیمات سیستم ← نوار منو ← «اجازه در نوار منو»** را بررسی کنید."
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اگر آیکون در نوار منو ظاهر نشد، **تنظیمات سیستم ← نوار منو ← «اجازه در نوار منو»** را بررسی کنید."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Si l'icône n'apparaît pas dans la barre de menus, vérifie **Réglages Système → Barre de menus → « Autoriser dans la barre de menus »**."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si l'icône n'apparaît pas dans la barre de menus, vérifie **Réglages Système → Barre de menus → « Autoriser dans la barre de menus »**."
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "אם הצלמית לא מופיעה בשורת התפריטים, בדוק את **הגדרות המערכת ← שורת התפריטים ← \"אפשר בשורת התפריטים\"**."
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אם הצלמית לא מופיעה בשורת התפריטים, בדוק את **הגדרות המערכת ← שורת התפריטים ← \"אפשר בשורת התפריטים\"**."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "अगर मेन्यू बार में आइकन नहीं दिखे, तो **सिस्टम सेटिंग्स → मेन्यू बार → \"मेन्यू बार में अनुमति दें\"** देखें।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अगर मेन्यू बार में आइकन नहीं दिखे, तो **सिस्टम सेटिंग्स → मेन्यू बार → \"मेन्यू बार में अनुमति दें\"** देखें।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se l'icona non compare nella barra dei menu, controlla **Impostazioni di Sistema → Barra dei menu → \"Consenti nella barra dei menu\"**."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se l'icona non compare nella barra dei menu, controlla **Impostazioni di Sistema → Barra dei menu → \"Consenti nella barra dei menu\"**."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "メニューバーにアイコンが表示されない場合は、**システム設定 → メニューバー → \"メニューバーで許可\"** を確認してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メニューバーにアイコンが表示されない場合は、**システム設定 → メニューバー → \"メニューバーで許可\"** を確認してください。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "메뉴 막대에 아이콘이 보이지 않으면 **시스템 설정 → 메뉴 막대 → \"메뉴 막대에서 허용\"** 을 확인하세요."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "메뉴 막대에 아이콘이 보이지 않으면 **시스템 설정 → 메뉴 막대 → \"메뉴 막대에서 허용\"** 을 확인하세요."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Als het pictogram niet in de menubalk verschijnt, controleer **Systeeminstellingen → Menubalk → \"Toestaan in menubalk\"**."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Als het pictogram niet in de menubalk verschijnt, controleer **Systeeminstellingen → Menubalk → \"Toestaan in menubalk\"**."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jeśli ikona nie pojawia się na pasku menu, sprawdź **Ustawienia systemowe → Pasek menu → „Zezwól na pasku menu\"**."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jeśli ikona nie pojawia się na pasku menu, sprawdź **Ustawienia systemowe → Pasek menu → „Zezwól na pasku menu\"**."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se o ícone não aparecer na barra de menus, confira **Ajustes do Sistema → Barra de Menus → \"Permitir na barra de menus\"**."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se o ícone não aparecer na barra de menus, confira **Ajustes do Sistema → Barra de Menus → \"Permitir na barra de menus\"**."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Если значок не появляется в строке меню, проверьте **Системные настройки → Строка меню → «Разрешить в строке меню»**."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Если значок не появляется в строке меню, проверьте **Системные настройки → Строка меню → «Разрешить в строке меню»**."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "如果图标没有出现在菜单栏中,请检查 **系统设置 → 菜单栏 → \"在菜单栏中允许\"**。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "如果图标没有出现在菜单栏中,请检查 **系统设置 → 菜单栏 → \"在菜单栏中允许\"**。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "如果圖示沒有出現在選單列中,請檢查 **系統設定 → 選單列 → \"允許在選單列中顯示\"**。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "如果圖示沒有出現在選單列中,請檢查 **系統設定 → 選單列 → \"允許在選單列中顯示\"**。"
           }
         }
       }
     },
-    "Include symbols (experimental)" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تضمين الرموز (تجريبي)"
+    "Include symbols (experimental)": {
+      "extractionState": "stale",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تضمين الرموز (تجريبي)"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Symbole einbeziehen (experimentell)"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symbole einbeziehen (experimentell)"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Include symbols (experimental)"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Include symbols (experimental)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Incluir símbolos (experimental)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incluir símbolos (experimental)"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Incluir símbolos (experimental)"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incluir símbolos (experimental)"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "گنجاندن نمادها (آزمایشی)"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "گنجاندن نمادها (آزمایشی)"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inclure les symboles (expérimental)"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inclure les symboles (expérimental)"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "כלול סמלים (ניסיוני)"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "כלול סמלים (ניסיוני)"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "प्रतीक शामिल करें (प्रायोगिक)"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "प्रतीक शामिल करें (प्रायोगिक)"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Includi simboli (sperimentale)"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Includi simboli (sperimentale)"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "記号を含める(実験的)"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "記号を含める(実験的)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "기호 포함 (실험적)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기호 포함 (실험적)"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Symbolen meenemen (experimenteel)"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symbolen meenemen (experimenteel)"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uwzględnij symbole (eksperymentalne)"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uwzględnij symbole (eksperymentalne)"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Incluir símbolos (experimental)"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incluir símbolos (experimental)"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Включать символы (экспериментально)"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включать символы (экспериментально)"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "包含符号(实验性)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "包含符号(实验性)"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "包含符號(實驗性)"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "包含符號(實驗性)"
           }
         }
       }
     },
-    "Include ★ ⌘ ⌥ and similar characters in results (experimental)." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تضمين ★ ⌘ ⌥ والأحرف المشابهة في النتائج (تجريبي)."
+    "Include ★ ⌘ ⌥ and similar characters in results (experimental).": {
+      "localizations": {
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Include ★ ⌘ ⌥ and similar characters in results (experimental)."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "★ ⌘ ⌥ und ähnliche Zeichen in den Ergebnissen anzeigen (experimentell)."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "★ ⌘ ⌥ und ähnliche Zeichen in den Ergebnissen anzeigen (experimentell)."
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Include ★ ⌘ ⌥ and similar characters in results (experimental)."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incluir ★ ⌘ ⌥ y caracteres similares en los resultados (experimental)."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Incluir ★ ⌘ ⌥ y caracteres similares en los resultados (experimental)."
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incluir ★ ⌘ ⌥ y caracteres similares en los resultados (experimental)."
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Incluir ★ ⌘ ⌥ y caracteres similares en los resultados (experimental)."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inclure ★ ⌘ ⌥ et caractères similaires dans les résultats (expérimental)."
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "گنجاندن ★ ⌘ ⌥ و کاراکترهای مشابه در نتایج (آزمایشی)."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Includi ★ ⌘ ⌥ e caratteri simili nei risultati (sperimentale)."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inclure ★ ⌘ ⌥ et caractères similaires dans les résultats (expérimental)."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incluir ★ ⌘ ⌥ e caracteres semelhantes nos resultados (experimental)."
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "כלול את ★ ⌘ ⌥ ותווים דומים בתוצאות (ניסיוני)."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "★ ⌘ ⌥ などの記号を結果に含めます(実験的)。"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "परिणामों में ★ ⌘ ⌥ और मिलते-जुलते वर्ण शामिल करें (प्रयोगात्मक)।"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在结果中包含 ★ ⌘ ⌥ 等字符(实验性)。"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Includi ★ ⌘ ⌥ e caratteri simili nei risultati (sperimentale)."
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在結果中包含 ★ ⌘ ⌥ 等字元(實驗性)。"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "★ ⌘ ⌥ などの記号を結果に含めます(実験的)。"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "★ ⌘ ⌥ 등 유사 문자를 결과에 포함합니다(실험적)."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "★ ⌘ ⌥ 등 유사 문자를 결과에 포함합니다(실험적)."
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "परिणामों में ★ ⌘ ⌥ और मिलते-जुलते वर्ण शामिल करें (प्रयोगात्मक)।"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toon ★ ⌘ ⌥ en vergelijkbare tekens in resultaten (experimenteel)."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включать ★ ⌘ ⌥ и подобные символы в результаты (экспериментально)."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uwzględniaj ★ ⌘ ⌥ i podobne znaki w wynikach (eksperymentalne)."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uwzględniaj ★ ⌘ ⌥ i podobne znaki w wynikach (eksperymentalne)."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Incluir ★ ⌘ ⌥ e caracteres semelhantes nos resultados (experimental)."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toon ★ ⌘ ⌥ en vergelijkbare tekens in resultaten (experimenteel)."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Включать ★ ⌘ ⌥ и подобные символы в результаты (экспериментально)."
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تضمين ★ ⌘ ⌥ والأحرف المشابهة في النتائج (تجريبي)."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在结果中包含 ★ ⌘ ⌥ 等字符(实验性)。"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "گنجاندن ★ ⌘ ⌥ و کاراکترهای مشابه در نتایج (آزمایشی)."
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在結果中包含 ★ ⌘ ⌥ 等字元(實驗性)。"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "כלול את ★ ⌘ ⌥ ותווים דומים בתוצאות (ניסיוני)."
           }
         }
       }
     },
-    "Input Monitoring" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "مراقبة الإدخال"
+    "Input Monitoring": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مراقبة الإدخال"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eingabeüberwachung"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eingabeüberwachung"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Input Monitoring"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Input Monitoring"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Monitorización de entrada"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monitorización de entrada"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Monitoreo de entrada"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monitoreo de entrada"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "نظارت بر ورودی"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نظارت بر ورودی"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Surveillance des entrées"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Surveillance des entrées"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ניטור קלט"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ניטור קלט"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "इनपुट मॉनिटरिंग"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "इनपुट मॉनिटरिंग"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Monitoraggio dell'input"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monitoraggio dell'input"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "入力監視"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "入力監視"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "입력 모니터링"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "입력 모니터링"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invoercontrole"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invoercontrole"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Monitorowanie wprowadzania"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monitorowanie wprowadzania"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Monitoramento de Entrada"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monitoramento de Entrada"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Мониторинг ввода"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Мониторинг ввода"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "输入监控"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "输入监控"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "輸入監控"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輸入監控"
           }
         }
       }
     },
-    "Keyboard shortcuts" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اختصارات لوحة المفاتيح"
+    "Keyboard shortcuts": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اختصارات لوحة المفاتيح"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tastaturkürzel"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastaturkürzel"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keyboard shortcuts"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keyboard shortcuts"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atajos de teclado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atajos de teclado"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atajos de teclado"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atajos de teclado"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "میان‌برهای صفحه‌کلید"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "میان‌برهای صفحه‌کلید"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Raccourcis clavier"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Raccourcis clavier"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "קיצורי מקלדת"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "קיצורי מקלדת"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "कीबोर्ड शॉर्टकट"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कीबोर्ड शॉर्टकट"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scorciatoie da tastiera"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scorciatoie da tastiera"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "キーボードショートカット"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーボードショートカット"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "키보드 단축키"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키보드 단축키"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toetscombinaties"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toetscombinaties"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skróty klawiszowe"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skróty klawiszowe"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atalhos de teclado"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atalhos de teclado"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сочетания клавиш"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сочетания клавиш"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "键盘快捷键"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "键盘快捷键"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "鍵盤捷徑"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鍵盤捷徑"
           }
         }
       }
     },
-    "Keystrokes aren't logged" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لا يتمّ تسجيل ضغطات المفاتيح"
+    "Keystrokes aren't logged": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا يتمّ تسجيل ضغطات المفاتيح"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tastenanschläge werden nicht protokolliert"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastenanschläge werden nicht protokolliert"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keystrokes aren't logged"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keystrokes aren't logged"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Las pulsaciones no se registran"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las pulsaciones no se registran"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Las pulsaciones no se registran"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las pulsaciones no se registran"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ضربه‌های کلید ذخیره نمی‌شود"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ضربه‌های کلید ذخیره نمی‌شود"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les frappes ne sont pas journalisées"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les frappes ne sont pas journalisées"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "הקשות מקלדת אינן נשמרות"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הקשות מקלדת אינן נשמרות"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "कीस्ट्रोक्स लॉग नहीं किए जाते"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कीस्ट्रोक्स लॉग नहीं किए जाते"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le digitazioni non vengono registrate"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le digitazioni non vengono registrate"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "キー入力は記録されません"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キー入力は記録されません"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "키 입력은 기록되지 않습니다"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키 입력은 기록되지 않습니다"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toetsaanslagen worden niet vastgelegd"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toetsaanslagen worden niet vastgelegd"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Naciśnięcia klawiszy nie są zapisywane"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Naciśnięcia klawiszy nie są zapisywane"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "As teclas digitadas não são registradas"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As teclas digitadas não são registradas"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Нажатия клавиш не записываются"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нажатия клавиш не записываются"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "不会记录按键"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不会记录按键"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "不會記錄按鍵"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不會記錄按鍵"
           }
         }
       }
-    },
-    "Legend" : {
-
     },
-    "Let GIF search work in excluded apps" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "السماح بالبحث عن GIF في التطبيقات المستثناة"
+    "Let GIF search work in excluded apps": {
+      "localizations": {
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Let GIF search work in excluded apps"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF-Suche auch in ausgeschlossenen Apps zulassen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF-Suche auch in ausgeschlossenen Apps zulassen"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Let GIF search work in excluded apps"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir la búsqueda de GIF en apps excluidas"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir la búsqueda de GIF en apps excluidas"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir la búsqueda de GIF en apps excluidas"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir la búsqueda de GIF en apps excluidas"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autoriser la recherche de GIF dans les apps exclues"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اجازه دادن جست‌وجوی GIF در برنامه‌های مستثنا"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consenti la ricerca di GIF nelle app escluse"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autoriser la recherche de GIF dans les apps exclues"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir busca de GIF em apps excluídos"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "אפשר חיפוש GIF גם באפליקציות מוחרגות"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "除外したアプリでも GIF 検索を有効にする"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "बहिष्कृत ऐप्स में भी GIF खोज की अनुमति दें"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在已排除的应用中也启用 GIF 搜索"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Consenti la ricerca di GIF nelle app escluse"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在已排除的 App 中仍允許 GIF 搜尋"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "除外したアプリでも GIF 検索を有効にする"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제외된 앱에서도 GIF 검색 허용"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "제외된 앱에서도 GIF 검색 허용"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बहिष्कृत ऐप्स में भी GIF खोज की अनुमति दें"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF-zoeken toestaan in uitgesloten apps"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разрешать поиск GIF в исключённых приложениях"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zezwalaj na wyszukiwanie GIF-ów w wykluczonych aplikacjach"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zezwalaj na wyszukiwanie GIF-ów w wykluczonych aplikacjach"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir busca de GIF em apps excluídos"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF-zoeken toestaan in uitgesloten apps"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Разрешать поиск GIF в исключённых приложениях"
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "السماح بالبحث عن GIF في التطبيقات المستثناة"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在已排除的应用中也启用 GIF 搜索"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اجازه دادن جست‌وجوی GIF در برنامه‌های مستثنا"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在已排除的 App 中仍允許 GIF 搜尋"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אפשר חיפוש GIF גם באפליקציות מוחרגות"
           }
         }
       }
     },
-    "Lets %@ anchor the picker next to your text cursor." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "يتيح لـ %@ تثبيت أداة الاختيار بجوار مؤشر النص."
+    "Lets %@ anchor the picker next to your text cursor.": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يتيح لـ %@ تثبيت أداة الاختيار بجوار مؤشر النص."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erlaubt %@, den Picker neben deinem Textcursor zu verankern."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erlaubt %@, den Picker neben deinem Textcursor zu verankern."
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lets %@ anchor the picker next to your text cursor."
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lets %@ anchor the picker next to your text cursor."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permite que %@ ancle el selector junto al cursor de texto."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permite que %@ ancle el selector junto al cursor de texto."
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permite que %@ ancle el selector junto al cursor de texto."
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permite que %@ ancle el selector junto al cursor de texto."
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "به %@ اجازه می‌دهد انتخابگر را کنار مکان‌نمای متن قرار دهد."
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "به %@ اجازه می‌دهد انتخابگر را کنار مکان‌نمای متن قرار دهد."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permet à %@ d'ancrer le sélecteur à côté de votre curseur de texte."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permet à %@ d'ancrer le sélecteur à côté de votre curseur de texte."
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "מאפשר ל-%@ לעגן את הבורר ליד סמן הטקסט."
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מאפשר ל-%@ לעגן את הבורר ליד סמן הטקסט."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ को आपके टेक्स्ट कर्सर के बगल में पिकर लगाने देता है।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ को आपके टेक्स्ट कर्सर के बगल में पिकर लगाने देता है।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permette a %@ di ancorare il selettore accanto al cursore di testo."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permette a %@ di ancorare il selettore accanto al cursore di testo."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ がピッカーをテキストカーソルの隣に固定できるようになります。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ がピッカーをテキストカーソルの隣に固定できるようになります。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@이(가) 선택기를 텍스트 커서 옆에 고정할 수 있게 합니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@이(가) 선택기를 텍스트 커서 옆에 고정할 수 있게 합니다."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Laat %@ de kiezer naast je tekstcursor verankeren."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Laat %@ de kiezer naast je tekstcursor verankeren."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pozwala aplikacji %@ umieszczać okno wyboru obok kursora."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pozwala aplikacji %@ umieszczać okno wyboru obok kursora."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permite que o %@ ancore o seletor ao lado do cursor de texto."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permite que o %@ ancore o seletor ao lado do cursor de texto."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Позволяет %@ закреплять окно подбора рядом с курсором."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Позволяет %@ закреплять окно подбора рядом с курсором."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "让 %@ 把选取器锚定在文本光标旁。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "让 %@ 把选取器锚定在文本光标旁。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "讓 %@ 將選取器固定在文字游標旁邊。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "讓 %@ 將選取器固定在文字游標旁邊。"
           }
         }
       }
     },
-    "Lets %@ watch keystrokes for `:` triggers. Nothing is logged." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "يتيح لـ %@ مراقبة الضغطات بحثاً عن `:`. لا يُسجَّل شيء."
+    "Lets %@ watch keystrokes for `:` triggers. Nothing is logged.": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يتيح لـ %@ مراقبة الضغطات بحثاً عن `:`. لا يُسجَّل شيء."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erlaubt %@, Tastenanschläge auf `:` zu beobachten. Es wird nichts protokolliert."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erlaubt %@, Tastenanschläge auf `:` zu beobachten. Es wird nichts protokolliert."
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lets %@ watch keystrokes for `:` triggers. Nothing is logged."
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lets %@ watch keystrokes for `:` triggers. Nothing is logged."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permite que %@ vigile las pulsaciones en busca del `:`. No se registra nada."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permite que %@ vigile las pulsaciones en busca del `:`. No se registra nada."
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permite que %@ vigile las pulsaciones en busca del `:`. No se registra nada."
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permite que %@ vigile las pulsaciones en busca del `:`. No se registra nada."
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "به %@ اجازه می‌دهد ضربه‌های `:` را پی بگیرد. هیچ‌چیز ذخیره نمی‌شود."
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "به %@ اجازه می‌دهد ضربه‌های `:` را پی بگیرد. هیچ‌چیز ذخیره نمی‌شود."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permet à %@ de surveiller les frappes pour détecter `:`. Rien n'est journalisé."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permet à %@ de surveiller les frappes pour détecter `:`. Rien n'est journalisé."
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "מאפשר ל-%@ לעקוב אחר הקשות `:`. דבר לא נשמר."
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מאפשר ל-%@ לעקוב אחר הקשות `:`. דבר לא נשמר."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ को `:` के लिए कीस्ट्रोक देखने देता है। कुछ भी लॉग नहीं होता।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ को `:` के लिए कीस्ट्रोक देखने देता है। कुछ भी लॉग नहीं होता।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permette a %@ di osservare le digitazioni in cerca di `:`. Nulla viene registrato."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permette a %@ di osservare le digitazioni in cerca di `:`. Nulla viene registrato."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ が `:` のキー入力を監視できるようにします。何も記録されません。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ が `:` のキー入力を監視できるようにします。何も記録されません。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@이(가) `:` 입력을 감지하도록 합니다. 아무것도 기록되지 않습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@이(가) `:` 입력을 감지하도록 합니다. 아무것도 기록되지 않습니다."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Laat %@ toetsaanslagen volgen voor `:`. Er wordt niets vastgelegd."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Laat %@ toetsaanslagen volgen voor `:`. Er wordt niets vastgelegd."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pozwala aplikacji %@ obserwować naciśnięcia `:`. Nic nie jest zapisywane."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pozwala aplikacji %@ obserwować naciśnięcia `:`. Nic nie jest zapisywane."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permite que o %@ observe as teclas em busca de `:`. Nada é registrado."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permite que o %@ observe as teclas em busca de `:`. Nada é registrado."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Позволяет %@ отслеживать нажатия `:`. Ничего не записывается."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Позволяет %@ отслеживать нажатия `:`. Ничего не записывается."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "让 %@ 监听 `:` 触发键。不会记录任何内容。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "让 %@ 监听 `:` 触发键。不会记录任何内容。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "讓 %@ 監聽 `:` 觸發鍵。不會記錄任何內容。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "讓 %@ 監聽 `:` 觸發鍵。不會記錄任何內容。"
           }
         }
       }
     },
-    "Load more" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تحميل المزيد"
+    "Load more": {
+      "localizations": {
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Load more"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mehr laden"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mehr laden"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Load more"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cargar más"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cargar más"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cargar más"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cargar más"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Charger plus"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "بارگذاری بیشتر"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carica altri"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Charger plus"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carregar mais"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "טען עוד"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "さらに読み込む"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "और लोड करें"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "加载更多"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Carica altri"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "載入更多"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "さらに読み込む"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "더 불러오기"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "더 불러오기"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "और लोड करें"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Meer laden"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Загрузить ещё"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Załaduj więcej"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Załaduj więcej"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Carregar mais"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Meer laden"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Загрузить ещё"
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تحميل المزيد"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "加载更多"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بارگذاری بیشتر"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "載入更多"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "טען עוד"
           }
         }
       }
     },
-    "No GIFs found." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لم يُعثر على أي GIF."
+    "No GIFs found.": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لم يُعثر على أي GIF."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine GIFs gefunden."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine GIFs gefunden."
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No GIFs found."
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No GIFs found."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se han encontrado GIF."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se han encontrado GIF."
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se encontraron GIF."
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontraron GIF."
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "هیچ GIF‌ای پیدا نشد."
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "هیچ GIF‌ای پیدا نشد."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucun GIF trouvé."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun GIF trouvé."
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "לא נמצאו GIF-ים."
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "לא נמצאו GIF-ים."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "कोई GIF नहीं मिला।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कोई GIF नहीं मिला।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessun GIF trovato."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessun GIF trovato."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF が見つかりませんでした。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF が見つかりませんでした。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF를 찾을 수 없습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF를 찾을 수 없습니다."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geen GIFs gevonden."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geen GIFs gevonden."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nie znaleziono GIF-ów."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie znaleziono GIF-ów."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nenhum GIF encontrado."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum GIF encontrado."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF не найдены."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF не найдены."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "没有找到 GIF。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有找到 GIF。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "找不到 GIF。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "找不到 GIF。"
           }
         }
       }
     },
-    "No ads, tracking, or subscriptions." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لا إعلانات، لا تتبّع، لا اشتراكات."
+    "No ads, tracking, or subscriptions.": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا إعلانات، لا تتبّع، لا اشتراكات."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Werbung, kein Tracking, keine Abos."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Werbung, kein Tracking, keine Abos."
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No ads, tracking, or subscriptions."
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No ads, tracking, or subscriptions."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sin anuncios, seguimiento ni suscripciones."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin anuncios, seguimiento ni suscripciones."
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sin anuncios, rastreo ni suscripciones."
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin anuncios, rastreo ni suscripciones."
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "بدون تبلیغ، ردیابی یا اشتراک."
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بدون تبلیغ، ردیابی یا اشتراک."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pas de pubs, pas de pistage, pas d'abonnement."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pas de pubs, pas de pistage, pas d'abonnement."
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ללא פרסומות, מעקב או מנויים."
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ללא פרסומות, מעקב או מנויים."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "कोई विज्ञापन, ट्रैकिंग या सदस्यता नहीं।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कोई विज्ञापन, ट्रैकिंग या सदस्यता नहीं।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Niente pubblicità, tracciamento o abbonamenti."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Niente pubblicità, tracciamento o abbonamenti."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "広告、トラッキング、サブスクリプションは一切ありません。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "広告、トラッキング、サブスクリプションは一切ありません。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "광고도, 추적도, 구독도 없습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "광고도, 추적도, 구독도 없습니다."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geen advertenties, tracking of abonnementen."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geen advertenties, tracking of abonnementen."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bez reklam, śledzenia i subskrypcji."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bez reklam, śledzenia i subskrypcji."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sem anúncios, rastreamento ou assinaturas."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sem anúncios, rastreamento ou assinaturas."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Без рекламы, отслеживания и подписок."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Без рекламы, отслеживания и подписок."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无广告、无追踪、无订阅。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无广告、无追踪、无订阅。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無廣告、無追蹤、無訂閱。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無廣告、無追蹤、無訂閱。"
           }
         }
       }
     },
-    "No emoji for :%@:" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لا توجد إيموجي لـ :%@:"
+    "No emoji for :%@:": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توجد إيموجي لـ :%@:"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kein Emoji für :%@:"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein Emoji für :%@:"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No emoji for :%@:"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No emoji for :%@:"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No hay emoji para :%@:"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay emoji para :%@:"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No hay emoji para :%@:"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay emoji para :%@:"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ایموجی‌ای برای :%@: یافت نشد"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ایموجی‌ای برای :%@: یافت نشد"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucun émoji pour :%@:"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun émoji pour :%@:"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "אין אימוג'י עבור :%@:"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אין אימוג'י עבור :%@:"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ":%@: के लिए कोई इमोजी नहीं"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ":%@: के लिए कोई इमोजी नहीं"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessuna emoji per :%@:"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessuna emoji per :%@:"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ":%@: に対応する絵文字はありません"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ":%@: に対応する絵文字はありません"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ":%@: 에 해당하는 이모지가 없습니다"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ":%@: 에 해당하는 이모지가 없습니다"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geen emoji voor :%@:"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geen emoji voor :%@:"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Brak emoji dla :%@:"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brak emoji dla :%@:"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nenhum emoji para :%@:"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum emoji para :%@:"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Нет эмодзи для :%@:"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет эмодзи для :%@:"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "没有 :%@: 对应的 emoji"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有 :%@: 对应的 emoji"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "找不到 :%@: 對應的 emoji"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "找不到 :%@: 對應的 emoji"
           }
         }
       }
     },
-    "Open settings" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "فتح الإعدادات"
+    "Open settings": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فتح الإعدادات"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einstellungen öffnen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen öffnen"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open settings"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open settings"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir ajustes"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir ajustes"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir ajustes"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir ajustes"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "باز کردن تنظیمات"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "باز کردن تنظیمات"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ouvrir les réglages"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir les réglages"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "פתח הגדרות"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "פתח הגדרות"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "सेटिंग्स खोलें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सेटिंग्स खोलें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apri impostazioni"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri impostazioni"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "設定を開く"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定を開く"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "설정 열기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정 열기"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open instellingen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open instellingen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Otwórz ustawienia"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otwórz ustawienia"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir ajustes"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir ajustes"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Открыть настройки"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть настройки"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开设置"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开设置"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打開設定"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打開設定"
           }
         }
       }
     },
-    "Open source and auditable" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "مفتوح المصدر وقابل للمراجعة"
+    "Open source and auditable": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مفتوح المصدر وقابل للمراجعة"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Source und überprüfbar"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Source und überprüfbar"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open source and auditable"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open source and auditable"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "De código abierto y auditable"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "De código abierto y auditable"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "De código abierto y auditable"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "De código abierto y auditable"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "متن‌باز و قابل بررسی"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "متن‌باز و قابل بررسی"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open source et vérifiable"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open source et vérifiable"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "קוד פתוח וניתן לביקורת"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "קוד פתוח וניתן לביקורת"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ओपन सोर्स और जाँच-योग्य"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ओपन सोर्स और जाँच-योग्य"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open source e verificabile"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open source e verificabile"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オープンソースで監査可能"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オープンソースで監査可能"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "오픈 소스, 직접 확인 가능"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오픈 소스, 직접 확인 가능"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open source en controleerbaar"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open source en controleerbaar"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open source, można sprawdzić"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open source, można sprawdzić"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Código aberto e auditável"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Código aberto e auditável"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Открытый исходный код, можно проверить"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открытый исходный код, можно проверить"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "开源,可审计"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开源,可审计"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "開源、可審核"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開源、可審核"
           }
         }
       }
     },
-    "Pause" : {
-
-    },
-    "Pause for 1 hour" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إيقاف مؤقّت لمدّة ساعة"
+    "Pause for 1 hour": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إيقاف مؤقّت لمدّة ساعة"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eine Stunde pausieren"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine Stunde pausieren"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pause for 1 hour"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pause for 1 hour"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pausar 1 hora"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausar 1 hora"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pausar 1 hora"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausar 1 hora"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "توقف برای ۱ ساعت"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "توقف برای ۱ ساعت"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mettre en pause 1 heure"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mettre en pause 1 heure"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "השהה לשעה אחת"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "השהה לשעה אחת"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1 घंटे के लिए रोकें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 घंटे के लिए रोकें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pausa per 1 ora"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausa per 1 ora"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1時間一時停止"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1時間一時停止"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1시간 동안 일시 중지"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1시간 동안 일시 중지"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1 uur pauzeren"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 uur pauzeren"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wstrzymaj na 1 godzinę"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wstrzymaj na 1 godzinę"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pausar por 1 hora"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausar por 1 hora"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Пауза на 1 час"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пауза на 1 час"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "暂停 1 小时"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂停 1 小时"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "暫停 1 小時"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暫停 1 小時"
           }
         }
       }
     },
-    "Pause until tomorrow" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إيقاف مؤقّت حتى الغد"
+    "Pause until tomorrow": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إيقاف مؤقّت حتى الغد"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bis morgen pausieren"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bis morgen pausieren"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pause until tomorrow"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pause until tomorrow"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pausar hasta mañana"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausar hasta mañana"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pausar hasta mañana"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausar hasta mañana"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "توقف تا فردا"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "توقف تا فردا"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mettre en pause jusqu'à demain"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mettre en pause jusqu'à demain"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "השהה עד מחר"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "השהה עד מחר"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "कल तक के लिए रोकें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कल तक के लिए रोकें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pausa fino a domani"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausa fino a domani"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "明日まで一時停止"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "明日まで一時停止"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "내일까지 일시 중지"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "내일까지 일시 중지"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pauzeer tot morgen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pauzeer tot morgen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wstrzymaj do jutra"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wstrzymaj do jutra"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pausar até amanhã"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausar até amanhã"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Пауза до завтра"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пауза до завтра"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "暂停到明天"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂停到明天"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "暫停到明天"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暫停到明天"
           }
         }
       }
     },
-    "Permissions" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الأذونات"
+    "Permissions": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الأذونات"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Berechtigungen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Berechtigungen"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permissions"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permissions"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permisos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permisos"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permisos"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permisos"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اجازه‌ها"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اجازه‌ها"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autorisations"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autorisations"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "הרשאות"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הרשאות"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "अनुमतियाँ"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अनुमतियाँ"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permessi"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permessi"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "権限"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "権限"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "권한"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "권한"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toestemmingen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toestemmingen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uprawnienia"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uprawnienia"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permissões"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permissões"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Разрешения"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разрешения"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "权限"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "权限"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "權限"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "權限"
           }
         }
       }
     },
-    "Press the same shortcut again while paused to resume." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اضغط الاختصار نفسه أثناء الإيقاف المؤقّت للاستئناف."
+    "Press the same shortcut again while paused to resume.": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اضغط الاختصار نفسه أثناء الإيقاف المؤقّت للاستئناف."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Drücke dieselbe Tastenkombination während der Pause erneut, um fortzufahren."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Drücke dieselbe Tastenkombination während der Pause erneut, um fortzufahren."
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Press the same shortcut again while paused to resume."
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Press the same shortcut again while paused to resume."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pulsa el mismo atajo de nuevo mientras está en pausa para reanudar."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pulsa el mismo atajo de nuevo mientras está en pausa para reanudar."
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apretá el mismo atajo de nuevo durante la pausa para reanudar."
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apretá el mismo atajo de nuevo durante la pausa para reanudar."
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "در حالت توقف، همان میان‌بر را دوباره فشار دهید تا ادامه یابد."
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "در حالت توقف، همان میان‌بر را دوباره فشار دهید تا ادامه یابد."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Appuyez à nouveau sur le même raccourci pendant la pause pour reprendre."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Appuyez à nouveau sur le même raccourci pendant la pause pour reprendre."
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "לחץ שוב על אותו קיצור בעת ההשהיה כדי להמשיך."
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "לחץ שוב על אותו קיצור בעת ההשהיה כדי להמשיך."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "रुके होने पर वही शॉर्टकट दोबारा दबाने से फिर शुरू हो जाएगा।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "रुके होने पर वही शॉर्टकट दोबारा दबाने से फिर शुरू हो जाएगा।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Premi di nuovo la stessa scorciatoia in pausa per riprendere."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Premi di nuovo la stessa scorciatoia in pausa per riprendere."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一時停止中に同じショートカットをもう一度押すと再開します。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一時停止中に同じショートカットをもう一度押すと再開します。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "일시 중지 중에 같은 단축키를 다시 누르면 다시 시작됩니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일시 중지 중에 같은 단축키를 다시 누르면 다시 시작됩니다."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Druk tijdens de pauze opnieuw op dezelfde sneltoets om te hervatten."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Druk tijdens de pauze opnieuw op dezelfde sneltoets om te hervatten."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Naciśnij ten sam skrót podczas wstrzymania, by wznowić."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Naciśnij ten sam skrót podczas wstrzymania, by wznowić."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pressione o mesmo atalho durante a pausa para retomar."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pressione o mesmo atalho durante a pausa para retomar."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Нажмите тот же сочетание клавиш во время паузы, чтобы продолжить."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нажмите тот же сочетание клавиш во время паузы, чтобы продолжить."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "暂停期间再次按相同的快捷键即可恢复。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂停期间再次按相同的快捷键即可恢复。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "暫停期間再次按相同的快捷鍵即可恢復。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暫停期間再次按相同的快捷鍵即可恢復。"
           }
         }
       }
     },
-    "Prevent %@ from triggering inside these apps." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "منع تشغيل %@ داخل هذه التطبيقات."
+    "Prevent %@ from triggering inside these apps.": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "منع تشغيل %@ داخل هذه التطبيقات."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verhindere, dass %@ in diesen Apps auslöst."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verhindere, dass %@ in diesen Apps auslöst."
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prevent %@ from triggering inside these apps."
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prevent %@ from triggering inside these apps."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Evita que %@ se active dentro de estas apps."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evita que %@ se active dentro de estas apps."
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Evitá que %@ se active dentro de estas apps."
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evitá que %@ se active dentro de estas apps."
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏%@ در این برنامه‌ها فعال نشود."
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏%@ در این برنامه‌ها فعال نشود."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Empêche %@ de se déclencher dans ces apps."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empêche %@ de se déclencher dans ces apps."
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "מנע מ-%@ לפעול בתוך אפליקציות אלו."
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מנע מ-%@ לפעול בתוך אפליקציות אלו."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "इन ऐप्स के अंदर %@ को सक्रिय होने से रोकें।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "इन ऐप्स के अंदर %@ को सक्रिय होने से रोकें।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impedisci a %@ di attivarsi in queste app."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impedisci a %@ di attivarsi in queste app."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "これらのアプリ内で %@ が動作しないようにします。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "これらのアプリ内で %@ が動作しないようにします。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이 앱들 안에서는 %@이(가) 작동하지 않도록 합니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 앱들 안에서는 %@이(가) 작동하지 않도록 합니다."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voorkom dat %@ in deze apps actief is."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voorkom dat %@ in deze apps actief is."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nie uruchamiaj %@ w tych aplikacjach."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie uruchamiaj %@ w tych aplikacjach."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impede que %@ seja acionado dentro destes apps."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impede que %@ seja acionado dentro destes apps."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не запускать %@ внутри этих приложений."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не запускать %@ внутри этих приложений."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在这些 App 内不触发 %@。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在这些 App 内不触发 %@。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在這些 App 內不觸發 %@。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在這些 App 內不觸發 %@。"
           }
         }
       }
     },
-    "Prevent %@ from triggering on these sites. `*` matches a subdomain." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "منع تشغيل %@ على هذه المواقع. `*` يطابق نطاقاً فرعياً."
+    "Prevent %@ from triggering on these sites. `*` matches a subdomain.": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "منع تشغيل %@ على هذه المواقع. `*` يطابق نطاقاً فرعياً."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verhindere, dass %@ auf diesen Seiten auslöst. `*` steht für eine Subdomain."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verhindere, dass %@ auf diesen Seiten auslöst. `*` steht für eine Subdomain."
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prevent %@ from triggering on these sites. `*` matches a subdomain."
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prevent %@ from triggering on these sites. `*` matches a subdomain."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Evita que %@ se active en estos sitios. `*` representa un subdominio."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evita que %@ se active en estos sitios. `*` representa un subdominio."
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Evitá que %@ se active en estos sitios. `*` representa un subdominio."
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evitá que %@ se active en estos sitios. `*` representa un subdominio."
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏%@ در این سایت‌ها فعال نشود. `*` با زیردامنه‌ها مطابقت می‌کند."
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏%@ در این سایت‌ها فعال نشود. `*` با زیردامنه‌ها مطابقت می‌کند."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Empêche %@ de se déclencher sur ces sites. `*` correspond à un sous-domaine."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empêche %@ de se déclencher sur ces sites. `*` correspond à un sous-domaine."
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "מנע מ-%@ לפעול באתרים אלה. `*` מתאים לתת-דומיין."
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מנע מ-%@ לפעול באתרים אלה. `*` מתאים לתת-דומיין."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "इन साइटों पर %@ को सक्रिय होने से रोकें। `*` एक उपडोमेन से मेल खाता है।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "इन साइटों पर %@ को सक्रिय होने से रोकें। `*` एक उपडोमेन से मेल खाता है।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impedisci a %@ di attivarsi su questi siti. `*` rappresenta un sottodominio."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impedisci a %@ di attivarsi su questi siti. `*` rappresenta un sottodominio."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "これらのサイトで %@ が動作しないようにします。`*` はサブドメインを表します。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "これらのサイトで %@ が動作しないようにします。`*` はサブドメインを表します。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이 사이트들에서는 %@이(가) 작동하지 않도록 합니다. `*` 는 하위 도메인을 의미합니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 사이트들에서는 %@이(가) 작동하지 않도록 합니다. `*` 는 하위 도메인을 의미합니다."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voorkom dat %@ op deze sites actief is. `*` komt overeen met een subdomein."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voorkom dat %@ op deze sites actief is. `*` komt overeen met een subdomein."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nie uruchamiaj %@ na tych witrynach. `*` pasuje do subdomeny."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie uruchamiaj %@ na tych witrynach. `*` pasuje do subdomeny."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impede que %@ seja acionado nestes sites. `*` corresponde a um subdomínio."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impede que %@ seja acionado nestes sites. `*` corresponde a um subdomínio."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не запускать %@ на этих сайтах. `*` соответствует поддомену."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не запускать %@ на этих сайтах. `*` соответствует поддомену."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在这些网站上不触发 %@。`*` 匹配子域名。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在这些网站上不触发 %@。`*` 匹配子域名。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在這些網站上不觸發 %@。`*` 匹配子網域。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在這些網站上不觸發 %@。`*` 匹配子網域。"
           }
         }
       }
     },
-    "Privacy" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الخصوصية"
+    "Privacy": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الخصوصية"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Datenschutz"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datenschutz"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Privacy"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privacy"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Privacidad"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privacidad"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Privacidad"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privacidad"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "حریم خصوصی"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حریم خصوصی"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confidentialité"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confidentialité"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "פרטיות"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "פרטיות"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "निजता"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "निजता"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Privacy"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privacy"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "プライバシー"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プライバシー"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "개인정보"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "개인정보"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Privacy"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privacy"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prywatność"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prywatność"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Privacidade"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privacidade"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Конфиденциальность"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Конфиденциальность"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "隐私"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隐私"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "私隱"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "私隱"
           }
         }
       }
     },
-    "Privacy details…" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تفاصيل الخصوصية…"
+    "Privacy details…": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تفاصيل الخصوصية…"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Datenschutz-Details…"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datenschutz-Details…"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Privacy details…"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privacy details…"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Detalles de privacidad…"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detalles de privacidad…"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Detalles de privacidad…"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detalles de privacidad…"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "جزئیات حریم خصوصی…"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جزئیات حریم خصوصی…"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Détails de confidentialité…"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Détails de confidentialité…"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "פרטי פרטיות…"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "פרטי פרטיות…"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "निजता विवरण…"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "निजता विवरण…"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dettagli sulla privacy…"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dettagli sulla privacy…"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "プライバシーの詳細…"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プライバシーの詳細…"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "개인정보 자세히…"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "개인정보 자세히…"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Privacydetails…"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privacydetails…"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Szczegóły prywatności…"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Szczegóły prywatności…"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Detalhes de privacidade…"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detalhes de privacidade…"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Подробнее о конфиденциальности…"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подробнее о конфиденциальности…"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "隐私详情…"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隐私详情…"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "私隱詳情…"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "私隱詳情…"
           }
         }
       }
     },
-    "Quit %@" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إنهاء %@"
+    "Quit %@": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إنهاء %@"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ beenden"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ beenden"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quit %@"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quit %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Salir de %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salir de %@"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Salir de %@"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salir de %@"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "خروج از %@"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خروج از %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quitter %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitter %@"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "צא מ-%@"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "צא מ-%@"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ छोड़ें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ छोड़ें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esci da %@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esci da %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ を終了"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ を終了"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 종료"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 종료"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stop %@"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop %@"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zakończ %@"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zakończ %@"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Encerrar %@"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Encerrar %@"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Завершить %@"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завершить %@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "退出 %@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "退出 %@"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "結束 %@"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "結束 %@"
           }
         }
       }
     },
-    "Quit & Reopen" : {
-
-    },
-    "Rank frequently used emoji higher" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ترتيب الإيموجي الأكثر استخداماً في الأعلى"
+    "Rank frequently used emoji higher": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ترتيب الإيموجي الأكثر استخداماً في الأعلى"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Häufig verwendete Emoji höher einstufen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Häufig verwendete Emoji höher einstufen"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rank frequently used emoji higher"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rank frequently used emoji higher"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Priorizar los emoji que usas más"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Priorizar los emoji que usas más"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Priorizar los emojis que más usás"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Priorizar los emojis que más usás"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ایموجی‌های پرکاربرد بالاتر باشند"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ایموجی‌های پرکاربرد بالاتر باشند"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mettre en avant les émoji utilisés souvent"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mettre en avant les émoji utilisés souvent"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "דרג גבוה יותר אימוג'י שאתה משתמש בהם הרבה"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "דרג גבוה יותר אימוג'י שאתה משתמש בהם הרבה"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "अक्सर इस्तेमाल किए जाने वाले इमोजी ऊपर रखें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अक्सर इस्तेमाल किए जाने वाले इमोजी ऊपर रखें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dai priorità alle emoji più usate"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dai priorità alle emoji più usate"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "よく使う絵文字を上位に表示"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "よく使う絵文字を上位に表示"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "자주 쓰는 이모지를 위로"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "자주 쓰는 이모지를 위로"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Veelgebruikte emoji hoger sorteren"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veelgebruikte emoji hoger sorteren"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pokazuj często używane emoji wyżej"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pokazuj często używane emoji wyżej"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Priorizar emoji usados com frequência"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Priorizar emoji usados com frequência"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Часто используемые эмодзи выше"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Часто используемые эмодзи выше"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "常用 emoji 排序靠前"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "常用 emoji 排序靠前"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "常用 emoji 排序靠前"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "常用 emoji 排序靠前"
           }
         }
       }
     },
-    "Report an issue" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الإبلاغ عن مشكلة"
+    "Report an issue": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الإبلاغ عن مشكلة"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Problem melden"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Problem melden"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Report an issue"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Report an issue"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Informar de un problema"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informar de un problema"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Informar un problema"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informar un problema"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "گزارش مشکل"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "گزارش مشکل"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Signaler un problème"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signaler un problème"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "דווח על בעיה"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "דווח על בעיה"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "समस्या रिपोर्ट करें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "समस्या रिपोर्ट करें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Segnala un problema"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Segnala un problema"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "問題を報告"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "問題を報告"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "문제 신고"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "문제 신고"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Meld een probleem"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Meld een probleem"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zgłoś problem"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zgłoś problem"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Relatar um problema"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relatar um problema"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сообщить о проблеме"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сообщить о проблеме"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "报告问题"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "报告问题"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "回報問題"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "回報問題"
           }
         }
       }
     },
-    "Require `::` to search symbols" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اشترط `::` للبحث عن الرموز"
+    "Require `::` to search symbols": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اشترط `::` للبحث عن الرموز"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "`::` zum Suchen von Symbolen verlangen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "`::` zum Suchen von Symbolen verlangen"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Require `::` to search symbols"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Require `::` to search symbols"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Requerir `::` para buscar símbolos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requerir `::` para buscar símbolos"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Requerir `::` para buscar símbolos"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requerir `::` para buscar símbolos"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "برای جست‌وجوی نمادها `::` لازم باشد"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "برای جست‌وجوی نمادها `::` لازم باشد"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exiger `::` pour rechercher des symboles"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exiger `::` pour rechercher des symboles"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "דרוש `::` כדי לחפש סמלים"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "דרוש `::` כדי לחפש סמלים"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "प्रतीक खोजने के लिए `::` अनिवार्य"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "प्रतीक खोजने के लिए `::` अनिवार्य"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Richiedi `::` per cercare simboli"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Richiedi `::` per cercare simboli"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "記号の検索に `::` を必須にする"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "記号の検索に `::` を必須にする"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "기호 검색 시 `::` 입력 필요"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기호 검색 시 `::` 입력 필요"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vereis `::` om symbolen te zoeken"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vereis `::` om symbolen te zoeken"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wymagaj `::` do wyszukiwania symboli"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wymagaj `::` do wyszukiwania symboli"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exigir `::` para buscar símbolos"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exigir `::` para buscar símbolos"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Требовать `::` для поиска символов"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Требовать `::` для поиска символов"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "搜索符号需要输入 `::`"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索符号需要输入 `::`"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "搜尋符號需要輸入 `::`"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜尋符號需要輸入 `::`"
           }
         }
       }
     },
-    "Reset all easter egg progress?" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "هل تريد إعادة تعيين كلّ تقدّم البيوض المفاجِئة؟"
+    "Reset all easter egg progress?": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "هل تريد إعادة تعيين كلّ تقدّم البيوض المفاجِئة؟"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allen Easter-Egg-Fortschritt zurücksetzen?"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allen Easter-Egg-Fortschritt zurücksetzen?"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset all easter egg progress?"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset all easter egg progress?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Restablecer el progreso de los huevos de pascua?"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Restablecer el progreso de los huevos de pascua?"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Restablecer el progreso de los huevos de pascua?"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Restablecer el progreso de los huevos de pascua?"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تمام پیشرفت تخم‌مرغ‌های نوروزی پاک شود؟"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تمام پیشرفت تخم‌مرغ‌های نوروزی پاک شود؟"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Réinitialiser la progression des easter eggs ?"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réinitialiser la progression des easter eggs ?"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "לאפס את כל ההתקדמות בביצי הפסחא?"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "לאפס את כל ההתקדמות בביצי הפסחא?"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "क्या सभी ईस्टर एग प्रगति रीसेट कर दें?"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "क्या सभी ईस्टर एग प्रगति रीसेट कर दें?"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vuoi azzerare i progressi degli easter egg?"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vuoi azzerare i progressi degli easter egg?"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "イースターエッグの進捗をすべてリセットしますか?"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "イースターエッグの進捗をすべてリセットしますか?"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이스터에그 진행 상황을 모두 초기화할까요?"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이스터에그 진행 상황을 모두 초기화할까요?"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alle easter-egg-voortgang terugzetten?"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle easter-egg-voortgang terugzetten?"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zresetować cały postęp easter eggs?"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zresetować cały postęp easter eggs?"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Redefinir todo o progresso dos easter eggs?"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redefinir todo o progresso dos easter eggs?"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сбросить весь прогресс по пасхалкам?"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сбросить весь прогресс по пасхалкам?"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重置所有彩蛋进度?"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置所有彩蛋进度?"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重設所有彩蛋進度?"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重設所有彩蛋進度?"
           }
         }
       }
     },
-    "Reset eggs" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إعادة تعيين البيوض"
+    "Reset eggs": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعادة تعيين البيوض"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eggs zurücksetzen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eggs zurücksetzen"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset eggs"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset eggs"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restablecer huevos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer huevos"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restablecer huevos"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer huevos"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "پاک‌کردن تخم‌مرغ‌ها"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پاک‌کردن تخم‌مرغ‌ها"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Réinitialiser les eggs"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réinitialiser les eggs"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "אפס ביצים"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אפס ביצים"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "एग रीसेट करें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "एग रीसेट करें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Azzera gli egg"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Azzera gli egg"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "エッグをリセット"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エッグをリセット"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "에그 초기화"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "에그 초기화"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eggs herstellen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eggs herstellen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zresetuj eggs"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zresetuj eggs"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Redefinir eggs"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redefinir eggs"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сбросить пасхалки"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сбросить пасхалки"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重置彩蛋"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置彩蛋"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重設彩蛋"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重設彩蛋"
           }
         }
       }
     },
-    "Reset eggs..." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إعادة تعيين البيوض…"
+    "Reset eggs...": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعادة تعيين البيوض…"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eggs zurücksetzen…"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eggs zurücksetzen…"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset eggs…"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset eggs…"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restablecer huevos…"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer huevos…"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restablecer huevos…"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer huevos…"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "پاک‌کردن تخم‌مرغ‌ها…"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پاک‌کردن تخم‌مرغ‌ها…"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Réinitialiser les eggs…"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réinitialiser les eggs…"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "אפס ביצים…"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אפס ביצים…"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "एग रीसेट करें…"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "एग रीसेट करें…"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Azzera gli egg…"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Azzera gli egg…"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "エッグをリセット…"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エッグをリセット…"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "에그 초기화…"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "에그 초기화…"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eggs herstellen…"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eggs herstellen…"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zresetuj eggs…"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zresetuj eggs…"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Redefinir eggs…"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redefinir eggs…"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сбросить пасхалки…"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сбросить пасхалки…"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重置彩蛋…"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置彩蛋…"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重設彩蛋…"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重設彩蛋…"
           }
         }
       }
     },
-    "Resume" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "استئناف"
+    "Resume": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استئناف"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fortsetzen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fortsetzen"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resume"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resume"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reanudar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reanudar"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reanudar"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reanudar"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ادامه"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ادامه"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reprendre"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reprendre"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "המשך"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "המשך"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "फिर शुरू करें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "फिर शुरू करें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Riprendi"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riprendi"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "再開"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再開"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "다시 시작"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다시 시작"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hervat"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hervat"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wznów"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wznów"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retomar"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retomar"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Продолжить"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Продолжить"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "继续"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "继续"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "繼續"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "繼續"
           }
         }
       }
     },
-    "Search GIFs…" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "البحث عن GIF…"
+    "Search GIFs…": {
+      "extractionState": "stale",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "البحث عن GIF…"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIFs suchen…"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIFs suchen…"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search GIFs…"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search GIFs…"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscar GIF…"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar GIF…"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscar GIF…"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar GIF…"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "جست‌وجوی GIF…"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جست‌وجوی GIF…"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rechercher des GIF…"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher des GIF…"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "חפש GIF…"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "חפש GIF…"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF खोजें…"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF खोजें…"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cerca GIF…"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerca GIF…"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF を検索…"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF を検索…"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF 검색…"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF 검색…"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zoek GIFs…"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zoek GIFs…"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Szukaj GIF-ów…"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Szukaj GIF-ów…"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscar GIF…"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar GIF…"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Найти GIF…"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Найти GIF…"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "搜索 GIF…"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索 GIF…"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "搜尋 GIF…"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜尋 GIF…"
           }
         }
       }
     },
-    "Searching…" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "جارٍ البحث…"
+    "Searching…": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جارٍ البحث…"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suche läuft…"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suche läuft…"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Searching…"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Searching…"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscando…"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscando…"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscando…"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscando…"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "در حال جست‌وجو…"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "در حال جست‌وجو…"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recherche…"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recherche…"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "מחפש…"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מחפש…"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "खोजा जा रहा है…"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "खोजा जा रहा है…"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ricerca in corso…"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ricerca in corso…"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "検索中…"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検索中…"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "검색 중…"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "검색 중…"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zoeken…"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zoeken…"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wyszukiwanie…"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wyszukiwanie…"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscando…"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscando…"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Идёт поиск…"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Идёт поиск…"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "搜索中…"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索中…"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "搜尋中…"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜尋中…"
           }
         }
       }
     },
-    "Settings…" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الإعدادات…"
+    "Settings…": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الإعدادات…"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einstellungen…"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen…"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Settings…"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings…"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajustes…"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes…"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajustes…"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes…"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تنظیمات…"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تنظیمات…"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Réglages…"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réglages…"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "הגדרות…"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הגדרות…"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "सेटिंग्स…"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सेटिंग्स…"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impostazioni…"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impostazioni…"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "設定…"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定…"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "설정…"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정…"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instellingen…"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instellingen…"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ustawienia…"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ustawienia…"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajustes…"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes…"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Настройки…"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройки…"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "设置…"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置…"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "設定…"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定…"
           }
         }
       }
-    },
-    "Show Details" : {
-
     },
-    "Show Onboarding" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "عرض الإعداد الترحيبي"
+    "Show Onboarding": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عرض الإعداد الترحيبي"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einführung anzeigen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einführung anzeigen"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Onboarding"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Onboarding"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar la bienvenida"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar la bienvenida"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar la bienvenida"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar la bienvenida"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "نمایش راه‌اندازی اولیه"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نمایش راه‌اندازی اولیه"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afficher l'onboarding"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher l'onboarding"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "הצג מסך הצטרפות"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הצג מסך הצטרפות"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ऑनबोर्डिंग दिखाएँ"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ऑनबोर्डिंग दिखाएँ"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostra l'onboarding"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostra l'onboarding"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オンボーディングを表示"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オンボーディングを表示"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "온보딩 보기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "온보딩 보기"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toon onboarding"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toon onboarding"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pokaż wprowadzenie"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pokaż wprowadzenie"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar onboarding"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar onboarding"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Показать вступительный обзор"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показать вступительный обзор"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "显示引导"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示引导"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "顯示引導"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示引導"
           }
         }
       }
     },
-    "Show icon in menu bar" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إظهار الأيقونة في شريط القوائم"
+    "Show icon in menu bar": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إظهار الأيقونة في شريط القوائم"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Symbol in der Menüleiste anzeigen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symbol in der Menüleiste anzeigen"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show icon in menu bar"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show icon in menu bar"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar icono en la barra de menús"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar icono en la barra de menús"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar ícono en la barra de menús"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar ícono en la barra de menús"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "نمایش آیکون در نوار منو"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نمایش آیکون در نوار منو"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afficher l'icône dans la barre de menus"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher l'icône dans la barre de menus"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "הצג צלמית בשורת התפריטים"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הצג צלמית בשורת התפריטים"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "मेन्यू बार में आइकन दिखाएँ"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मेन्यू बार में आइकन दिखाएँ"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostra l'icona nella barra dei menu"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostra l'icona nella barra dei menu"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "メニューバーにアイコンを表示"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メニューバーにアイコンを表示"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "메뉴 막대에 아이콘 표시"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "메뉴 막대에 아이콘 표시"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toon pictogram in menubalk"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toon pictogram in menubalk"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pokaż ikonę na pasku menu"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pokaż ikonę na pasku menu"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar ícone na barra de menus"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar ícone na barra de menus"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Показывать значок в строке меню"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показывать значок в строке меню"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在菜单栏中显示图标"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在菜单栏中显示图标"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在選單列中顯示圖示"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在選單列中顯示圖示"
           }
         }
       }
     },
-    "Skin tone" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لون البشرة"
+    "Skin tone": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لون البشرة"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hautton"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hautton"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skin tone"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skin tone"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tono de piel"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tono de piel"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tono de piel"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tono de piel"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "رنگ پوست"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "رنگ پوست"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Teinte de peau"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teinte de peau"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "גוון עור"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "גוון עור"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "त्वचा का रंग"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "त्वचा का रंग"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tono della pelle"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tono della pelle"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "肌の色"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "肌の色"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "피부색"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "피부색"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Huidtint"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Huidtint"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Odcień skóry"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odcień skóry"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tom de pele"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tom de pele"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Тон кожи"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тон кожи"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "肤色"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "肤色"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "膚色"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "膚色"
           }
         }
       }
     },
-    "Start at login" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "البدء عند تسجيل الدخول"
+    "Start at login": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "البدء عند تسجيل الدخول"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beim Anmelden starten"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beim Anmelden starten"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Start at login"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start at login"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Iniciar al iniciar sesión"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iniciar al iniciar sesión"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Iniciar al iniciar sesión"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iniciar al iniciar sesión"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اجرا هنگام ورود"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اجرا هنگام ورود"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lancer à l'ouverture de session"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lancer à l'ouverture de session"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "הפעל בעת הכניסה"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הפעל בעת הכניסה"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "लॉगिन पर शुरू करें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लॉगिन पर शुरू करें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avvia all'accesso"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avvia all'accesso"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ログイン時に起動"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ログイン時に起動"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "로그인 시 시작"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로그인 시 시작"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Start bij inloggen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start bij inloggen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uruchamiaj przy logowaniu"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uruchamiaj przy logowaniu"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Iniciar ao fazer login"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iniciar ao fazer login"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Запускать при входе"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запускать при входе"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "登录时启动"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "登录时启动"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "登入時啟動"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "登入時啟動"
           }
         }
       }
     },
-    "Stats" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الإحصاءات"
+    "Stats": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الإحصاءات"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Statistiken"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistiken"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stats"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stats"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estadísticas"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estadísticas"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estadísticas"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estadísticas"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "آمار"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "آمار"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Statistiques"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistiques"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "סטטיסטיקות"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "סטטיסטיקות"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "आँकड़े"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आँकड़े"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Statistiche"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistiche"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "統計"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "統計"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "통계"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "통계"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Statistieken"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistieken"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Statystyki"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statystyki"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estatísticas"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estatísticas"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Статистика"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Статистика"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "统计"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "统计"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "統計"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "統計"
           }
         }
       }
     },
-    "Stop" : {
-
-    },
-    "Support Wells" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ادعم Wells"
+    "Support Wells": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ادعم Wells"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wells unterstützen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wells unterstützen"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Support Wells"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Support Wells"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apoya a Wells"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apoya a Wells"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apoyá a Wells"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apoyá a Wells"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "از Wells حمایت کنید"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "از Wells حمایت کنید"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Soutenir Wells"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Soutenir Wells"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "תמוך ב-Wells"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "תמוך ב-Wells"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wells का सहयोग करें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wells का सहयोग करें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sostieni Wells"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sostieni Wells"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wells を支援する"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wells を支援する"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wells 후원하기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wells 후원하기"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Steun Wells"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Steun Wells"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wesprzyj Wellsa"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wesprzyj Wellsa"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apoiar Wells"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apoiar Wells"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Поддержать Wells"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поддержать Wells"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "支持 Wells"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "支持 Wells"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "支持 Wells"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "支持 Wells"
           }
         }
       }
     },
-    "Symbols" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الرموز"
+    "Symbols": {
+      "localizations": {
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symbols"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Symbole"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symbole"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Symbols"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Símbolos"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Símbolos"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Símbolos"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Símbolos"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symboles"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "نمادها"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Simboli"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Symboles"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Símbolos"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "סמלים"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "記号"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "प्रतीक"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "符号"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Simboli"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "符號"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "記号"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기호"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "기호"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "प्रतीक"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Symbolen"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Символы"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Symbole"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symbole"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Símbolos"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symbolen"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Символы"
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الرموز"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "符号"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نمادها"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "符號"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "סמלים"
           }
         }
       }
     },
-    "Thank you" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "شكراً"
+    "Thank you": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "شكراً"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Danke"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Danke"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thank you"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thank you"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gracias"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gracias"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gracias"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gracias"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ممنون"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ممنون"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Merci"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Merci"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "תודה"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "תודה"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "धन्यवाद"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "धन्यवाद"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Grazie"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grazie"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ありがとう"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ありがとう"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "감사합니다"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "감사합니다"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bedankt"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bedankt"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dziękuję"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dziękuję"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obrigado"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obrigado"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Спасибо"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Спасибо"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "谢谢"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "谢谢"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "謝謝"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "謝謝"
           }
         }
       }
     },
-    "This will erase your autocomplete stats and Top 8. Settings and exclusions won't be changed." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "سيؤدّي ذلك إلى مسح إحصاءات الإكمال التلقائي وقائمة الـ Top 8 الخاصة بك. لن تتغيّر الإعدادات والاستثناءات."
+    "This will erase your autocomplete stats and Top 8. Settings and exclusions won't be changed.": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سيؤدّي ذلك إلى مسح إحصاءات الإكمال التلقائي وقائمة الـ Top 8 الخاصة بك. لن تتغيّر الإعدادات والاستثناءات."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Damit werden deine Autovervollständigungs-Statistiken und Top 8 gelöscht. Einstellungen und Ausnahmen bleiben unverändert."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Damit werden deine Autovervollständigungs-Statistiken und Top 8 gelöscht. Einstellungen und Ausnahmen bleiben unverändert."
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This will erase your autocomplete stats and Top 8. Settings and exclusions won't be changed."
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This will erase your autocomplete stats and Top 8. Settings and exclusions won't be changed."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esto borrará tus estadísticas de autocompletado y tu Top 8. Los ajustes y exclusiones no cambiarán."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto borrará tus estadísticas de autocompletado y tu Top 8. Los ajustes y exclusiones no cambiarán."
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esto borrará tus estadísticas de autocompletado y tu Top 8. Los ajustes y exclusiones no cambiarán."
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto borrará tus estadísticas de autocompletado y tu Top 8. Los ajustes y exclusiones no cambiarán."
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "این کار آمار تکمیل خودکار و Top 8 شما را پاک می‌کند. تنظیمات و موارد مستثنا تغییری نمی‌کنند."
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "این کار آمار تکمیل خودکار و Top 8 شما را پاک می‌کند. تنظیمات و موارد مستثنا تغییری نمی‌کنند."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cela effacera vos statistiques d'autocomplétion et votre Top 8. Les réglages et exclusions ne changeront pas."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cela effacera vos statistiques d'autocomplétion et votre Top 8. Les réglages et exclusions ne changeront pas."
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "פעולה זו תמחק את סטטיסטיקות ההשלמה האוטומטית ואת ה-Top 8 שלך. ההגדרות וההחרגות יישארו כפי שהן."
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "פעולה זו תמחק את סטטיסטיקות ההשלמה האוטומטית ואת ה-Top 8 שלך. ההגדרות וההחרגות יישארו כפי שהן."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "इससे आपके ऑटोकम्प्लीट आँकड़े और टॉप 8 हट जाएँगे। सेटिंग्स और अपवर्जन नहीं बदलेंगे।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "इससे आपके ऑटोकम्प्लीट आँकड़े और टॉप 8 हट जाएँगे। सेटिंग्स और अपवर्जन नहीं बदलेंगे।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verranno cancellate le statistiche di completamento automatico e la Top 8. Impostazioni ed esclusioni resteranno invariate."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verranno cancellate le statistiche di completamento automatico e la Top 8. Impostazioni ed esclusioni resteranno invariate."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自動補完の統計と Top 8 を削除します。設定と除外リストは変更されません。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動補完の統計と Top 8 を削除します。設定と除外リストは変更されません。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "자동 완성 통계와 Top 8이(가) 삭제됩니다. 설정과 제외 항목은 변경되지 않습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "자동 완성 통계와 Top 8이(가) 삭제됩니다. 설정과 제외 항목은 변경되지 않습니다."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hiermee verwijder je je autocomplete-statistieken en Top 8. Instellingen en uitsluitingen blijven onveranderd."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hiermee verwijder je je autocomplete-statistieken en Top 8. Instellingen en uitsluitingen blijven onveranderd."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wyczyści to twoje statystyki autouzupełniania i Top 8. Ustawienia i wykluczenia pozostaną bez zmian."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wyczyści to twoje statystyki autouzupełniania i Top 8. Ustawienia i wykluczenia pozostaną bez zmian."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Isso apagará suas estatísticas de autocompletar e o Top 8. Os ajustes e exclusões não serão alterados."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Isso apagará suas estatísticas de autocompletar e o Top 8. Os ajustes e exclusões não serão alterados."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Это удалит вашу статистику автодополнения и Top 8. Настройки и исключения не изменятся."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Это удалит вашу статистику автодополнения и Top 8. Настройки и исключения не изменятся."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此操作将清除你的自动补全统计和 Top 8。设置和排除项不会改变。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此操作将清除你的自动补全统计和 Top 8。设置和排除项不会改变。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此操作將清除你的自動完成統計和 Top 8。設定和排除項目不會改變。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此操作將清除你的自動完成統計和 Top 8。設定和排除項目不會改變。"
           }
         }
       }
     },
-    "This will erase your discovery progress and any per-egg counters. The eggs themselves still work — you'll just need to find them again." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "سيؤدّي ذلك إلى مسح تقدّم اكتشافك وكل عدّادات البيوض الفردية. البيوض نفسها ستظلّ تعمل — ستحتاج فقط للعثور عليها من جديد."
+    "This will erase your discovery progress and any per-egg counters. The eggs themselves still work — you'll just need to find them again.": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سيؤدّي ذلك إلى مسح تقدّم اكتشافك وكل عدّادات البيوض الفردية. البيوض نفسها ستظلّ تعمل — ستحتاج فقط للعثور عليها من جديد."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Damit werden dein Entdeckungs-Fortschritt und alle eggs-spezifischen Zähler gelöscht. Die Eggs selbst funktionieren weiter – du musst sie nur wieder finden."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Damit werden dein Entdeckungs-Fortschritt und alle eggs-spezifischen Zähler gelöscht. Die Eggs selbst funktionieren weiter – du musst sie nur wieder finden."
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This will erase your discovery progress and any per-egg counters. The eggs themselves still work — you'll just need to find them again."
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This will erase your discovery progress and any per-egg counters. The eggs themselves still work — you'll just need to find them again."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esto borrará tu progreso de descubrimiento y los contadores de cada egg. Los eggs siguen funcionando — solo tendrás que encontrarlos otra vez."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto borrará tu progreso de descubrimiento y los contadores de cada egg. Los eggs siguen funcionando — solo tendrás que encontrarlos otra vez."
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esto borrará tu progreso de descubrimiento y los contadores de cada egg. Los eggs siguen funcionando — solo tendrás que encontrarlos otra vez."
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto borrará tu progreso de descubrimiento y los contadores de cada egg. Los eggs siguen funcionando — solo tendrás que encontrarlos otra vez."
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "این کار پیشرفت کشف و شمارنده‌های هر تخم‌مرغ را پاک می‌کند. خود تخم‌مرغ‌ها همچنان کار می‌کنند — فقط باید دوباره پیدای‌شان کنید."
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "این کار پیشرفت کشف و شمارنده‌های هر تخم‌مرغ را پاک می‌کند. خود تخم‌مرغ‌ها همچنان کار می‌کنند — فقط باید دوباره پیدای‌شان کنید."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cela effacera votre progression et les compteurs propres à chaque egg. Les eggs continuent de fonctionner — il faudra juste les retrouver."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cela effacera votre progression et les compteurs propres à chaque egg. Les eggs continuent de fonctionner — il faudra juste les retrouver."
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "פעולה זו תמחק את התקדמות הגילוי ואת המונים של כל ביצה. הביצים עצמן ימשיכו לעבוד — פשוט תצטרך למצוא אותן שוב."
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "פעולה זו תמחק את התקדמות הגילוי ואת המונים של כל ביצה. הביצים עצמן ימשיכו לעבוד — פשוט תצטרך למצוא אותן שוב."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "इससे आपकी खोज प्रगति और हर एग के काउंटर मिट जाएँगे। एग खुद काम करते रहेंगे — आपको बस उन्हें फिर से ढूँढना होगा।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "इससे आपकी खोज प्रगति और हर एग के काउंटर मिट जाएँगे। एग खुद काम करते रहेंगे — आपको बस उन्हें फिर से ढूँढना होगा।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verranno cancellati i tuoi progressi e tutti i contatori dei singoli egg. Gli egg continuano a funzionare — dovrai solo ritrovarli."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verranno cancellati i tuoi progressi e tutti i contatori dei singoli egg. Gli egg continuano a funzionare — dovrai solo ritrovarli."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "発見の進捗と各エッグごとのカウンターを削除します。エッグ自体は動作するので、また見つけ直してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "発見の進捗と各エッグごとのカウンターを削除します。エッグ自体は動作するので、また見つけ直してください。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "발견 진행 상황과 에그별 카운터가 삭제됩니다. 에그 자체는 그대로 동작하니, 다시 찾으면 됩니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "발견 진행 상황과 에그별 카운터가 삭제됩니다. 에그 자체는 그대로 동작하니, 다시 찾으면 됩니다."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hiermee verwijder je je ontdekkings­voortgang en alle per-egg-tellers. De eggs zelf werken nog steeds — je hoeft ze gewoon opnieuw te vinden."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hiermee verwijder je je ontdekkings­voortgang en alle per-egg-tellers. De eggs zelf werken nog steeds — je hoeft ze gewoon opnieuw te vinden."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wyczyści to twój postęp odkrywania i liczniki poszczególnych easter eggs. Same eggs nadal działają — wystarczy je odkryć ponownie."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wyczyści to twój postęp odkrywania i liczniki poszczególnych easter eggs. Same eggs nadal działają — wystarczy je odkryć ponownie."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Isso apagará seu progresso de descoberta e os contadores de cada egg. Os eggs continuam funcionando — você só precisará encontrá-los de novo."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Isso apagará seu progresso de descoberta e os contadores de cada egg. Os eggs continuam funcionando — você só precisará encontrá-los de novo."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Это удалит ваш прогресс открытий и все счётчики по конкретным пасхалкам. Сами пасхалки продолжат работать — просто найдёте их заново."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Это удалит ваш прогресс открытий и все счётчики по конкретным пасхалкам. Сами пасхалки продолжат работать — просто найдёте их заново."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此操作将清除你的发现进度和每个彩蛋的计数。彩蛋本身仍然有效 — 你只需重新发现它们。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此操作将清除你的发现进度和每个彩蛋的计数。彩蛋本身仍然有效 — 你只需重新发现它们。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此操作將清除你的發現進度和每個彩蛋的計數。彩蛋本身仍然有效 — 你只需重新發現它們。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此操作將清除你的發現進度和每個彩蛋的計數。彩蛋本身仍然有效 — 你只需重新發現它們。"
           }
         }
       }
     },
-    "Type `:::` then a search term to insert a GIF from Giphy." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اكتب `:::` ثم كلمة بحث لإدراج صورة GIF من Giphy."
+    "Type `:::` then a search term to insert a GIF from Giphy.": {
+      "localizations": {
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Type `:::` then a search term to insert a GIF from Giphy."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tippe `:::` und dann einen Suchbegriff, um ein GIF von Giphy einzufügen."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tippe `:::` und dann einen Suchbegriff, um ein GIF von Giphy einzufügen."
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Type `:::` then a search term to insert a GIF from Giphy."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escribe `:::` seguido de un término de búsqueda para insertar un GIF de Giphy."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escribe `:::` seguido de un término de búsqueda para insertar un GIF de Giphy."
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escribí `:::` seguido de un término de búsqueda para insertar un GIF de Giphy."
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escribí `:::` seguido de un término de búsqueda para insertar un GIF de Giphy."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tape `:::` puis un terme de recherche pour insérer un GIF depuis Giphy."
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏`:::` و سپس یک عبارت جست‌وجو تایپ کنید تا یک GIF از Giphy درج شود."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Digita `:::` seguito da un termine di ricerca per inserire un GIF da Giphy."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tape `:::` puis un terme de recherche pour insérer un GIF depuis Giphy."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Digite `:::` e depois um termo de busca para inserir um GIF do Giphy."
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "הקלד `:::` ואז ביטוי חיפוש כדי להוסיף GIF מ-Giphy."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "`:::` の後に検索語を入力すると、Giphy から GIF を挿入できます。"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giphy से GIF डालने के लिए `:::` के बाद कोई खोज शब्द टाइप करें।"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "输入 `:::` 后跟搜索词,从 Giphy 插入 GIF。"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Digita `:::` seguito da un termine di ricerca per inserire un GIF da Giphy."
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輸入 `:::` 後接搜尋字詞,即可從 Giphy 插入 GIF。"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "`:::` の後に検索語を入力すると、Giphy から GIF を挿入できます。"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "`:::` 다음에 검색어를 입력하면 Giphy에서 GIF를 삽입합니다."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "`:::` 다음에 검색어를 입력하면 Giphy에서 GIF를 삽입합니다."
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giphy से GIF डालने के लिए `:::` के बाद कोई खोज शब्द टाइप करें।"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Typ `:::` gevolgd door een zoekterm om een GIF van Giphy in te voegen."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Введите `:::` и поисковый запрос, чтобы вставить GIF из Giphy."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wpisz `:::`, a następnie szukane hasło, aby wstawić GIF z Giphy."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wpisz `:::`, a następnie szukane hasło, aby wstawić GIF z Giphy."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Digite `:::` e depois um termo de busca para inserir um GIF do Giphy."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Typ `:::` gevolgd door een zoekterm om een GIF van Giphy in te voegen."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Введите `:::` и поисковый запрос, чтобы вставить GIF из Giphy."
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اكتب `:::` ثم كلمة بحث لإدراج صورة GIF من Giphy."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "输入 `:::` 后跟搜索词,从 Giphy 插入 GIF。"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏`:::` و سپس یک عبارت جست‌وجو تایپ کنید تا یک GIF از Giphy درج شود."
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "輸入 `:::` 後接搜尋字詞,即可從 Giphy 插入 GIF。"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הקלד `:::` ואז ביטוי חיפוש כדי להוסיף GIF מ-Giphy."
           }
         }
       }
     },
-    "Type `:` to search for any emoji or symbol in seconds." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اكتب `:` للبحث عن أيّ إيموجي أو رمز في ثوانٍ."
+    "Type `:` to search for any emoji or symbol in seconds.": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اكتب `:` للبحث عن أيّ إيموجي أو رمز في ثوانٍ."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tippe `:`, um in Sekunden ein Emoji oder Symbol zu finden."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tippe `:`, um in Sekunden ein Emoji oder Symbol zu finden."
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Type `:` to search for any emoji or symbol in seconds."
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Type `:` to search for any emoji or symbol in seconds."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escribe `:` para buscar cualquier emoji o símbolo en segundos."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escribe `:` para buscar cualquier emoji o símbolo en segundos."
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escribí `:` para buscar cualquier emoji o símbolo en segundos."
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escribí `:` para buscar cualquier emoji o símbolo en segundos."
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "برای جست‌وجوی هر ایموجی یا نماد در چند ثانیه، `:` را تایپ کنید."
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "برای جست‌وجوی هر ایموجی یا نماد در چند ثانیه، `:` را تایپ کنید."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tapez `:` pour trouver n'importe quel émoji ou symbole en quelques secondes."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tapez `:` pour trouver n'importe quel émoji ou symbole en quelques secondes."
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "הקלד `:` כדי לחפש כל אימוג'י או סמל בשניות."
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הקלד `:` כדי לחפש כל אימוג'י או סמל בשניות."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "किसी भी इमोजी या प्रतीक को सेकंडों में खोजने के लिए `:` टाइप करें।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "किसी भी इमोजी या प्रतीक को सेकंडों में खोजने के लिए `:` टाइप करें।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Digita `:` per cercare qualsiasi emoji o simbolo in pochi secondi."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Digita `:` per cercare qualsiasi emoji o simbolo in pochi secondi."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "`:` を入力すれば、絵文字や記号を数秒で検索できます。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "`:` を入力すれば、絵文字や記号を数秒で検索できます。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "`:` 만 입력하면 몇 초 만에 이모지나 기호를 찾을 수 있습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "`:` 만 입력하면 몇 초 만에 이모지나 기호를 찾을 수 있습니다."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Typ `:` om in seconden elke emoji of symbool te zoeken."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Typ `:` om in seconden elke emoji of symbool te zoeken."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wpisz `:`, by w sekundę znaleźć dowolne emoji lub symbol."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wpisz `:`, by w sekundę znaleźć dowolne emoji lub symbol."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Digite `:` para buscar qualquer emoji ou símbolo em segundos."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Digite `:` para buscar qualquer emoji ou símbolo em segundos."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Введите `:`, чтобы за секунды найти любое эмодзи или символ."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Введите `:`, чтобы за секунды найти любое эмодзи или символ."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "输入 `:` 即可在数秒内搜索任意 emoji 或符号。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "输入 `:` 即可在数秒内搜索任意 emoji 或符号。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "輸入 `:` 即可在數秒內搜尋任意 emoji 或符號。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輸入 `:` 即可在數秒內搜尋任意 emoji 或符號。"
           }
         }
       }
     },
-    "Type some emoji and they'll show up here." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اكتب بعض الإيموجي وستظهر هنا."
+    "Type some emoji and they'll show up here.": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اكتب بعض الإيموجي وستظهر هنا."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tippe ein paar Emoji – sie tauchen dann hier auf."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tippe ein paar Emoji – sie tauchen dann hier auf."
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Type some emoji and they'll show up here."
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Type some emoji and they'll show up here."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escribe algunos emoji y aparecerán aquí."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escribe algunos emoji y aparecerán aquí."
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escribí algunos emojis y aparecerán acá."
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escribí algunos emojis y aparecerán acá."
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "چند ایموجی تایپ کنید تا اینجا نمایش داده شوند."
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "چند ایموجی تایپ کنید تا اینجا نمایش داده شوند."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tapez quelques émoji et ils apparaîtront ici."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tapez quelques émoji et ils apparaîtront ici."
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "הקלד כמה אימוג'י והם יופיעו כאן."
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הקלד כמה אימוג'י והם יופיעו כאן."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "कुछ इमोजी टाइप करें, वे यहाँ दिखेंगे।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कुछ इमोजी टाइप करें, वे यहाँ दिखेंगे।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Digita qualche emoji e compariranno qui."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Digita qualche emoji e compariranno qui."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "絵文字をいくつか入力すると、ここに表示されます。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "絵文字をいくつか入力すると、ここに表示されます。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이모지를 몇 개 입력하면 여기에 나타납니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이모지를 몇 개 입력하면 여기에 나타납니다."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Typ wat emoji en ze verschijnen hier."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Typ wat emoji en ze verschijnen hier."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wpisz kilka emoji, a pojawią się tutaj."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wpisz kilka emoji, a pojawią się tutaj."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Digite alguns emoji e eles aparecerão aqui."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Digite alguns emoji e eles aparecerão aqui."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Введите несколько эмодзи — они появятся здесь."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Введите несколько эмодзи — они появятся здесь."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "输入一些 emoji,它们就会显示在这里。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "输入一些 emoji,它们就会显示在这里。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "輸入一些 emoji,它們就會顯示在這裡。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輸入一些 emoji,它們就會顯示在這裡。"
           }
         }
       }
     },
-    "Type to search GIFs." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اكتب للبحث عن GIF."
+    "Type to search GIFs.": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اكتب للبحث عن GIF."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tippe, um GIFs zu suchen."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tippe, um GIFs zu suchen."
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Type to search GIFs."
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Type to search GIFs."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escribe para buscar GIF."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escribe para buscar GIF."
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escribí para buscar GIF."
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escribí para buscar GIF."
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "برای جست‌وجوی GIF تایپ کنید."
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "برای جست‌وجوی GIF تایپ کنید."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tape pour rechercher des GIF."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tape pour rechercher des GIF."
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "הקלד כדי לחפש GIF-ים."
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הקלד כדי לחפש GIF-ים."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF खोजने के लिए टाइप करें।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF खोजने के लिए टाइप करें।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Digita per cercare GIF."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Digita per cercare GIF."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF を検索するには入力してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF を検索するには入力してください。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GIF를 검색하려면 입력하세요."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF를 검색하려면 입력하세요."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Typ om GIFs te zoeken."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Typ om GIFs te zoeken."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wpisz, aby wyszukać GIF-y."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wpisz, aby wyszukać GIF-y."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Digite para buscar GIF."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Digite para buscar GIF."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Введите запрос для поиска GIF."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Введите запрос для поиска GIF."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "输入以搜索 GIF。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "输入以搜索 GIF。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "輸入以搜尋 GIF。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輸入以搜尋 GIF。"
           }
         }
       }
     },
-    "Update check failed" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "فشل التحقّق من التحديثات"
+    "Update check failed": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فشل التحقّق من التحديثات"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Update-Prüfung fehlgeschlagen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update-Prüfung fehlgeschlagen"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Update check failed"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update check failed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error al buscar actualizaciones"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error al buscar actualizaciones"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falló la búsqueda de actualizaciones"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falló la búsqueda de actualizaciones"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "بررسی به‌روزرسانی شکست خورد"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بررسی به‌روزرسانی شکست خورد"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Échec de la vérification des mises à jour"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec de la vérification des mises à jour"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "בדיקת העדכון נכשלה"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "בדיקת העדכון נכשלה"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "अपडेट जाँच विफल"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अपडेट जाँच विफल"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verifica aggiornamenti non riuscita"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verifica aggiornamenti non riuscita"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アップデートの確認に失敗しました"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップデートの確認に失敗しました"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "업데이트 확인 실패"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "업데이트 확인 실패"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Update controleren mislukt"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update controleren mislukt"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sprawdzanie aktualizacji nieudane"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprawdzanie aktualizacji nieudane"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falha ao verificar atualizações"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falha ao verificar atualizações"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не удалось проверить обновления"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось проверить обновления"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "检查更新失败"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查更新失败"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "檢查更新失敗"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "檢查更新失敗"
           }
         }
       }
     },
-    "Usage counts, settings, and your exclusion list are stored locally. %@ doesn't send any telemetry or usage data back to our server—we don't even have a server 🙂" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تُحفظ أعداد الاستخدام والإعدادات وقائمة الاستثناء محلياً. لا يُرسل %@ أيّ بيانات قياس أو استخدام إلى خادم — لا يوجد لدينا خادم أصلاً 🙂"
+    "Usage counts, settings, and your exclusion list are stored locally. %@ doesn't send any telemetry or usage data back to our server—we don't even have a server 🙂": {
+      "extractionState": "stale",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تُحفظ أعداد الاستخدام والإعدادات وقائمة الاستثناء محلياً. لا يُرسل %@ أيّ بيانات قياس أو استخدام إلى خادم — لا يوجد لدينا خادم أصلاً 🙂"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nutzungszähler, Einstellungen und deine Ausnahmeliste werden lokal gespeichert. %@ sendet keine Telemetrie- oder Nutzungsdaten an einen Server – wir haben nicht mal einen 🙂"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nutzungszähler, Einstellungen und deine Ausnahmeliste werden lokal gespeichert. %@ sendet keine Telemetrie- oder Nutzungsdaten an einen Server – wir haben nicht mal einen 🙂"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usage counts, settings, and your exclusion list are stored locally. %@ doesn't send any telemetry or usage data back to our server—we don't even have a server 🙂"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usage counts, settings, and your exclusion list are stored locally. %@ doesn't send any telemetry or usage data back to our server—we don't even have a server 🙂"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Los contadores de uso, los ajustes y tu lista de exclusiones se guardan localmente. %@ no envía telemetría ni datos de uso a un servidor — ni siquiera tenemos servidor 🙂"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los contadores de uso, los ajustes y tu lista de exclusiones se guardan localmente. %@ no envía telemetría ni datos de uso a un servidor — ni siquiera tenemos servidor 🙂"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Los contadores de uso, los ajustes y tu lista de exclusiones se guardan localmente. %@ no envía telemetría ni datos de uso a un servidor — ni siquiera tenemos servidor 🙂"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los contadores de uso, los ajustes y tu lista de exclusiones se guardan localmente. %@ no envía telemetría ni datos de uso a un servidor — ni siquiera tenemos servidor 🙂"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "شمارنده‌های استفاده، تنظیمات و فهرست مستثنیات شما به‌صورت محلی ذخیره می‌شوند. %@ هیچ داده‌ای را به سرور ارسال نمی‌کند — اصلاً ما سروری نداریم 🙂"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "شمارنده‌های استفاده، تنظیمات و فهرست مستثنیات شما به‌صورت محلی ذخیره می‌شوند. %@ هیچ داده‌ای را به سرور ارسال نمی‌کند — اصلاً ما سروری نداریم 🙂"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les compteurs d'utilisation, les réglages et votre liste d'exclusions restent en local. %@ n'envoie aucune télémétrie ni donnée d'usage à un serveur — on n'a même pas de serveur 🙂"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les compteurs d'utilisation, les réglages et votre liste d'exclusions restent en local. %@ n'envoie aucune télémétrie ni donnée d'usage à un serveur — on n'a même pas de serveur 🙂"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ספירת השימוש, ההגדרות ורשימת ההחרגות נשמרות מקומית. %@ לא שולח שום נתוני טלמטריה או שימוש לשרת — אין לנו אפילו שרת 🙂"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ספירת השימוש, ההגדרות ורשימת ההחרגות נשמרות מקומית. %@ לא שולח שום נתוני טלמטריה או שימוש לשרת — אין לנו אפילו שרת 🙂"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "उपयोग गिनती, सेटिंग्स और आपकी अपवर्जन सूची स्थानीय रूप से सेव होती है। %@ कोई टेलीमेट्री या उपयोग डेटा सर्वर पर नहीं भेजता — हमारे पास सर्वर ही नहीं है 🙂"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "उपयोग गिनती, सेटिंग्स और आपकी अपवर्जन सूची स्थानीय रूप से सेव होती है। %@ कोई टेलीमेट्री या उपयोग डेटा सर्वर पर नहीं भेजता — हमारे पास सर्वर ही नहीं है 🙂"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "I contatori d'uso, le impostazioni e l'elenco delle esclusioni restano in locale. %@ non invia telemetria o dati di utilizzo a un server — non abbiamo nemmeno un server 🙂"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I contatori d'uso, le impostazioni e l'elenco delle esclusioni restano in locale. %@ non invia telemetria o dati di utilizzo a un server — non abbiamo nemmeno un server 🙂"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "使用回数、設定、除外リストはローカルに保存されます。%@ はテレメトリや利用データをサーバーに送信しません — そもそもサーバーがありません 🙂"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用回数、設定、除外リストはローカルに保存されます。%@ はテレメトリや利用データをサーバーに送信しません — そもそもサーバーがありません 🙂"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "사용 횟수, 설정, 제외 목록은 모두 로컬에 저장됩니다. %@은(는) 어떤 텔레메트리나 사용 데이터도 서버로 보내지 않습니다 — 서버 자체가 없어요 🙂"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용 횟수, 설정, 제외 목록은 모두 로컬에 저장됩니다. %@은(는) 어떤 텔레메트리나 사용 데이터도 서버로 보내지 않습니다 — 서버 자체가 없어요 🙂"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gebruiksstatistieken, instellingen en je uitsluitingslijst worden lokaal opgeslagen. %@ stuurt geen telemetrie of gebruiksgegevens naar een server — we hebben niet eens een server 🙂"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gebruiksstatistieken, instellingen en je uitsluitingslijst worden lokaal opgeslagen. %@ stuurt geen telemetrie of gebruiksgegevens naar een server — we hebben niet eens een server 🙂"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Liczniki użycia, ustawienia i lista wykluczeń są zapisywane lokalnie. %@ nie wysyła żadnej telemetrii ani danych użycia — nie mamy nawet serwera 🙂"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liczniki użycia, ustawienia i lista wykluczeń są zapisywane lokalnie. %@ nie wysyła żadnej telemetrii ani danych użycia — nie mamy nawet serwera 🙂"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Os contadores de uso, os ajustes e sua lista de exclusões ficam no seu Mac. %@ não envia telemetria nem dados de uso para um servidor — a gente nem tem servidor 🙂"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Os contadores de uso, os ajustes e sua lista de exclusões ficam no seu Mac. %@ não envia telemetria nem dados de uso para um servidor — a gente nem tem servidor 🙂"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Счётчики использования, настройки и список исключений хранятся локально. %@ не отправляет телеметрию и данные использования — у нас даже сервера нет 🙂"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Счётчики использования, настройки и список исключений хранятся локально. %@ не отправляет телеметрию и данные использования — у нас даже сервера нет 🙂"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "使用次数、设置和你的排除列表都存在本地。%@ 不会将任何遥测或使用数据发送到服务器 — 我们连服务器都没有 🙂"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用次数、设置和你的排除列表都存在本地。%@ 不会将任何遥测或使用数据发送到服务器 — 我们连服务器都没有 🙂"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "使用次數、設定和你的排除清單都存在本機。%@ 不會將任何遙測或使用資料傳送到伺服器 — 我們根本沒有伺服器 🙂"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用次數、設定和你的排除清單都存在本機。%@ 不會將任何遙測或使用資料傳送到伺服器 — 我們根本沒有伺服器 🙂"
           }
         }
       }
-    },
-    "Usage counts, settings, and your exclusion list are stored locally. %@ doesn't send any telemetry or usage data back to our server—we don't even have a server 🙂\n\nException: GIF search sends your query to Giphy." : {
-
     },
-    "Used to detect `:` triggers. Nothing else." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "يُستخدم فقط لاكتشاف اختصارات `:`. لا شيء غير ذلك."
+    "Usage counts, settings, and your exclusion list are stored locally. %@ doesn't send any telemetry or usage data back to our server—we don't even have a server 🙂\n\nException: GIF search sends your query to Giphy.": {},
+    "Used to detect `:` triggers. Nothing else.": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يُستخدم فقط لاكتشاف اختصارات `:`. لا شيء غير ذلك."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wird nur zum Erkennen von `:`-Triggern verwendet. Mehr nicht."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird nur zum Erkennen von `:`-Triggern verwendet. Mehr nicht."
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Used to detect `:` triggers. Nothing else."
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Used to detect `:` triggers. Nothing else."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se usa para detectar el `:`. Nada más."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se usa para detectar el `:`. Nada más."
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se usa para detectar el `:`. Nada más."
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se usa para detectar el `:`. Nada más."
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "فقط برای تشخیص `:` استفاده می‌شود. هیچ‌چیز دیگر."
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فقط برای تشخیص `:` استفاده می‌شود. هیچ‌چیز دیگر."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sert à détecter les déclencheurs `:`. Rien d'autre."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sert à détecter les déclencheurs `:`. Rien d'autre."
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "משמש לזיהוי `:`. שום דבר נוסף."
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "משמש לזיהוי `:`. שום דבר נוסף."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "केवल `:` ट्रिगर्स पहचानने के लिए। और कुछ नहीं।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "केवल `:` ट्रिगर्स पहचानने के लिए। और कुछ नहीं।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Serve solo a rilevare il `:`. Nient'altro."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Serve solo a rilevare il `:`. Nient'altro."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "`:` の検出にのみ使用します。それ以外には使いません。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "`:` の検出にのみ使用します。それ以外には使いません。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "`:` 입력 감지에만 사용합니다. 그 외에는 쓰이지 않습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "`:` 입력 감지에만 사용합니다. 그 외에는 쓰이지 않습니다."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wordt alleen gebruikt om `:` te detecteren. Verder niets."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wordt alleen gebruikt om `:` te detecteren. Verder niets."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Służy do wykrywania `:`. Nic więcej."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Służy do wykrywania `:`. Nic więcej."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usado para detectar o `:`. Nada mais."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usado para detectar o `:`. Nada mais."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Используется только для обнаружения `:`. И больше ничего."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Используется только для обнаружения `:`. И больше ничего."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "仅用于检测 `:` 触发键,无其他用途。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅用于检测 `:` 触发键,无其他用途。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "僅用於偵測 `:` 觸發鍵,無其他用途。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "僅用於偵測 `:` 觸發鍵,無其他用途。"
           }
         }
       }
     },
-    "User since" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "مستخدم منذ"
+    "User since": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مستخدم منذ"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nutzer seit"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nutzer seit"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "User since"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User since"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usuario desde"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usuario desde"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usuario desde"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usuario desde"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "کاربر از"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کاربر از"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utilisateur depuis"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utilisateur depuis"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "משתמש מאז"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "משתמש מאז"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "उपयोगकर्ता बने"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "उपयोगकर्ता बने"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utente dal"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utente dal"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "利用開始"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "利用開始"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "사용 시작일"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용 시작일"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gebruiker sinds"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gebruiker sinds"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Użytkownik od"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Użytkownik od"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usuário desde"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usuário desde"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Пользователь с"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пользователь с"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "用户起始"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "用户起始"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "用戶起始"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "用戶起始"
           }
         }
       }
     },
-    "Version %@ (%@)" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الإصدار %1$@ (%2$@)"
+    "Version %@ (%@)": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الإصدار %1$@ (%2$@)"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version %1$@ (%2$@)"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %1$@ (%2$@)"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Version %1$@ (%2$@)"
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Version %1$@ (%2$@)"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version %1$@ (%2$@)"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %1$@ (%2$@)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versión %1$@ (%2$@)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versión %1$@ (%2$@)"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versión %1$@ (%2$@)"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versión %1$@ (%2$@)"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "نسخهٔ %1$@ (%2$@)"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسخهٔ %1$@ (%2$@)"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version %1$@ (%2$@)"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %1$@ (%2$@)"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "גרסה %1$@ (%2$@)"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "גרסה %1$@ (%2$@)"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "संस्करण %1$@ (%2$@)"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "संस्करण %1$@ (%2$@)"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versione %1$@ (%2$@)"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versione %1$@ (%2$@)"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "バージョン %1$@ (%2$@)"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バージョン %1$@ (%2$@)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "버전 %1$@ (%2$@)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "버전 %1$@ (%2$@)"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versie %1$@ (%2$@)"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versie %1$@ (%2$@)"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wersja %1$@ (%2$@)"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wersja %1$@ (%2$@)"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versão %1$@ (%2$@)"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versão %1$@ (%2$@)"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Версия %1$@ (%2$@)"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Версия %1$@ (%2$@)"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "版本 %1$@ (%2$@)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "版本 %1$@ (%2$@)"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "版本 %1$@ (%2$@)"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "版本 %1$@ (%2$@)"
           }
         }
       }
     },
-    "View source" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "عرض المصدر"
+    "View source": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عرض المصدر"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quellcode ansehen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quellcode ansehen"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "View source"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View source"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ver el código"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver el código"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ver el código"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver el código"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "مشاهدهٔ کد"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مشاهدهٔ کد"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voir le code source"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voir le code source"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "צפה בקוד"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "צפה בקוד"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "स्रोत देखें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "स्रोत देखें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vedi il codice"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vedi il codice"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ソースを見る"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ソースを見る"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "소스 보기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "소스 보기"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bekijk broncode"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bekijk broncode"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zobacz kod"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zobacz kod"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ver o código"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver o código"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Открыть исходники"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть исходники"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "查看源代码"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查看源代码"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "檢視原始碼"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "檢視原始碼"
           }
         }
       }
     },
-    "Watches keystrokes for the `:` trigger." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "يراقب الضغطات بحثاً عن `:`."
+    "Watches keystrokes for the `:` trigger.": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يراقب الضغطات بحثاً عن `:`."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beobachtet Tastenanschläge auf den `:`-Trigger."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beobachtet Tastenanschläge auf den `:`-Trigger."
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Watches keystrokes for the `:` trigger."
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Watches keystrokes for the `:` trigger."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vigila las pulsaciones en busca del `:`."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vigila las pulsaciones en busca del `:`."
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vigila las pulsaciones en busca del `:`."
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vigila las pulsaciones en busca del `:`."
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ضربه‌های `:` را پی می‌گیرد."
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ضربه‌های `:` را پی می‌گیرد."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Surveille les frappes pour détecter le déclencheur `:`."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Surveille les frappes pour détecter le déclencheur `:`."
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "עוקב אחר הקשות `:`."
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "עוקב אחר הקשות `:`."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "`:` ट्रिगर के लिए कीस्ट्रोक देखता है।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "`:` ट्रिगर के लिए कीस्ट्रोक देखता है।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Osserva le digitazioni in cerca del `:`."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Osserva le digitazioni in cerca del `:`."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "`:` のキー入力を監視します。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "`:` のキー入力を監視します。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "`:` 입력을 감지합니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "`:` 입력을 감지합니다."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Volgt toetsaanslagen voor `:`."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Volgt toetsaanslagen voor `:`."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obserwuje naciśnięcia `:`."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obserwuje naciśnięcia `:`."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Observa as teclas em busca do `:`."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observa as teclas em busca do `:`."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отслеживает нажатия `:`."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отслеживает нажатия `:`."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "监听 `:` 触发键。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "监听 `:` 触发键。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "監聽 `:` 觸發鍵。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "監聽 `:` 觸發鍵。"
           }
         }
       }
     },
-    "Website" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الموقع الإلكتروني"
+    "Website": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الموقع الإلكتروني"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Website"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Website"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Website"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Website"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sitio web"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitio web"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sitio web"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitio web"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "وب‌سایت"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "وب‌سایت"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Site web"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Site web"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "אתר"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אתר"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "वेबसाइट"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "वेबसाइट"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sito web"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sito web"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ウェブサイト"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ウェブサイト"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "웹사이트"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "웹사이트"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Website"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Website"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Witryna"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Witryna"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Site"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Site"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сайт"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сайт"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "网站"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网站"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "網站"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "網站"
           }
         }
       }
     },
-    "You're all set" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "كلّ شيء جاهز"
+    "You're all set": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "كلّ شيء جاهز"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alles bereit"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alles bereit"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You're all set"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You're all set"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Todo listo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todo listo"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Todo listo"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todo listo"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "همه‌چیز آماده است"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "همه‌چیز آماده است"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tout est prêt"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout est prêt"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "הכל מוכן"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הכל מוכן"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "सब तैयार है"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सब तैयार है"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tutto pronto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tutto pronto"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "準備完了です"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "準備完了です"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "모든 준비가 끝났어요"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모든 준비가 끝났어요"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alles staat klaar"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alles staat klaar"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wszystko gotowe"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wszystko gotowe"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tudo pronto"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tudo pronto"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Готово к работе"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Готово к работе"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一切就绪"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一切就绪"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一切就緒"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一切就緒"
           }
         }
       }
     },
-    "Your data stays on this Mac" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تبقى بياناتك على هذا الـ Mac"
+    "Your data stays on this Mac": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تبقى بياناتك على هذا الـ Mac"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deine Daten bleiben auf diesem Mac"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deine Daten bleiben auf diesem Mac"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your data stays on this Mac"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your data stays on this Mac"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tus datos se quedan en este Mac"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tus datos se quedan en este Mac"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tus datos se quedan en esta Mac"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tus datos se quedan en esta Mac"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "داده‌های شما روی همین Mac می‌ماند"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "داده‌های شما روی همین Mac می‌ماند"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vos données restent sur ce Mac"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vos données restent sur ce Mac"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "הנתונים שלך נשארים על ה-Mac הזה"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הנתונים שלך נשארים על ה-Mac הזה"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "आपका डेटा इसी Mac पर रहता है"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आपका डेटा इसी Mac पर रहता है"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "I tuoi dati restano su questo Mac"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I tuoi dati restano su questo Mac"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "データはこの Mac から出ません"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "データはこの Mac から出ません"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "데이터는 이 Mac에만 머무릅니다"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "데이터는 이 Mac에만 머무릅니다"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Je gegevens blijven op deze Mac"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Je gegevens blijven op deze Mac"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Twoje dane zostają na tym Macu"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Twoje dane zostają na tym Macu"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seus dados ficam neste Mac"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seus dados ficam neste Mac"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ваши данные остаются на этом Mac"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ваши данные остаются на этом Mac"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "你的数据只留在这台 Mac 上"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你的数据只留在这台 Mac 上"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "你的資料只留在這台 Mac 上"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你的資料只留在這台 Mac 上"
           }
         }
       }
     },
-    "Your top 8" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "أفضل 8 لديك"
+    "Your top 8": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أفضل 8 لديك"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deine Top 8"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deine Top 8"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your top 8"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your top 8"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tu Top 8"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu Top 8"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tu Top 8"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu Top 8"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "هشت برتر شما"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "هشت برتر شما"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Votre Top 8"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Votre Top 8"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ה-Top 8 שלך"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ה-Top 8 שלך"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "आपका टॉप 8"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आपका टॉप 8"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La tua Top 8"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La tua Top 8"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "あなたのトップ 8"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "あなたのトップ 8"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "내 Top 8"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "내 Top 8"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jouw Top 8"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jouw Top 8"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Twój Top 8"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Twój Top 8"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seu Top 8"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seu Top 8"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Твой Топ 8"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Твой Топ 8"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "你的 Top 8"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你的 Top 8"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "你的 Top 8"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你的 Top 8"
           }
         }
       }
     },
-    "`:::` overrides the exclusion list." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏`:::` يتجاوز قائمة الاستثناءات."
+    "`:::` overrides the exclusion list.": {
+      "localizations": {
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "`:::` overrides the exclusion list."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "`:::` umgeht die Ausschlussliste."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "`:::` umgeht die Ausschlussliste."
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "`:::` overrides the exclusion list."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "`:::` ignora la lista de exclusiones."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "`:::` ignora la lista de exclusiones."
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "`:::` ignora la lista de exclusiones."
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "`:::` ignora la lista de exclusiones."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "`:::` ignore la liste d'exclusions."
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏`:::` فهرست استثناها را نادیده می‌گیرد."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "`:::` ignora l'elenco delle esclusioni."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "`:::` ignore la liste d'exclusions."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "`:::` ignora a lista de exclusões."
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‏`:::` עוקף את רשימת ההחרגות."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "`:::` は除外リストを無視します。"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "`:::` बहिष्कार सूची को नज़रअंदाज़ करता है।"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "`:::` 会忽略排除列表。"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "`:::` ignora l'elenco delle esclusioni."
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "`:::` 會略過排除清單。"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "`:::` は除外リストを無視します。"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "`:::`은(는) 제외 목록을 무시합니다."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "`:::`은(는) 제외 목록을 무시합니다."
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "`:::` बहिष्कार सूची को नज़रअंदाज़ करता है।"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "`:::` negeert de uitsluitingslijst."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "`:::` обходит список исключений."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "`:::` pomija listę wykluczeń."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "`:::` pomija listę wykluczeń."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "`:::` ignora a lista de exclusões."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "`:::` negeert de uitsluitingslijst."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "`:::` обходит список исключений."
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏`:::` يتجاوز قائمة الاستثناءات."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "`:::` 会忽略排除列表。"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏`:::` فهرست استثناها را نادیده می‌گیرد."
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "`:::` 會略過排除清單。"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‏`:::` עוקף את רשימת ההחרגות."
           }
         }
       }
     },
-    "copy" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "نسخ"
+    "copy": {
+      "extractionState": "stale",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسخ"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "kopieren"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kopieren"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "copy"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "copy"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "copiar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "copiar"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "copiar"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "copiar"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "کپی"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کپی"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "copier"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "copier"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "העתק"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "העתק"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "कॉपी"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कॉपी"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "copia"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "copia"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "コピー"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コピー"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "복사"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "복사"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "kopieer"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kopieer"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "kopiuj"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kopiuj"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "copiar"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "copiar"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "копировать"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "копировать"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "复制"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "複製"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製"
           }
         }
       }
     },
-    "dismiss" : {
-
-    },
-    "e.g. mail.google.com or *.notion.so" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "مثلاً: mail.google.com أو *.notion.so"
+    "dismiss": {},
+    "e.g. mail.google.com or *.notion.so": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مثلاً: mail.google.com أو *.notion.so"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "z. B. mail.google.com oder *.notion.so"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "z. B. mail.google.com oder *.notion.so"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "e.g. mail.google.com or *.notion.so"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "e.g. mail.google.com or *.notion.so"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "p. ej. mail.google.com o *.notion.so"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "p. ej. mail.google.com o *.notion.so"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "p. ej. mail.google.com o *.notion.so"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "p. ej. mail.google.com o *.notion.so"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "مثلاً mail.google.com یا *.notion.so"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مثلاً mail.google.com یا *.notion.so"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "p. ex. mail.google.com ou *.notion.so"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "p. ex. mail.google.com ou *.notion.so"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "למשל mail.google.com או *.notion.so"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "למשל mail.google.com או *.notion.so"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "उदा. mail.google.com या *.notion.so"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "उदा. mail.google.com या *.notion.so"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "es. mail.google.com o *.notion.so"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "es. mail.google.com o *.notion.so"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "例: mail.google.com または *.notion.so"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "例: mail.google.com または *.notion.so"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "예: mail.google.com 또는 *.notion.so"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "예: mail.google.com 또는 *.notion.so"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "bijv. mail.google.com of *.notion.so"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bijv. mail.google.com of *.notion.so"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "np. mail.google.com lub *.notion.so"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "np. mail.google.com lub *.notion.so"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ex.: mail.google.com ou *.notion.so"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ex.: mail.google.com ou *.notion.so"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "напр. mail.google.com или *.notion.so"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "напр. mail.google.com или *.notion.so"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "例如 mail.google.com 或 *.notion.so"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "例如 mail.google.com 或 *.notion.so"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "例如 mail.google.com 或 *.notion.so"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "例如 mail.google.com 或 *.notion.so"
           }
         }
       }
-    },
-    "insert" : {
-
     },
-    "navigate" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تنقّل"
+    "insert": {},
+    "navigate": {
+      "extractionState": "stale",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تنقّل"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "navigieren"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "navigieren"
           }
         },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "navigate"
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "navigate"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "navegar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "navegar"
           }
         },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "navegar"
+        "es-419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "navegar"
           }
         },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "حرکت"
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حرکت"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "naviguer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "naviguer"
           }
         },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ניווט"
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ניווט"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "नेविगेट"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "नेविगेट"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "naviga"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "naviga"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移動"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移動"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이동"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이동"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "navigeer"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "navigeer"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "nawiguj"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nawiguj"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "navegar"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "navegar"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "перемещение"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "перемещение"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移动"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移动"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移動"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移動"
           }
         }
       }
     }
   },
-  "version" : "1.0"
+  "version": "1.0"
 }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1,13020 +1,13055 @@
 {
-  "sourceLanguage": "en",
-  "strings": {
-    "": {},
-    "%@ couldn't reach the update server.": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تعذّر على %@ الوصول إلى خادم التحديثات."
+  "sourceLanguage" : "en",
+  "strings" : {
+    "" : {
+
+    },
+    "%@ couldn't reach the update server." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تعذّر على %@ الوصول إلى خادم التحديثات."
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ konnte den Update-Server nicht erreichen."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ konnte den Update-Server nicht erreichen."
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ couldn't reach the update server."
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ couldn't reach the update server."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ no pudo conectar con el servidor de actualizaciones."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ no pudo conectar con el servidor de actualizaciones."
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ no pudo conectar con el servidor de actualizaciones."
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ no pudo conectar con el servidor de actualizaciones."
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏%@ نتوانست به سرور به‌روزرسانی متصل شود."
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏%@ نتوانست به سرور به‌روزرسانی متصل شود."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ n'a pas pu joindre le serveur de mises à jour."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ n'a pas pu joindre le serveur de mises à jour."
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏%@ לא הצליח להתחבר לשרת העדכונים."
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏%@ לא הצליח להתחבר לשרת העדכונים."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ अपडेट सर्वर तक नहीं पहुँच सका।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ अपडेट सर्वर तक नहीं पहुँच सका।"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ non è riuscito a raggiungere il server degli aggiornamenti."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ non è riuscito a raggiungere il server degli aggiornamenti."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ はアップデートサーバーに接続できませんでした。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ はアップデートサーバーに接続できませんでした。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@이(가) 업데이트 서버에 연결할 수 없습니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@이(가) 업데이트 서버에 연결할 수 없습니다."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ kon de update-server niet bereiken."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ kon de update-server niet bereiken."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ nie mógł połączyć się z serwerem aktualizacji."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ nie mógł połączyć się z serwerem aktualizacji."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ não conseguiu acessar o servidor de atualizações."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ não conseguiu acessar o servidor de atualizações."
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ не удалось связаться с сервером обновлений."
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ не удалось связаться с сервером обновлений."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 无法连接到更新服务器。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 无法连接到更新服务器。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 無法連線到更新伺服器。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 無法連線到更新伺服器。"
           }
         }
       }
     },
-    "%@ is built to respect your privacy. Here's how.": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "صُمِّم %@ لاحترام خصوصيتك. إليك كيف."
+    "%@ is built to respect your privacy. Here's how." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "صُمِّم %@ لاحترام خصوصيتك. إليك كيف."
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ ist auf den Schutz deiner Privatsphäre ausgelegt. So funktioniert's."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ ist auf den Schutz deiner Privatsphäre ausgelegt. So funktioniert's."
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ is built to respect your privacy. Here's how."
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ is built to respect your privacy. Here's how."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ está hecho para respetar tu privacidad. Así lo hace."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ está hecho para respetar tu privacidad. Así lo hace."
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ está hecho para respetar tu privacidad. Así lo hace."
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ está hecho para respetar tu privacidad. Así lo hace."
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏%@ برای احترام به حریم خصوصی شما ساخته شده است. به این صورت:"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏%@ برای احترام به حریم خصوصی شما ساخته شده است. به این صورت:"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ est conçu pour respecter votre vie privée. Voici comment."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ est conçu pour respecter votre vie privée. Voici comment."
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏%@ נבנה תוך כיבוד הפרטיות שלך. כך זה עובד."
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏%@ נבנה תוך כיבוד הפרטיות שלך. כך זה עובד."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ आपकी निजता का सम्मान करने के लिए बनाया गया है। यह इस तरह काम करता है।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ आपकी निजता का सम्मान करने के लिए बनाया गया है। यह इस तरह काम करता है।"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ è progettato per rispettare la tua privacy. Ecco come."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ è progettato per rispettare la tua privacy. Ecco come."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ はあなたのプライバシーを尊重するように作られています。その仕組みをご紹介します。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ はあなたのプライバシーを尊重するように作られています。その仕組みをご紹介します。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@은(는) 사용자의 개인정보를 존중하도록 만들어졌습니다. 그 방법은 다음과 같습니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@은(는) 사용자의 개인정보를 존중하도록 만들어졌습니다. 그 방법은 다음과 같습니다."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ is gebouwd met respect voor je privacy. Zo werkt het."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ is gebouwd met respect voor je privacy. Zo werkt het."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ został zaprojektowany z myślą o twojej prywatności. Oto jak."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ został zaprojektowany z myślą o twojej prywatności. Oto jak."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ foi feito para respeitar sua privacidade. Veja como."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ foi feito para respeitar sua privacidade. Veja como."
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ создан с уважением к вашей конфиденциальности. Вот как именно."
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ создан с уважением к вашей конфиденциальности. Вот как именно."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 在设计时充分尊重你的隐私。以下是具体方式。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 在设计时充分尊重你的隐私。以下是具体方式。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 設計時就以保護你的隱私為前提。以下是做法。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 設計時就以保護你的隱私為前提。以下是做法。"
           }
         }
       }
     },
-    "%@ is forever free, but your support helps fund future projects. Thank you!": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏%@ مجاني إلى الأبد، لكن دعمك يساعد على تمويل المشاريع المستقبلية. شكراً لك!"
+    "%@ is forever free, but your support helps fund future projects. Thank you!" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏%@ مجاني إلى الأبد، لكن دعمك يساعد على تمويل المشاريع المستقبلية. شكراً لك!"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ bleibt für immer kostenlos – deine Unterstützung hilft aber, zukünftige Projekte zu finanzieren. Danke!"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ bleibt für immer kostenlos – deine Unterstützung hilft aber, zukünftige Projekte zu finanzieren. Danke!"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ is forever free, but your support helps fund future projects. Thank you!"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ is forever free, but your support helps fund future projects. Thank you!"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ es siempre gratis, pero tu apoyo ayuda a financiar futuros proyectos. ¡Gracias!"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ es siempre gratis, pero tu apoyo ayuda a financiar futuros proyectos. ¡Gracias!"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ es siempre gratis, pero tu apoyo ayuda a financiar futuros proyectos. ¡Gracias!"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ es siempre gratis, pero tu apoyo ayuda a financiar futuros proyectos. ¡Gracias!"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏%@ همیشه رایگان است، اما حمایت شما به تأمین مالی پروژه‌های آینده کمک می‌کند. ممنون!"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏%@ همیشه رایگان است، اما حمایت شما به تأمین مالی پروژه‌های آینده کمک می‌کند. ممنون!"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ est gratuit pour toujours, mais votre soutien aide à financer les projets futurs. Merci !"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ est gratuit pour toujours, mais votre soutien aide à financer les projets futurs. Merci !"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏%@ חינמי לתמיד, אבל התמיכה שלך עוזרת לממן פרויקטים עתידיים. תודה!"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏%@ חינמי לתמיד, אבל התמיכה שלך עוזרת לממן פרויקטים עתידיים. תודה!"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ हमेशा मुफ़्त है, लेकिन आपका सहयोग भविष्य की परियोजनाओं को बनाने में मदद करता है। धन्यवाद!"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ हमेशा मुफ़्त है, लेकिन आपका सहयोग भविष्य की परियोजनाओं को बनाने में मदद करता है। धन्यवाद!"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ è gratis per sempre, ma il tuo supporto aiuta a finanziare progetti futuri. Grazie!"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ è gratis per sempre, ma il tuo supporto aiuta a finanziare progetti futuri. Grazie!"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ はずっと無料ですが、あなたのご支援は今後のプロジェクトの資金になります。ありがとうございます！"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ はずっと無料ですが、あなたのご支援は今後のプロジェクトの資金になります。ありがとうございます！"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@은(는) 영원히 무료지만, 후원해 주시면 앞으로의 프로젝트에 큰 힘이 됩니다. 감사합니다!"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@은(는) 영원히 무료지만, 후원해 주시면 앞으로의 프로젝트에 큰 힘이 됩니다. 감사합니다!"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ is voor altijd gratis, maar je steun helpt om toekomstige projecten te financieren. Bedankt!"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ is voor altijd gratis, maar je steun helpt om toekomstige projecten te financieren. Bedankt!"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ jest darmowy na zawsze, ale twoje wsparcie pomaga finansować przyszłe projekty. Dziękuję!"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ jest darmowy na zawsze, ale twoje wsparcie pomaga finansować przyszłe projekty. Dziękuję!"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ é grátis para sempre, mas seu apoio ajuda a financiar projetos futuros. Obrigado!"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ é grátis para sempre, mas seu apoio ajuda a financiar projetos futuros. Obrigado!"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ навсегда бесплатен, но ваша поддержка помогает финансировать будущие проекты. Спасибо!"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ навсегда бесплатен, но ваша поддержка помогает финансировать будущие проекты. Спасибо!"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 永久免费,但你的支持能帮助资助未来的项目。谢谢!"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 永久免费,但你的支持能帮助资助未来的项目。谢谢!"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 永遠免費,但你的支持能幫助贊助未來的專案。謝謝!"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 永遠免費,但你的支持能幫助贊助未來的專案。謝謝!"
           }
         }
       }
     },
-    "%@ is off": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏%@ متوقّف"
+    "%@ is off" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏%@ متوقّف"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ ist aus"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ ist aus"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ is off"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ is off"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ está desactivado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ está desactivado"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ está desactivado"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ está desactivado"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏%@ خاموش است"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏%@ خاموش است"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ est désactivé"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ est désactivé"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏%@ כבוי"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏%@ כבוי"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ बंद है"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ बंद है"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ è disattivato"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ è disattivato"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ はオフです"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ はオフです"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@이(가) 꺼져 있음"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@이(가) 꺼져 있음"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ is uit"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ is uit"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ jest wyłączony"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ jest wyłączony"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ está desativado"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ está desativado"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ выключен"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ выключен"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 已关闭"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 已关闭"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 已關閉"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 已關閉"
           }
         }
       }
     },
-    "%@ is on": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏%@ مُشغَّل"
+    "%@ is on" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏%@ مُشغَّل"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ ist an"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ ist an"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ is on"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ is on"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ está activado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ está activado"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ está activado"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ está activado"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏%@ روشن است"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏%@ روشن است"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ est activé"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ est activé"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏%@ פועל"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏%@ פועל"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ चालू है"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ चालू है"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ è attivo"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ è attivo"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ はオンです"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ はオンです"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@이(가) 켜져 있음"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@이(가) 켜져 있음"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ is aan"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ is aan"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ jest włączony"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ jest włączony"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ está ativado"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ está ativado"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ включён"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ включён"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 已开启"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 已开启"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 已開啟"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 已開啟"
           }
         }
       }
     },
-    "%@ is paused": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏%@ موقوف مؤقّتاً"
+    "%@ is paused" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏%@ موقوف مؤقّتاً"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ ist pausiert"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ ist pausiert"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ is paused"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ is paused"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ está en pausa"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ está en pausa"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ está en pausa"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ está en pausa"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏%@ متوقّف شده است"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏%@ متوقّف شده است"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ est en pause"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ est en pause"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏%@ מושהה"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏%@ מושהה"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ रोका गया है"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ रोका गया है"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ è in pausa"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ è in pausa"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ は一時停止中です"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ は一時停止中です"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@이(가) 일시 중지됨"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@이(가) 일시 중지됨"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ is gepauzeerd"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ is gepauzeerd"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ jest wstrzymany"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ jest wstrzymany"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ está pausado"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ está pausado"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ приостановлен"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ приостановлен"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 已暂停"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 已暂停"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 已暫停"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 已暫停"
           }
         }
       }
     },
-    "%@ is running 🏃‍♂️": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏%@ يعمل 🏃‍♂️"
+    "%@ is running 🏃‍♂️" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏%@ يعمل 🏃‍♂️"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ läuft 🏃‍♂️"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ läuft 🏃‍♂️"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ is running 🏃‍♂️"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ is running 🏃‍♂️"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ está en marcha 🏃‍♂️"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ está en marcha 🏃‍♂️"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ está en marcha 🏃‍♂️"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ está en marcha 🏃‍♂️"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏%@ در حال اجراست 🏃‍♂️"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏%@ در حال اجراست 🏃‍♂️"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ tourne 🏃‍♂️"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ tourne 🏃‍♂️"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏%@ פועל 🏃‍♂️"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏%@ פועל 🏃‍♂️"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ चल रहा है 🏃‍♂️"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ चल रहा है 🏃‍♂️"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ è in esecuzione 🏃‍♂️"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ è in esecuzione 🏃‍♂️"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ は動作中です 🏃‍♂️"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ は動作中です 🏃‍♂️"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 실행 중 🏃‍♂️"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 실행 중 🏃‍♂️"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ draait 🏃‍♂️"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ draait 🏃‍♂️"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ działa 🏃‍♂️"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ działa 🏃‍♂️"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ está rodando 🏃‍♂️"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ está rodando 🏃‍♂️"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ работает 🏃‍♂️"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ работает 🏃‍♂️"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 正在运行 🏃‍♂️"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 正在运行 🏃‍♂️"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 正在執行 🏃‍♂️"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 正在執行 🏃‍♂️"
           }
         }
       }
     },
-    "%@ lives in your menu bar. Try typing `:tada:` in any text field.": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "يعيش %@ في شريط القوائم لديك. جرّب كتابة `:tada:` في أي حقل نصي."
+    "%@ lives in your menu bar. Try typing `:tada:` in any text field." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يعيش %@ في شريط القوائم لديك. جرّب كتابة `:tada:` في أي حقل نصي."
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ wohnt in deiner Menüleiste. Tippe `:tada:` in ein beliebiges Textfeld."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ wohnt in deiner Menüleiste. Tippe `:tada:` in ein beliebiges Textfeld."
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ lives in your menu bar. Try typing `:tada:` in any text field."
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ lives in your menu bar. Try typing `:tada:` in any text field."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ vive en tu barra de menús. Prueba a escribir `:tada:` en cualquier campo de texto."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ vive en tu barra de menús. Prueba a escribir `:tada:` en cualquier campo de texto."
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ vive en tu barra de menús. Probá escribir `:tada:` en cualquier campo de texto."
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ vive en tu barra de menús. Probá escribir `:tada:` en cualquier campo de texto."
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏%@ در نوار منوی شما زندگی می‌کند. در هر فیلد متنی `:tada:` را امتحان کنید."
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏%@ در نوار منوی شما زندگی می‌کند. در هر فیلد متنی `:tada:` را امتحان کنید."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ vit dans votre barre de menus. Essayez de taper `:tada:` dans n'importe quel champ."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ vit dans votre barre de menus. Essayez de taper `:tada:` dans n'importe quel champ."
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏%@ גר בשורת התפריטים שלך. נסה להקליד `:tada:` בכל שדה טקסט."
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏%@ גר בשורת התפריטים שלך. נסה להקליד `:tada:` בכל שדה טקסט."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ आपके मेन्यू बार में रहता है। किसी भी टेक्स्ट फ़ील्ड में `:tada:` टाइप करके देखें।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ आपके मेन्यू बार में रहता है। किसी भी टेक्स्ट फ़ील्ड में `:tada:` टाइप करके देखें।"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ vive nella tua barra dei menu. Prova a digitare `:tada:` in un campo di testo."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ vive nella tua barra dei menu. Prova a digitare `:tada:` in un campo di testo."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ はメニューバーに常駐します。任意のテキストフィールドで `:tada:` と入力してみてください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ はメニューバーに常駐します。任意のテキストフィールドで `:tada:` と入力してみてください。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@은(는) 메뉴 막대에서 작동합니다. 아무 텍스트 필드에 `:tada:` 를 입력해 보세요."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@은(는) 메뉴 막대에서 작동합니다. 아무 텍스트 필드에 `:tada:` 를 입력해 보세요."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ woont in je menubalk. Probeer `:tada:` te typen in een tekstveld."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ woont in je menubalk. Probeer `:tada:` te typen in een tekstveld."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ mieszka na pasku menu. Wpisz `:tada:` w dowolne pole tekstowe."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ mieszka na pasku menu. Wpisz `:tada:` w dowolne pole tekstowe."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ mora na sua barra de menus. Experimente digitar `:tada:` em qualquer campo de texto."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ mora na sua barra de menus. Experimente digitar `:tada:` em qualquer campo de texto."
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ живёт в строке меню. Попробуйте ввести `:tada:` в любом текстовом поле."
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ живёт в строке меню. Попробуйте ввести `:tada:` в любом текстовом поле."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 就在你的菜单栏里。在任何文本框中尝试输入 `:tada:`。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 就在你的菜单栏里。在任何文本框中尝试输入 `:tada:`。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 就在你的選單列裡。在任何文字輸入框試試輸入 `:tada:`。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 就在你的選單列裡。在任何文字輸入框試試輸入 `:tada:`。"
           }
         }
       }
     },
-    "%@ needs permission": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "يحتاج %@ إلى إذن"
+    "%@ needs permission" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يحتاج %@ إلى إذن"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ benötigt eine Berechtigung"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ benötigt eine Berechtigung"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ needs permission"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ needs permission"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ necesita permisos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ necesita permisos"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ necesita permisos"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ necesita permisos"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏%@ به اجازه نیاز دارد"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏%@ به اجازه نیاز دارد"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ a besoin d'une autorisation"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ a besoin d'une autorisation"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏%@ זקוק להרשאה"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏%@ זקוק להרשאה"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ को अनुमति चाहिए"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ को अनुमति चाहिए"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ necessita di permessi"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ necessita di permessi"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ には権限が必要です"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ には権限が必要です"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@에 권한이 필요합니다"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@에 권한이 필요합니다"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ heeft toestemming nodig"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ heeft toestemming nodig"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ wymaga uprawnień"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ wymaga uprawnień"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ precisa de permissão"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ precisa de permissão"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ требуются разрешения"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ требуются разрешения"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 需要权限"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 需要权限"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 需要權限"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 需要權限"
           }
         }
       }
     },
-    "%@ needs permission to work with your keyboard.": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "يحتاج %@ إلى إذن للعمل مع لوحة المفاتيح."
+    "%@ needs permission to work with your keyboard." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يحتاج %@ إلى إذن للعمل مع لوحة المفاتيح."
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ benötigt eine Berechtigung, um mit deiner Tastatur zu arbeiten."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ benötigt eine Berechtigung, um mit deiner Tastatur zu arbeiten."
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ needs permission to work with your keyboard."
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ needs permission to work with your keyboard."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ necesita permisos para funcionar con tu teclado."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ necesita permisos para funcionar con tu teclado."
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ necesita permisos para funcionar con tu teclado."
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ necesita permisos para funcionar con tu teclado."
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏%@ برای کار با صفحه‌کلید شما به اجازه نیاز دارد."
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏%@ برای کار با صفحه‌کلید شما به اجازه نیاز دارد."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ a besoin d'une autorisation pour fonctionner avec votre clavier."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ a besoin d'une autorisation pour fonctionner avec votre clavier."
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏%@ זקוק להרשאה כדי לפעול עם המקלדת שלך."
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏%@ זקוק להרשאה כדי לפעול עם המקלדת שלך."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "आपके कीबोर्ड के साथ काम करने के लिए %@ को अनुमति चाहिए।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "आपके कीबोर्ड के साथ काम करने के लिए %@ को अनुमति चाहिए।"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ necessita di permessi per funzionare con la tua tastiera."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ necessita di permessi per funzionare con la tua tastiera."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ がキーボードと連携するには権限が必要です。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ がキーボードと連携するには権限が必要です。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@이(가) 키보드와 함께 작동하려면 권한이 필요합니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@이(가) 키보드와 함께 작동하려면 권한이 필요합니다."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ heeft toestemming nodig om met je toetsenbord te werken."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ heeft toestemming nodig om met je toetsenbord te werken."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ wymaga uprawnień do pracy z twoją klawiaturą."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ wymaga uprawnień do pracy z twoją klawiaturą."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ precisa de permissão para funcionar com seu teclado."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ precisa de permissão para funcionar com seu teclado."
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ требуются разрешения для работы с клавиатурой."
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ требуются разрешения для работы с клавиатурой."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 需要权限才能与键盘配合工作。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 需要权限才能与键盘配合工作。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 需要權限才能與鍵盤搭配運作。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 需要權限才能與鍵盤搭配運作。"
           }
         }
       }
     },
-    "%lld of %lld": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld من %2$lld"
+    "%lld of %lld" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld من %2$lld"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld von %2$lld"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld von %2$lld"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "%1$lld of %2$lld"
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld of %2$lld"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld of %2$lld"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld of %2$lld"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld de %2$lld"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld de %2$lld"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld de %2$lld"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld de %2$lld"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld از %2$lld"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld از %2$lld"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld sur %2$lld"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld sur %2$lld"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld מתוך %2$lld"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld מתוך %2$lld"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%2$lld में से %1$lld"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%2$lld में से %1$lld"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld su %2$lld"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld su %2$lld"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%2$lld 中 %1$lld"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%2$lld 中 %1$lld"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%2$lld개 중 %1$lld개"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%2$lld개 중 %1$lld개"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld van %2$lld"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld van %2$lld"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld z %2$lld"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld z %2$lld"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld de %2$lld"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld de %2$lld"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld из %2$lld"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld из %2$lld"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%2$lld 中的 %1$lld"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%2$lld 中的 %1$lld"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%2$lld 中的 %1$lld"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%2$lld 中的 %1$lld"
           }
         }
       }
     },
-    "???": {
-      "comment": "Placeholder shown in About → Easter eggs for an entry the user hasn't discovered yet. Should stay short and visually act as 'three unknowns'.",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "؟؟؟"
+    "???" : {
+      "comment" : "Placeholder shown in About → Easter eggs for an entry the user hasn't discovered yet. Should stay short and visually act as 'three unknowns'.",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "؟؟؟"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "???"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "???"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "???"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "???"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "???"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "???"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "???"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "???"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "؟؟؟"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "؟؟؟"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "???"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "???"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "???"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "???"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "???"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "???"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "???"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "???"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "???"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "???"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "???"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "???"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "???"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "???"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "???"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "???"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "???"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "???"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "???"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "???"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "???"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "???"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "???"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "???"
           }
         }
       }
     },
-    "About": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حول"
+    "About" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حول"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Über"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Über"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "About"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "About"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Acerca de"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acerca de"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Acerca de"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acerca de"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "درباره"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "درباره"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "À propos"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "À propos"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "אודות"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "אודות"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "बारे में"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "बारे में"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Informazioni"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informazioni"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "情報"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "情報"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "정보"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "정보"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Over"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Over"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Informacje"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informacje"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sobre"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sobre"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "О программе"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "О программе"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "关于"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关于"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "關於"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關於"
           }
         }
       }
     },
-    "Accessibility": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إمكانية الوصول"
+    "Accessibility" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إمكانية الوصول"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bedienungshilfen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bedienungshilfen"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Accessibility"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accessibility"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Accesibilidad"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accesibilidad"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Accesibilidad"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accesibilidad"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "دسترس‌پذیری"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "دسترس‌پذیری"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Accessibilité"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accessibilité"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "נגישות"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "נגישות"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ऐक्सेसिबिलिटी"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ऐक्सेसिबिलिटी"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Accessibilità"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accessibilità"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アクセシビリティ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アクセシビリティ"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "손쉬운 사용"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "손쉬운 사용"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Toegankelijkheid"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toegankelijkheid"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dostępność"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dostępność"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Acessibilidade"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acessibilidade"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Универсальный доступ"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Универсальный доступ"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "辅助功能"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "辅助功能"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "輔助使用"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輔助使用"
           }
         }
       }
     },
-    "Acknowledgements": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "شُكر وتقدير"
+    "Acknowledgements" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "شُكر وتقدير"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Danksagungen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Danksagungen"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Acknowledgements"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acknowledgements"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Agradecimientos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agradecimientos"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Agradecimientos"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agradecimientos"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تقدیر و تشکر"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تقدیر و تشکر"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remerciements"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remerciements"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "תודות"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "תודות"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "आभार"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "आभार"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ringraziamenti"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ringraziamenti"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "謝辞"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "謝辞"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "감사의 말"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "감사의 말"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Met dank aan"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Met dank aan"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Podziękowania"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Podziękowania"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Agradecimentos"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agradecimentos"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Благодарности"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Благодарности"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "鸣谢"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鸣谢"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "致謝"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "致謝"
           }
         }
       }
     },
-    "Add": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إضافة"
+    "Add" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إضافة"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hinzufügen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hinzufügen"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Añadir"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Añadir"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Agregar"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "افزودن"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "افزودن"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ajouter"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הוסף"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הוסף"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "जोड़ें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "जोड़ें"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aggiungi"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiungi"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "追加"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "追加"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "추가"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "추가"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voeg toe"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voeg toe"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dodaj"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dodaj"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adicionar"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adicionar"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Добавить"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавить"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "添加"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "加入"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加入"
           }
         }
       }
     },
-    "Add a Giphy API key to enable GIF search.": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "أضف مفتاح Giphy API لتفعيل البحث عن GIF."
+    "Add a Giphy API key to enable GIF search." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أضف مفتاح Giphy API لتفعيل البحث عن GIF."
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Füge einen Giphy-API-Schlüssel hinzu, um die GIF-Suche zu aktivieren."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Füge einen Giphy-API-Schlüssel hinzu, um die GIF-Suche zu aktivieren."
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add a Giphy API key to enable GIF search."
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add a Giphy API key to enable GIF search."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Añade una clave de la API de Giphy para activar la búsqueda de GIF."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Añade una clave de la API de Giphy para activar la búsqueda de GIF."
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Agregá una clave de la API de Giphy para activar la búsqueda de GIF."
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregá una clave de la API de Giphy para activar la búsqueda de GIF."
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "برای فعال‌سازی جست‌وجوی GIF، یک کلید API Giphy اضافه کنید."
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "برای فعال‌سازی جست‌وجوی GIF، یک کلید API Giphy اضافه کنید."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ajoute une clé d'API Giphy pour activer la recherche de GIF."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajoute une clé d'API Giphy pour activer la recherche de GIF."
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הוסף מפתח Giphy API כדי להפעיל חיפוש GIF."
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הוסף מפתח Giphy API כדי להפעיל חיפוש GIF."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF खोज सक्षम करने के लिए Giphy API कुंजी जोड़ें।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF खोज सक्षम करने के लिए Giphy API कुंजी जोड़ें।"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aggiungi una chiave API di Giphy per attivare la ricerca di GIF."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiungi una chiave API di Giphy per attivare la ricerca di GIF."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF 検索を有効にするには、Giphy の API キーを追加してください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF 検索を有効にするには、Giphy の API キーを追加してください。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF 검색을 사용하려면 Giphy API 키를 추가하세요."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF 검색을 사용하려면 Giphy API 키를 추가하세요."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voeg een Giphy API-sleutel toe om GIF-zoeken aan te zetten."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voeg een Giphy API-sleutel toe om GIF-zoeken aan te zetten."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dodaj klucz API Giphy, aby włączyć wyszukiwanie GIF-ów."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dodaj klucz API Giphy, aby włączyć wyszukiwanie GIF-ów."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adicione uma chave da API do Giphy para ativar a busca de GIF."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adicione uma chave da API do Giphy para ativar a busca de GIF."
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Добавьте ключ API Giphy, чтобы включить поиск GIF."
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавьте ключ API Giphy, чтобы включить поиск GIF."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "添加 Giphy API 密钥以启用 GIF 搜索。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加 Giphy API 密钥以启用 GIF 搜索。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "新增 Giphy API 金鑰以啟用 GIF 搜尋。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增 Giphy API 金鑰以啟用 GIF 搜尋。"
           }
         }
       }
     },
-    "Add website": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إضافة موقع"
+    "Add website" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إضافة موقع"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Website hinzufügen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Website hinzufügen"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add website"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add website"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Añadir sitio web"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Añadir sitio web"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Agregar sitio web"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar sitio web"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "افزودن وب‌سایت"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "افزودن وب‌سایت"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ajouter un site web"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter un site web"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הוסף אתר"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הוסף אתר"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "वेबसाइट जोड़ें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "वेबसाइट जोड़ें"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aggiungi sito web"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiungi sito web"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ウェブサイトを追加"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウェブサイトを追加"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "웹사이트 추가"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "웹사이트 추가"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Website toevoegen"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Website toevoegen"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dodaj witrynę"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dodaj witrynę"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adicionar site"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adicionar site"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Добавить сайт"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавить сайт"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "添加网站"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加网站"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "加入網站"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加入網站"
           }
         }
       }
     },
-    "All the code is on GitHub. Read it, build it, fork it.": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "كل الكود موجود على GitHub. اقرأه، اِبنه، فُرّعه."
+    "All the code is on GitHub. Read it, build it, fork it." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "كل الكود موجود على GitHub. اقرأه، اِبنه، فُرّعه."
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Der gesamte Code liegt auf GitHub. Lies ihn, baue ihn, forke ihn."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der gesamte Code liegt auf GitHub. Lies ihn, baue ihn, forke ihn."
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "All the code is on GitHub. Read it, build it, fork it."
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All the code is on GitHub. Read it, build it, fork it."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Todo el código está en GitHub. Léelo, compílalo, bifúrcalo."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todo el código está en GitHub. Léelo, compílalo, bifúrcalo."
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Todo el código está en GitHub. Leelo, compilalo, bifurcalo."
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todo el código está en GitHub. Leelo, compilalo, bifurcalo."
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "همهٔ کد در GitHub است. بخوانید، بسازید، فورک کنید."
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "همهٔ کد در GitHub است. بخوانید، بسازید، فورک کنید."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tout le code est sur GitHub. Lisez-le, compilez-le, forkez-le."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tout le code est sur GitHub. Lisez-le, compilez-le, forkez-le."
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "כל הקוד נמצא ב-GitHub. קרא, בנה, פצל לפורק."
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "כל הקוד נמצא ב-GitHub. קרא, בנה, פצל לפורק."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "सारा कोड GitHub पर है। पढ़ें, बिल्ड करें, फ़ोर्क करें।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "सारा कोड GitHub पर है। पढ़ें, बिल्ड करें, फ़ोर्क करें।"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tutto il codice è su GitHub. Leggilo, compilalo, fai un fork."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tutto il codice è su GitHub. Leggilo, compilalo, fai un fork."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "すべてのコードは GitHub にあります。読んで、ビルドして、フォークしてください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてのコードは GitHub にあります。読んで、ビルドして、フォークしてください。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "모든 코드는 GitHub에 있습니다. 읽고, 빌드하고, 포크하세요."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모든 코드는 GitHub에 있습니다. 읽고, 빌드하고, 포크하세요."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Alle code staat op GitHub. Lees het, bouw het, fork het."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle code staat op GitHub. Lees het, bouw het, fork het."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cały kod jest na GitHubie. Czytaj, buduj, forkuj."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cały kod jest na GitHubie. Czytaj, buduj, forkuj."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Todo o código está no GitHub. Leia, compile, faça um fork."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todo o código está no GitHub. Leia, compile, faça um fork."
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Весь код — на GitHub. Читайте, собирайте, форкайте."
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Весь код — на GitHub. Читайте, собирайте, форкайте."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "所有代码都在 GitHub 上。读它、构建它、fork 它。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有代码都在 GitHub 上。读它、构建它、fork 它。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "所有原始碼都在 GitHub 上。閱讀、建置、fork 隨你便。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有原始碼都在 GitHub 上。閱讀、建置、fork 隨你便。"
           }
         }
       }
     },
-    "Allow": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "السماح"
+    "Allow" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "السماح"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Erlauben"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erlauben"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Allow"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Allow"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permitir"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permitir"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permitir"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permitir"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اجازه دادن"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اجازه دادن"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Autoriser"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autoriser"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "אפשר"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "אפשר"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "अनुमति दें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "अनुमति दें"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Consenti"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Consenti"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "許可"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "許可"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "허용"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "허용"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sta toe"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sta toe"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zezwól"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zezwól"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permitir"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permitir"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Разрешить"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Разрешить"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "允许"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允许"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "允許"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允許"
           }
         }
       }
     },
-    "Anchors the picker next to your text cursor.": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "يثبّت أداة الاختيار بجوار مؤشر النص."
+    "Already allowed but still not detected?" : {
+
+    },
+    "Anchors the picker next to your text cursor." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يثبّت أداة الاختيار بجوار مؤشر النص."
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verankert den Picker neben deinem Textcursor."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verankert den Picker neben deinem Textcursor."
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Anchors the picker next to your text cursor."
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anchors the picker next to your text cursor."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ancla el selector junto al cursor de texto."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ancla el selector junto al cursor de texto."
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ancla el selector junto al cursor de texto."
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ancla el selector junto al cursor de texto."
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "انتخابگر را کنار مکان‌نمای متن قرار می‌دهد."
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "انتخابگر را کنار مکان‌نمای متن قرار می‌دهد."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ancre le sélecteur à côté de votre curseur de texte."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ancre le sélecteur à côté de votre curseur de texte."
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מעגן את הבורר ליד סמן הטקסט."
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "מעגן את הבורר ליד סמן הטקסט."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "पिकर को आपके टेक्स्ट कर्सर के बगल में जोड़ता है।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "पिकर को आपके टेक्स्ट कर्सर के बगल में जोड़ता है।"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Àncora il selettore accanto al cursore di testo."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Àncora il selettore accanto al cursore di testo."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ピッカーをテキストカーソルの隣に固定します。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ピッカーをテキストカーソルの隣に固定します。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "선택기를 텍스트 커서 옆에 고정합니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "선택기를 텍스트 커서 옆에 고정합니다."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verankert de kiezer naast je tekstcursor."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verankert de kiezer naast je tekstcursor."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Umieszcza okno wyboru obok kursora tekstu."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umieszcza okno wyboru obok kursora tekstu."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ancora o seletor ao lado do cursor de texto."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ancora o seletor ao lado do cursor de texto."
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Закрепляет окно подбора рядом с текстовым курсором."
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Закрепляет окно подбора рядом с текстовым курсором."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "将选取器锚定在文本光标旁。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将选取器锚定在文本光标旁。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "將選取器固定在文字游標旁邊。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將選取器固定在文字游標旁邊。"
           }
         }
       }
     },
-    "Autocomplete `:emoji:` everywhere.": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الإكمال التلقائي لـ `:emoji:` في كل مكان."
+    "Autocomplete `:emoji:` everywhere." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الإكمال التلقائي لـ `:emoji:` في كل مكان."
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "`:emoji:` überall automatisch vervollständigen."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`:emoji:` überall automatisch vervollständigen."
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Autocomplete `:emoji:` everywhere."
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autocomplete `:emoji:` everywhere."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Autocompleta `:emoji:` en todas partes."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autocompleta `:emoji:` en todas partes."
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Autocompleta `:emoji:` en todas partes."
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autocompleta `:emoji:` en todas partes."
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تکمیل خودکار `:emoji:` همه‌جا."
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تکمیل خودکار `:emoji:` همه‌جا."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Autocomplétez `:emoji:` partout."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autocomplétez `:emoji:` partout."
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "השלמה אוטומטית של `:emoji:` בכל מקום."
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "השלמה אוטומטית של `:emoji:` בכל מקום."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "हर जगह `:emoji:` ऑटोकम्प्लीट करें।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "हर जगह `:emoji:` ऑटोकम्प्लीट करें।"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Completamento automatico di `:emoji:` ovunque."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Completamento automatico di `:emoji:` ovunque."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "どこでも `:emoji:` を自動補完。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "どこでも `:emoji:` を自動補完。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "어디서나 `:emoji:` 자동 완성."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "어디서나 `:emoji:` 자동 완성."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Autocomplete `:emoji:` overal."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autocomplete `:emoji:` overal."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Autouzupełnianie `:emoji:` wszędzie."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autouzupełnianie `:emoji:` wszędzie."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Autocompletar `:emoji:` em qualquer lugar."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autocompletar `:emoji:` em qualquer lugar."
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Автодополнение `:emoji:` где угодно."
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автодополнение `:emoji:` где угодно."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "随处自动补全 `:emoji:`。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "随处自动补全 `:emoji:`。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "到處都能自動完成 `:emoji:`。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "到處都能自動完成 `:emoji:`。"
           }
         }
       }
     },
-    "Automatic updates": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "التحديثات التلقائية"
+    "Automatic updates" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "التحديثات التلقائية"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Automatische Updates"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatische Updates"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Automatic updates"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatic updates"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Actualizaciones automáticas"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizaciones automáticas"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Actualizaciones automáticas"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizaciones automáticas"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "به‌روزرسانی خودکار"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "به‌روزرسانی خودکار"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mises à jour automatiques"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mises à jour automatiques"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "עדכונים אוטומטיים"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "עדכונים אוטומטיים"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "स्वचालित अपडेट"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "स्वचालित अपडेट"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aggiornamenti automatici"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiornamenti automatici"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "自動アップデート"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動アップデート"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "자동 업데이트"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "자동 업데이트"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Automatische updates"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatische updates"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Automatyczne aktualizacje"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatyczne aktualizacje"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Atualizações automáticas"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atualizações automáticas"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Автоматические обновления"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автоматические обновления"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "自动更新"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动更新"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "自動更新"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動更新"
           }
         }
       }
     },
-    "Back": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "رجوع"
+    "Back" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "رجوع"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zurück"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zurück"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Back"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Back"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Atrás"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atrás"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Atrás"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atrás"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بازگشت"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بازگشت"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retour"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retour"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "חזרה"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "חזרה"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "पीछे"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "पीछे"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Indietro"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indietro"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "戻る"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "戻る"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "뒤로"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "뒤로"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Terug"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terug"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wstecz"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wstecz"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voltar"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voltar"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Назад"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Назад"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "返回"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "返回"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "返回"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "返回"
           }
         }
       }
     },
-    "Cancel": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إلغاء"
+    "Cancel" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إلغاء"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abbrechen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abbrechen"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancelar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancelar"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "لغو"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لغو"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Annuler"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annuler"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ביטול"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ביטול"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "रद्द करें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "रद्द करें"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Annulla"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annulla"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キャンセル"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセル"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "취소"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "취소"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Annuleer"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annuleer"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Anuluj"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anuluj"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancelar"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Отмена"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отмена"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "取消"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "取消"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消"
           }
         }
       }
     },
-    "Check for Updates…": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "التحقّق من التحديثات…"
+    "Check for Updates…" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "التحقّق من التحديثات…"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auf Updates prüfen…"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auf Updates prüfen…"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Check for Updates…"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Check for Updates…"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buscar actualizaciones…"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar actualizaciones…"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buscar actualizaciones…"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar actualizaciones…"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بررسی به‌روزرسانی‌ها…"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بررسی به‌روزرسانی‌ها…"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rechercher les mises à jour…"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechercher les mises à jour…"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "בדוק עדכונים…"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "בדוק עדכונים…"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "अपडेट देखें…"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "अपडेट देखें…"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cerca aggiornamenti…"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerca aggiornamenti…"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アップデートを確認…"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アップデートを確認…"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "업데이트 확인…"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "업데이트 확인…"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zoek naar updates…"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoek naar updates…"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sprawdź aktualizacje…"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sprawdź aktualizacje…"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verificar atualizações…"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verificar atualizações…"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Проверить обновления…"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Проверить обновления…"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "检查更新…"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "检查更新…"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "檢查更新…"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檢查更新…"
           }
         }
       }
     },
-    "Check now": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "التحقّق الآن"
+    "Check now" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "التحقّق الآن"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jetzt prüfen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jetzt prüfen"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Check now"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Check now"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buscar ahora"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar ahora"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buscar ahora"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar ahora"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بررسی کن"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بررسی کن"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vérifier maintenant"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vérifier maintenant"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "בדוק עכשיו"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "בדוק עכשיו"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "अभी देखें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "अभी देखें"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cerca ora"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerca ora"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "今すぐ確認"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今すぐ確認"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "지금 확인"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "지금 확인"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Controleer nu"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Controleer nu"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sprawdź teraz"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sprawdź teraz"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verificar agora"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verificar agora"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Проверить сейчас"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Проверить сейчас"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "立即检查"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "立即检查"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "立即檢查"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "立即檢查"
           }
         }
       }
     },
-    "Clear all emoji usage stats?": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "هل تريد مسح كل إحصاءات استخدام الإيموجي؟"
+    "Clear all emoji usage stats?" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "هل تريد مسح كل إحصاءات استخدام الإيموجي؟"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Alle Emoji-Nutzungsstatistiken löschen?"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle Emoji-Nutzungsstatistiken löschen?"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Clear all emoji usage stats?"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear all emoji usage stats?"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "¿Borrar todas las estadísticas de uso de emoji?"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Borrar todas las estadísticas de uso de emoji?"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "¿Borrar todas las estadísticas de uso de emojis?"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Borrar todas las estadísticas de uso de emojis?"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "همهٔ آمار استفاده از ایموجی پاک شود؟"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "همهٔ آمار استفاده از ایموجی پاک شود؟"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Effacer toutes les statistiques d'utilisation des emoji ?"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Effacer toutes les statistiques d'utilisation des emoji ?"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "לנקות את כל סטטיסטיקות השימוש באימוג'י?"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "לנקות את כל סטטיסטיקות השימוש באימוג'י?"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "क्या सभी इमोजी उपयोग आँकड़े हटा दें?"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "क्या सभी इमोजी उपयोग आँकड़े हटा दें?"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vuoi cancellare tutte le statistiche di utilizzo delle emoji?"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vuoi cancellare tutte le statistiche di utilizzo delle emoji?"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "すべての絵文字使用統計を削除しますか?"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべての絵文字使用統計を削除しますか?"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "모든 이모지 사용 통계를 지울까요?"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모든 이모지 사용 통계를 지울까요?"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Alle emoji-statistieken wissen?"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle emoji-statistieken wissen?"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wyczyścić wszystkie statystyki użycia emoji?"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wyczyścić wszystkie statystyki użycia emoji?"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apagar todas as estatísticas de uso de emoji?"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apagar todas as estatísticas de uso de emoji?"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Очистить всю статистику использования эмодзи?"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистить всю статистику использования эмодзи?"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "清除所有 emoji 使用统计?"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除所有 emoji 使用统计?"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "清除所有 emoji 使用統計?"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除所有 emoji 使用統計?"
           }
         }
       }
     },
-    "Clear stats": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مسح الإحصاءات"
+    "Clear stats" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مسح الإحصاءات"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Statistiken löschen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Statistiken löschen"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Clear stats"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear stats"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Borrar estadísticas"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Borrar estadísticas"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Borrar estadísticas"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Borrar estadísticas"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "پاک‌کردن آمار"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پاک‌کردن آمار"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Effacer les stats"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Effacer les stats"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "נקה סטטיסטיקות"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "נקה סטטיסטיקות"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "आँकड़े हटाएँ"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "आँकड़े हटाएँ"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancella statistiche"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancella statistiche"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "統計を削除"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "統計を削除"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "통계 지우기"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "통계 지우기"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wis statistieken"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wis statistieken"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wyczyść statystyki"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wyczyść statystyki"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apagar estatísticas"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apagar estatísticas"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Очистить статистику"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистить статистику"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "清除统计"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除统计"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "清除統計"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除統計"
           }
         }
       }
     },
-    "Clear stats...": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مسح الإحصاءات…"
+    "Clear stats..." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مسح الإحصاءات…"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Statistiken löschen…"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Statistiken löschen…"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Clear stats…"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear stats…"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Borrar estadísticas…"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Borrar estadísticas…"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Borrar estadísticas…"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Borrar estadísticas…"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "پاک‌کردن آمار…"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پاک‌کردن آمار…"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Effacer les stats…"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Effacer les stats…"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "נקה סטטיסטיקות…"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "נקה סטטיסטיקות…"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "आँकड़े हटाएँ…"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "आँकड़े हटाएँ…"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancella statistiche…"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancella statistiche…"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "統計を削除…"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "統計を削除…"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "통계 지우기…"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "통계 지우기…"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wis statistieken…"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wis statistieken…"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wyczyść statystyki…"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wyczyść statystyki…"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apagar estatísticas…"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apagar estatísticas…"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Очистить статистику…"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистить статистику…"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "清除统计…"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除统计…"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "清除統計…"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除統計…"
           }
         }
       }
+    },
+    "Close" : {
+
     },
-    "Continue": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "متابعة"
+    "Continue" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "متابعة"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Weiter"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weiter"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continue"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continuar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuar"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continuar"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuar"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ادامه"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ادامه"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continuer"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuer"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "המשך"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "המשך"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "जारी रखें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "जारी रखें"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continua"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continua"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "続ける"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "続ける"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "계속"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "계속"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ga door"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ga door"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kontynuuj"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kontynuuj"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continuar"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuar"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Продолжить"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Продолжить"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "继续"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "继续"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "繼續"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "繼續"
           }
         }
       }
     },
-    "Convert emoticons (`:D` → 😃)": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تحويل الرموز التعبيرية النصّية (`:D` → 😃)"
+    "Convert emoticons (`:D` → 😃)" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تحويل الرموز التعبيرية النصّية (`:D` → 😃)"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Emoticons umwandeln (`:D` → 😃)"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Emoticons umwandeln (`:D` → 😃)"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Convert emoticons (`:D` → 😃)"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Convert emoticons (`:D` → 😃)"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Convertir emoticonos (`:D` → 😃)"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Convertir emoticonos (`:D` → 😃)"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Convertir emoticones (`:D` → 😃)"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Convertir emoticones (`:D` → 😃)"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تبدیل شکلک‌ها (`:D` → 😃)"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تبدیل شکلک‌ها (`:D` → 😃)"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Convertir les émoticônes (`:D` → 😃)"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Convertir les émoticônes (`:D` → 😃)"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "המר אמוטיקונים (`:D` → 😃)"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "המר אמוטיקונים (`:D` → 😃)"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "इमोटिकॉन बदलें (`:D` → 😃)"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "इमोटिकॉन बदलें (`:D` → 😃)"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Converti le emoticon (`:D` → 😃)"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Converti le emoticon (`:D` → 😃)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "顔文字を変換 (`:D` → 😃)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顔文字を変換 (`:D` → 😃)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "이모티콘 변환 (`:D` → 😃)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이모티콘 변환 (`:D` → 😃)"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zet emoticons om (`:D` → 😃)"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zet emoticons om (`:D` → 😃)"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Konwertuj emotikony (`:D` → 😃)"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konwertuj emotikony (`:D` → 😃)"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Converter emoticons (`:D` → 😃)"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Converter emoticons (`:D` → 😃)"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Преобразовывать эмотиконы (`:D` → 😃)"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Преобразовывать эмотиконы (`:D` → 😃)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "转换颜文字 (`:D` → 😃)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "转换颜文字 (`:D` → 😃)"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "轉換顏文字 (`:D` → 😃)"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "轉換顏文字 (`:D` → 😃)"
           }
         }
       }
     },
-    "Copied!": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تم النسخ!"
+    "Copied!" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تم النسخ!"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kopiert!"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kopiert!"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copied!"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copied!"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "¡Copiado!"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¡Copiado!"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "¡Copiado!"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¡Copiado!"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کپی شد!"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "کپی شد!"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copié !"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copié !"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הועתק!"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הועתק!"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कॉपी हो गया!"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "कॉपी हो गया!"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copiato!"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copiato!"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "コピーしました!"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コピーしました!"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "복사됨!"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "복사됨!"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gekopieerd!"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gekopieerd!"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Skopiowano!"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skopiowano!"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copiado!"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copiado!"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Скопировано!"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Скопировано!"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已复制!"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已复制!"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已複製!"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已複製!"
           }
         }
       }
     },
-    "Copy": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نسخ"
+    "Copy" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نسخ"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kopieren"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kopieren"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copy"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copiar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copiar"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copiar"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copiar"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کپی"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "کپی"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copier"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copier"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "העתק"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "העתק"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कॉपी करें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "कॉपी करें"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copia"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copia"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "コピー"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コピー"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "복사"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "복사"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kopieer"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kopieer"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kopiuj"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kopiuj"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copiar"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copiar"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Копировать"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Копировать"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "复制"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "复制"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "複製"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製"
           }
         }
       }
     },
-    "Couldn't reach Giphy.": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تعذّر الوصول إلى Giphy."
+    "Copy debug info" : {
+
+    },
+    "Couldn't reach Giphy." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تعذّر الوصول إلى Giphy."
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy nicht erreichbar."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy nicht erreichbar."
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't reach Giphy."
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't reach Giphy."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se pudo conectar con Giphy."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo conectar con Giphy."
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se pudo conectar con Giphy."
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo conectar con Giphy."
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اتصال به Giphy ممکن نشد."
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اتصال به Giphy ممکن نشد."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Impossible de joindre Giphy."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de joindre Giphy."
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "לא ניתן להתחבר ל-Giphy."
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "לא ניתן להתחבר ל-Giphy."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy तक नहीं पहुँचा जा सका।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy तक नहीं पहुँचा जा सका।"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Impossibile raggiungere Giphy."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile raggiungere Giphy."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy に接続できませんでした。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy に接続できませんでした。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy에 연결할 수 없습니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy에 연결할 수 없습니다."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kon Giphy niet bereiken."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kon Giphy niet bereiken."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nie udało się połączyć z Giphy."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie udało się połączyć z Giphy."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Não foi possível acessar o Giphy."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não foi possível acessar o Giphy."
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Не удалось связаться с Giphy."
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось связаться с Giphy."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无法连接到 Giphy。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法连接到 Giphy。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "無法連線到 Giphy。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法連線到 Giphy。"
           }
         }
       }
     },
-    "Danger zone": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "منطقة الخطر"
+    "Danger zone" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "منطقة الخطر"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gefahrenzone"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gefahrenzone"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Danger zone"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Danger zone"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zona peligrosa"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zona peligrosa"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zona peligrosa"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zona peligrosa"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "منطقهٔ خطر"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "منطقهٔ خطر"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zone à risque"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zone à risque"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "אזור מסוכן"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "אזור מסוכן"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ख़तरे का क्षेत्र"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ख़तरे का क्षेत्र"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zona pericolosa"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zona pericolosa"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "危険な操作"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "危険な操作"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "주의 영역"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "주의 영역"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gevaarlijke zone"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gevaarlijke zone"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Strefa ryzyka"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Strefa ryzyka"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zona de risco"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zona de risco"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Опасная зона"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Опасная зона"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "危险区域"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "危险区域"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "危險區域"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "危險區域"
           }
         }
       }
     },
-    "Donate": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تبرّع"
+    "Donate" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تبرّع"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Spenden"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spenden"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Donate"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Donate"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Donar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Donar"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Donar"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Donar"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حمایت"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حمایت"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Faire un don"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faire un don"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "תרום"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "תרום"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "दान करें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "दान करें"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dona"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dona"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "寄付する"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "寄付する"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "후원"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "후원"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Doneer"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Doneer"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wpłać"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wpłać"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Doar"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Doar"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Поддержать"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поддержать"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "捐赠"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "捐赠"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "贊助"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "贊助"
           }
         }
       }
     },
-    "Done": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تم"
+    "Done" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تم"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fertig"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fertig"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Done"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Done"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hecho"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hecho"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Listo"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listo"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تمام"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تمام"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Terminé"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminé"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "סיום"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "סיום"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "हो गया"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "हो गया"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fatto"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fatto"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "完了"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完了"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "완료"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "완료"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klaar"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klaar"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gotowe"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gotowe"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Concluído"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Concluído"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Готово"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Готово"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "完成"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "完成"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成"
           }
         }
       }
     },
-    "Easter egg discovered": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تم اكتشاف بيضة مفاجِئة"
+    "Easter egg discovered" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تم اكتشاف بيضة مفاجِئة"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Easter Egg entdeckt"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Easter Egg entdeckt"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Easter egg discovered"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Easter egg discovered"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Huevo de pascua descubierto"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Huevo de pascua descubierto"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Huevo de pascua descubierto"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Huevo de pascua descubierto"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تخم‌مرغ نوروزی پیدا شد"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تخم‌مرغ نوروزی پیدا شد"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Easter egg découvert"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Easter egg découvert"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "התגלתה ביצת פסחא"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "התגלתה ביצת פסחא"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ईस्टर एग मिला"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ईस्टर एग मिला"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Easter egg scoperto"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Easter egg scoperto"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "イースターエッグを発見"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "イースターエッグを発見"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "이스터에그 발견"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이스터에그 발견"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Easter egg gevonden"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Easter egg gevonden"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Odkryto easter egg"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Odkryto easter egg"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Easter egg descoberto"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Easter egg descoberto"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Найдена пасхалка"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Найдена пасхалка"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "发现彩蛋"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "发现彩蛋"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "發現彩蛋"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "發現彩蛋"
           }
         }
       }
     },
-    "Easter eggs": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بيوض مفاجِئة"
+    "Easter eggs" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بيوض مفاجِئة"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Easter Eggs"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Easter Eggs"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Easter eggs"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Easter eggs"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Huevos de pascua"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Huevos de pascua"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Huevos de pascua"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Huevos de pascua"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تخم‌مرغ‌های نوروزی"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تخم‌مرغ‌های نوروزی"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Easter eggs"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Easter eggs"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ביצי פסחא"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ביצי פסחא"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ईस्टर एग"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ईस्टर एग"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Easter egg"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Easter egg"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "イースターエッグ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "イースターエッグ"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "이스터에그"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이스터에그"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Easter eggs"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Easter eggs"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Easter eggs"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Easter eggs"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Easter eggs"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Easter eggs"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Пасхалки"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пасхалки"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "彩蛋"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "彩蛋"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "彩蛋"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "彩蛋"
           }
         }
       }
     },
-    "Emoji": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إيموجي"
+    "Emoji" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إيموجي"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Emoji"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Emoji"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Emoji"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Emoji"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Emoji"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Emoji"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Emoji"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Emoji"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ایموجی"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ایموجی"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Émoji"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Émoji"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "אימוג'י"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "אימוג'י"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "इमोजी"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "इमोजी"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Emoji"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Emoji"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "絵文字"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "絵文字"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "이모지"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이모지"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Emoji"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Emoji"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Emoji"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Emoji"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Emoji"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Emoji"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Эмодзи"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Эмодзи"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Emoji"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Emoji"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Emoji"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Emoji"
           }
         }
       }
     },
-    "Emoji autocompleted": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إيموجي تمّ إكمالها تلقائياً"
+    "Emoji autocompleted" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إيموجي تمّ إكمالها تلقائياً"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vervollständigte Emoji"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vervollständigte Emoji"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Emoji autocompleted"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Emoji autocompleted"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Emoji autocompletados"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Emoji autocompletados"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Emojis autocompletados"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Emojis autocompletados"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ایموجی‌های تکمیل‌شده"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ایموجی‌های تکمیل‌شده"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Émoji autocomplétés"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Émoji autocomplétés"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "אימוג'י שהושלמו"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "אימוג'י שהושלמו"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ऑटोकम्प्लीट किए गए इमोजी"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ऑटोकम्प्लीट किए गए इमोजी"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Emoji completati"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Emoji completati"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "自動補完した絵文字"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動補完した絵文字"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "자동 완성된 이모지"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "자동 완성된 이모지"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aangevulde emoji"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aangevulde emoji"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uzupełnione emoji"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uzupełnione emoji"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Emoji autocompletados"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Emoji autocompletados"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Эмодзи добавлено"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Эмодзи добавлено"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已自动补全 emoji"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已自动补全 emoji"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已自動完成 emoji"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已自動完成 emoji"
           }
         }
       }
     },
-    "Exclusions": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الاستثناءات"
+    "Exclusions" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الاستثناءات"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ausnahmen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ausnahmen"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exclusions"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exclusions"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exclusiones"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exclusiones"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exclusiones"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exclusiones"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "موارد مستثنا"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "موارد مستثنا"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exclusions"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exclusions"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "החרגות"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "החרגות"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "अपवर्जन"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "अपवर्जन"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esclusioni"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esclusioni"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "除外"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "除外"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "제외 항목"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "제외 항목"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uitsluitingen"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uitsluitingen"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wykluczenia"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wykluczenia"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exclusões"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exclusões"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Исключения"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Исключения"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "排除项"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "排除项"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "排除項目"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "排除項目"
           }
         }
       }
     },
-    "Funded by donations": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تموَّل من التبرّعات"
+    "Funded by donations" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تموَّل من التبرّعات"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Durch Spenden finanziert"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Durch Spenden finanziert"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Funded by donations"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Funded by donations"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Financiado con donaciones"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Financiado con donaciones"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Financiado con donaciones"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Financiado con donaciones"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "با حمایت‌های مردمی"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "با حمایت‌های مردمی"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Financé par les dons"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Financé par les dons"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ממומן בתרומות"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ממומן בתרומות"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "दान से वित्तपोषित"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "दान से वित्तपोषित"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Finanziato dalle donazioni"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finanziato dalle donazioni"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "寄付で支えられています"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "寄付で支えられています"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "후원으로 운영"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "후원으로 운영"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gefinancierd door donaties"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gefinancierd door donaties"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Finansowane z wpłat"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finansowane z wpłat"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Financiado por doações"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Financiado por doações"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Существует на пожертвования"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Существует на пожертвования"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "由捐赠资助"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "由捐赠资助"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "由贊助支持"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "由贊助支持"
           }
         }
       }
     },
-    "GIF search": {
-      "localizations": {
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF search"
+    "GIF search" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "البحث عن GIF"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF-Suche"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF-Suche"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Búsqueda de GIF"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF search"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Búsqueda de GIF"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Búsqueda de GIF"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recherche de GIF"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Búsqueda de GIF"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ricerca GIF"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "جست‌وجوی GIF"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Busca de GIF"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recherche de GIF"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF 検索"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "חיפוש GIF"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF 搜索"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF खोज"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF 搜尋"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ricerca GIF"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF 검색"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF 検索"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF खोज"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF 검색"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Поиск GIF"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF-zoeken"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wyszukiwanie GIF-ów"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wyszukiwanie GIF-ów"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF-zoeken"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Busca de GIF"
           }
         },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "البحث عن GIF"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поиск GIF"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "جست‌وجوی GIF"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF 搜索"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "חיפוש GIF"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF 搜尋"
           }
         }
       }
     },
-    "GIF search bypass": {
-      "localizations": {
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF search bypass"
+    "GIF search bypass" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "استثناء البحث عن GIF"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF-Suche ohne Ausschlüsse"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF-Suche ohne Ausschlüsse"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Excepción para búsqueda de GIF"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF search bypass"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Excepción para búsqueda de GIF"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Excepción para búsqueda de GIF"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exception pour la recherche de GIF"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Excepción para búsqueda de GIF"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eccezione per la ricerca di GIF"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "استثنای جست‌وجوی GIF"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exceção para a busca de GIF"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exception pour la recherche de GIF"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF 検索の例外"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "חריגה לחיפוש GIF"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF 搜索例外"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF खोज अपवाद"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF 搜尋例外"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eccezione per la ricerca di GIF"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF 검색 예외"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF 検索の例外"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF खोज अपवाद"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF 검색 예외"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Исключение для поиска GIF"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF-zoeken uitzondering"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wyjątek dla wyszukiwania GIF"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wyjątek dla wyszukiwania GIF"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF-zoeken uitzondering"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exceção para a busca de GIF"
           }
         },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "استثناء البحث عن GIF"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Исключение для поиска GIF"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "استثنای جست‌وجوی GIF"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF 搜索例外"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "חריגה לחיפוש GIF"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF 搜尋例外"
           }
         }
       }
     },
-    "GIFs and Symbols": {
-      "localizations": {
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIFs and Symbols"
+    "GIFs and Symbols" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "صور GIF والرموز"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIFs und Symbole"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIFs und Symbole"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF y símbolos"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIFs and Symbols"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF y símbolos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF y símbolos"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF et symboles"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF y símbolos"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF e simboli"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "گیف‌ها و نمادها"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIFs e símbolos"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF et symboles"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF と記号"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF-ים וסמלים"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF 和符号"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF और प्रतीक"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF 與符號"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF e simboli"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF 및 기호"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF と記号"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF और प्रतीक"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF 및 기호"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF и символы"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIFs en symbolen"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF-y i symbole"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF-y i symbole"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIFs en symbolen"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIFs e símbolos"
           }
         },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "صور GIF والرموز"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF и символы"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "گیف‌ها و نمادها"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF 和符号"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF-ים וסמלים"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF 與符號"
           }
         }
       }
     },
-    "General": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "عام"
+    "General" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عام"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Allgemein"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Allgemein"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "General"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "General"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "General"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "General"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "General"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "General"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "عمومی"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عمومی"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Général"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Général"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "כללי"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "כללי"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "सामान्य"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "सामान्य"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Generali"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Generali"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "一般"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一般"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "일반"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "일반"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Algemeen"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Algemeen"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ogólne"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ogólne"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Geral"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geral"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Основные"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Основные"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "通用"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通用"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "一般"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一般"
           }
         }
       }
     },
-    "Get started": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ابدأ"
+    "Get started" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ابدأ"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Los geht's"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los geht's"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Get started"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Get started"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Empezar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Empezar"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Empezar"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Empezar"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "شروع کنید"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "شروع کنید"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Commencer"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commencer"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "התחל"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "התחל"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "शुरू करें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "शुरू करें"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Inizia"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inizia"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "はじめる"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "はじめる"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "시작하기"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시작하기"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aan de slag"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aan de slag"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rozpocznij"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rozpocznij"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Começar"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Começar"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Начать"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Начать"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "开始使用"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "开始使用"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "開始使用"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開始使用"
           }
         }
       }
     },
-    "Giphy rejected the API key.": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "رفض Giphy مفتاح API."
+    "Giphy rejected the API key." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "رفض Giphy مفتاح API."
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy hat den API-Schlüssel abgelehnt."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy hat den API-Schlüssel abgelehnt."
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy rejected the API key."
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy rejected the API key."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy rechazó la clave de la API."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy rechazó la clave de la API."
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy rechazó la clave de la API."
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy rechazó la clave de la API."
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏Giphy کلید API را رد کرد."
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏Giphy کلید API را رد کرد."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy a refusé la clé d'API."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy a refusé la clé d'API."
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏Giphy דחתה את מפתח ה-API."
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏Giphy דחתה את מפתח ה-API."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy ने API कुंजी अस्वीकार कर दी।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy ने API कुंजी अस्वीकार कर दी।"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy ha rifiutato la chiave API."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy ha rifiutato la chiave API."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy が API キーを拒否しました。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy が API キーを拒否しました。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy가 API 키를 거부했습니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy가 API 키를 거부했습니다."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy weigerde de API-sleutel."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy weigerde de API-sleutel."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy odrzuciło klucz API."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy odrzuciło klucz API."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O Giphy rejeitou a chave da API."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O Giphy rejeitou a chave da API."
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy отклонил ключ API."
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy отклонил ключ API."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy 拒绝了 API 密钥。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy 拒绝了 API 密钥。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy 拒絕了 API 金鑰。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy 拒絕了 API 金鑰。"
           }
         }
       }
     },
-    "Giphy responded with an unexpected result.": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ردّ Giphy بنتيجة غير متوقعة."
+    "Giphy responded with an unexpected result." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ردّ Giphy بنتيجة غير متوقعة."
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy hat unerwartet geantwortet."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy hat unerwartet geantwortet."
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy responded with an unexpected result."
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy responded with an unexpected result."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy respondió con un resultado inesperado."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy respondió con un resultado inesperado."
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy respondió con un resultado inesperado."
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy respondió con un resultado inesperado."
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏Giphy پاسخی غیرمنتظره برگرداند."
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏Giphy پاسخی غیرمنتظره برگرداند."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy a répondu avec un résultat inattendu."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy a répondu avec un résultat inattendu."
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏Giphy החזירה תוצאה לא צפויה."
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏Giphy החזירה תוצאה לא צפויה."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy से अप्रत्याशित प्रतिक्रिया मिली।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy से अप्रत्याशित प्रतिक्रिया मिली।"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy ha risposto con un risultato inatteso."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy ha risposto con un risultato inatteso."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy から予期しない応答が返されました。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy から予期しない応答が返されました。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy가 예상치 못한 응답을 보냈습니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy가 예상치 못한 응답을 보냈습니다."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy gaf een onverwacht resultaat."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy gaf een onverwacht resultaat."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy zwróciło nieoczekiwany wynik."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy zwróciło nieoczekiwany wynik."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O Giphy retornou um resultado inesperado."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O Giphy retornou um resultado inesperado."
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy вернул неожиданный ответ."
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy вернул неожиданный ответ."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy 返回了意外的结果。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy 返回了意外的结果。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy 回傳了預期外的結果。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy 回傳了預期外的結果。"
           }
         }
       }
     },
-    "Grant accessibility permissions": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "منح أذونات إمكانية الوصول"
+    "Grant accessibility permissions" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "منح أذونات إمكانية الوصول"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bedienungshilfen-Berechtigungen erteilen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bedienungshilfen-Berechtigungen erteilen"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Grant accessibility permissions"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grant accessibility permissions"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conceder permisos de accesibilidad"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conceder permisos de accesibilidad"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Otorgar permisos de accesibilidad"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Otorgar permisos de accesibilidad"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اعطای دسترسی به دسترس‌پذیری"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اعطای دسترسی به دسترس‌پذیری"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Accorder les autorisations d'accessibilité"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accorder les autorisations d'accessibilité"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "אשר הרשאות נגישות"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "אשר הרשאות נגישות"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ऐक्सेसिबिलिटी अनुमतियाँ दें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ऐक्सेसिबिलिटी अनुमतियाँ दें"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Concedi i permessi di accessibilità"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Concedi i permessi di accessibilità"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アクセシビリティの権限を許可"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アクセシビリティの権限を許可"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "손쉬운 사용 권한 허용"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "손쉬운 사용 권한 허용"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Geef toegankelijkheidstoestemmingen"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geef toegankelijkheidstoestemmingen"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Udziel uprawnień dostępności"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Udziel uprawnień dostępności"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conceder permissões de acessibilidade"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conceder permissões de acessibilidade"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Предоставьте разрешения универсального доступа"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Предоставьте разрешения универсального доступа"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "授予辅助功能权限"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "授予辅助功能权限"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "授予輔助使用權限"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "授予輔助使用權限"
           }
         }
       }
     },
-    "I donated": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "لقد تبرّعت"
+    "Hide Details" : {
+
+    },
+    "I donated" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لقد تبرّعت"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ich habe gespendet"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ich habe gespendet"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I donated"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I donated"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ya he donado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ya he donado"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ya doné"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ya doné"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حمایت کردم"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حمایت کردم"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "J'ai fait un don"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "J'ai fait un don"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "תרמתי"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "תרמתי"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "मैंने दान किया"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "मैंने दान किया"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ho donato"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ho donato"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "寄付しました"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "寄付しました"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "후원했어요"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "후원했어요"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ik heb gedoneerd"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ik heb gedoneerd"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wpłaciłem(-am)"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wpłaciłem(-am)"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eu doei"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eu doei"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Я поддержал"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Я поддержал"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "我已捐赠"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "我已捐赠"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "我已贊助"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "我已贊助"
           }
         }
       }
     },
-    "If the icon doesn't appear in the menu bar, check **System Settings → Menu Bar → \"Allow in the Menu Bar\"**.": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إذا لم تظهر الأيقونة في شريط القوائم، تحقّق من **إعدادات النظام ← شريط القوائم ← \"السماح في شريط القوائم\"**."
+    "If the icon doesn't appear in the menu bar, check **System Settings → Menu Bar → \"Allow in the Menu Bar\"**." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إذا لم تظهر الأيقونة في شريط القوائم، تحقّق من **إعدادات النظام ← شريط القوائم ← \"السماح في شريط القوائم\"**."
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Falls das Symbol nicht in der Menüleiste erscheint, prüfe **Systemeinstellungen → Menüleiste → „In der Menüleiste erlauben\"**."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Falls das Symbol nicht in der Menüleiste erscheint, prüfe **Systemeinstellungen → Menüleiste → „In der Menüleiste erlauben\"**."
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "If the icon doesn't appear in the menu bar, check **System Settings → Menu Bar → \"Allow in the Menu Bar\"**."
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "If the icon doesn't appear in the menu bar, check **System Settings → Menu Bar → \"Allow in the Menu Bar\"**."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Si el icono no aparece en la barra de menús, revisa **Ajustes del sistema → Barra de menús → \"Permitir en la barra de menús\"**."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si el icono no aparece en la barra de menús, revisa **Ajustes del sistema → Barra de menús → \"Permitir en la barra de menús\"**."
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Si el ícono no aparece en la barra de menús, revisá **Ajustes del sistema → Barra de menús → \"Permitir en la barra de menús\"**."
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si el ícono no aparece en la barra de menús, revisá **Ajustes del sistema → Barra de menús → \"Permitir en la barra de menús\"**."
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اگر آیکون در نوار منو ظاهر نشد، **تنظیمات سیستم ← نوار منو ← «اجازه در نوار منو»** را بررسی کنید."
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اگر آیکون در نوار منو ظاهر نشد، **تنظیمات سیستم ← نوار منو ← «اجازه در نوار منو»** را بررسی کنید."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Si l'icône n'apparaît pas dans la barre de menus, vérifie **Réglages Système → Barre de menus → « Autoriser dans la barre de menus »**."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si l'icône n'apparaît pas dans la barre de menus, vérifie **Réglages Système → Barre de menus → « Autoriser dans la barre de menus »**."
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "אם הצלמית לא מופיעה בשורת התפריטים, בדוק את **הגדרות המערכת ← שורת התפריטים ← \"אפשר בשורת התפריטים\"**."
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "אם הצלמית לא מופיעה בשורת התפריטים, בדוק את **הגדרות המערכת ← שורת התפריטים ← \"אפשר בשורת התפריטים\"**."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "अगर मेन्यू बार में आइकन नहीं दिखे, तो **सिस्टम सेटिंग्स → मेन्यू बार → \"मेन्यू बार में अनुमति दें\"** देखें।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "अगर मेन्यू बार में आइकन नहीं दिखे, तो **सिस्टम सेटिंग्स → मेन्यू बार → \"मेन्यू बार में अनुमति दें\"** देखें।"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Se l'icona non compare nella barra dei menu, controlla **Impostazioni di Sistema → Barra dei menu → \"Consenti nella barra dei menu\"**."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se l'icona non compare nella barra dei menu, controlla **Impostazioni di Sistema → Barra dei menu → \"Consenti nella barra dei menu\"**."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "メニューバーにアイコンが表示されない場合は、**システム設定 → メニューバー → \"メニューバーで許可\"** を確認してください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メニューバーにアイコンが表示されない場合は、**システム設定 → メニューバー → \"メニューバーで許可\"** を確認してください。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "메뉴 막대에 아이콘이 보이지 않으면 **시스템 설정 → 메뉴 막대 → \"메뉴 막대에서 허용\"** 을 확인하세요."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "메뉴 막대에 아이콘이 보이지 않으면 **시스템 설정 → 메뉴 막대 → \"메뉴 막대에서 허용\"** 을 확인하세요."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Als het pictogram niet in de menubalk verschijnt, controleer **Systeeminstellingen → Menubalk → \"Toestaan in menubalk\"**."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Als het pictogram niet in de menubalk verschijnt, controleer **Systeeminstellingen → Menubalk → \"Toestaan in menubalk\"**."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jeśli ikona nie pojawia się na pasku menu, sprawdź **Ustawienia systemowe → Pasek menu → „Zezwól na pasku menu\"**."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jeśli ikona nie pojawia się na pasku menu, sprawdź **Ustawienia systemowe → Pasek menu → „Zezwól na pasku menu\"**."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Se o ícone não aparecer na barra de menus, confira **Ajustes do Sistema → Barra de Menus → \"Permitir na barra de menus\"**."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se o ícone não aparecer na barra de menus, confira **Ajustes do Sistema → Barra de Menus → \"Permitir na barra de menus\"**."
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Если значок не появляется в строке меню, проверьте **Системные настройки → Строка меню → «Разрешить в строке меню»**."
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Если значок не появляется в строке меню, проверьте **Системные настройки → Строка меню → «Разрешить в строке меню»**."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "如果图标没有出现在菜单栏中,请检查 **系统设置 → 菜单栏 → \"在菜单栏中允许\"**。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "如果图标没有出现在菜单栏中,请检查 **系统设置 → 菜单栏 → \"在菜单栏中允许\"**。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "如果圖示沒有出現在選單列中,請檢查 **系統設定 → 選單列 → \"允許在選單列中顯示\"**。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "如果圖示沒有出現在選單列中,請檢查 **系統設定 → 選單列 → \"允許在選單列中顯示\"**。"
           }
         }
       }
     },
-    "Include symbols (experimental)": {
-      "extractionState": "stale",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تضمين الرموز (تجريبي)"
+    "Include symbols (experimental)" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تضمين الرموز (تجريبي)"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Symbole einbeziehen (experimentell)"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symbole einbeziehen (experimentell)"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Include symbols (experimental)"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Include symbols (experimental)"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Incluir símbolos (experimental)"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Incluir símbolos (experimental)"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Incluir símbolos (experimental)"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Incluir símbolos (experimental)"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "گنجاندن نمادها (آزمایشی)"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "گنجاندن نمادها (آزمایشی)"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Inclure les symboles (expérimental)"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inclure les symboles (expérimental)"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "כלול סמלים (ניסיוני)"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "כלול סמלים (ניסיוני)"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "प्रतीक शामिल करें (प्रायोगिक)"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "प्रतीक शामिल करें (प्रायोगिक)"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Includi simboli (sperimentale)"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Includi simboli (sperimentale)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "記号を含める(実験的)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "記号を含める(実験的)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "기호 포함 (실험적)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기호 포함 (실험적)"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Symbolen meenemen (experimenteel)"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symbolen meenemen (experimenteel)"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uwzględnij symbole (eksperymentalne)"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uwzględnij symbole (eksperymentalne)"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Incluir símbolos (experimental)"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Incluir símbolos (experimental)"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Включать символы (экспериментально)"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Включать символы (экспериментально)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "包含符号(实验性)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包含符号(实验性)"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "包含符號(實驗性)"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包含符號(實驗性)"
           }
         }
       }
     },
-    "Include ★ ⌘ ⌥ and similar characters in results (experimental).": {
-      "localizations": {
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Include ★ ⌘ ⌥ and similar characters in results (experimental)."
+    "Include ★ ⌘ ⌥ and similar characters in results (experimental)." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تضمين ★ ⌘ ⌥ والأحرف المشابهة في النتائج (تجريبي)."
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "★ ⌘ ⌥ und ähnliche Zeichen in den Ergebnissen anzeigen (experimentell)."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "★ ⌘ ⌥ und ähnliche Zeichen in den Ergebnissen anzeigen (experimentell)."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Incluir ★ ⌘ ⌥ y caracteres similares en los resultados (experimental)."
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Include ★ ⌘ ⌥ and similar characters in results (experimental)."
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Incluir ★ ⌘ ⌥ y caracteres similares en los resultados (experimental)."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Incluir ★ ⌘ ⌥ y caracteres similares en los resultados (experimental)."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Inclure ★ ⌘ ⌥ et caractères similaires dans les résultats (expérimental)."
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Incluir ★ ⌘ ⌥ y caracteres similares en los resultados (experimental)."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Includi ★ ⌘ ⌥ e caratteri simili nei risultati (sperimentale)."
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "گنجاندن ★ ⌘ ⌥ و کاراکترهای مشابه در نتایج (آزمایشی)."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Incluir ★ ⌘ ⌥ e caracteres semelhantes nos resultados (experimental)."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inclure ★ ⌘ ⌥ et caractères similaires dans les résultats (expérimental)."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "★ ⌘ ⌥ などの記号を結果に含めます(実験的)。"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "כלול את ★ ⌘ ⌥ ותווים דומים בתוצאות (ניסיוני)."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "在结果中包含 ★ ⌘ ⌥ 等字符(实验性)。"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "परिणामों में ★ ⌘ ⌥ और मिलते-जुलते वर्ण शामिल करें (प्रयोगात्मक)।"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "在結果中包含 ★ ⌘ ⌥ 等字元(實驗性)。"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Includi ★ ⌘ ⌥ e caratteri simili nei risultati (sperimentale)."
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "★ ⌘ ⌥ 등 유사 문자를 결과에 포함합니다(실험적)."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "★ ⌘ ⌥ などの記号を結果に含めます(実験的)。"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "परिणामों में ★ ⌘ ⌥ और मिलते-जुलते वर्ण शामिल करें (प्रयोगात्मक)।"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "★ ⌘ ⌥ 등 유사 문자를 결과에 포함합니다(실험적)."
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Включать ★ ⌘ ⌥ и подобные символы в результаты (экспериментально)."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toon ★ ⌘ ⌥ en vergelijkbare tekens in resultaten (experimenteel)."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uwzględniaj ★ ⌘ ⌥ i podobne znaki w wynikach (eksperymentalne)."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uwzględniaj ★ ⌘ ⌥ i podobne znaki w wynikach (eksperymentalne)."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Toon ★ ⌘ ⌥ en vergelijkbare tekens in resultaten (experimenteel)."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Incluir ★ ⌘ ⌥ e caracteres semelhantes nos resultados (experimental)."
           }
         },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تضمين ★ ⌘ ⌥ والأحرف المشابهة في النتائج (تجريبي)."
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Включать ★ ⌘ ⌥ и подобные символы в результаты (экспериментально)."
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "گنجاندن ★ ⌘ ⌥ و کاراکترهای مشابه در نتایج (آزمایشی)."
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在结果中包含 ★ ⌘ ⌥ 等字符(实验性)。"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "כלול את ★ ⌘ ⌥ ותווים דומים בתוצאות (ניסיוני)."
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在結果中包含 ★ ⌘ ⌥ 等字元(實驗性)。"
           }
         }
       }
     },
-    "Input Monitoring": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مراقبة الإدخال"
+    "Input Monitoring" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مراقبة الإدخال"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eingabeüberwachung"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eingabeüberwachung"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Input Monitoring"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Input Monitoring"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Monitorización de entrada"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monitorización de entrada"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Monitoreo de entrada"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monitoreo de entrada"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نظارت بر ورودی"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نظارت بر ورودی"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Surveillance des entrées"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Surveillance des entrées"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ניטור קלט"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ניטור קלט"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "इनपुट मॉनिटरिंग"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "इनपुट मॉनिटरिंग"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Monitoraggio dell'input"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monitoraggio dell'input"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "入力監視"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "入力監視"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "입력 모니터링"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "입력 모니터링"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invoercontrole"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invoercontrole"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Monitorowanie wprowadzania"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monitorowanie wprowadzania"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Monitoramento de Entrada"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monitoramento de Entrada"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Мониторинг ввода"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Мониторинг ввода"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "输入监控"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "输入监控"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "輸入監控"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入監控"
           }
         }
       }
     },
-    "Keyboard shortcuts": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اختصارات لوحة المفاتيح"
+    "Keyboard shortcuts" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اختصارات لوحة المفاتيح"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tastaturkürzel"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tastaturkürzel"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keyboard shortcuts"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keyboard shortcuts"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Atajos de teclado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atajos de teclado"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Atajos de teclado"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atajos de teclado"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "میان‌برهای صفحه‌کلید"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "میان‌برهای صفحه‌کلید"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Raccourcis clavier"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Raccourcis clavier"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "קיצורי מקלדת"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "קיצורי מקלדת"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कीबोर्ड शॉर्टकट"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "कीबोर्ड शॉर्टकट"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scorciatoie da tastiera"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scorciatoie da tastiera"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーボードショートカット"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キーボードショートカット"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키보드 단축키"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "키보드 단축키"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Toetscombinaties"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toetscombinaties"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Skróty klawiszowe"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skróty klawiszowe"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Atalhos de teclado"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atalhos de teclado"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Сочетания клавиш"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сочетания клавиш"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "键盘快捷键"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "键盘快捷键"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "鍵盤捷徑"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鍵盤捷徑"
           }
         }
       }
     },
-    "Keystrokes aren't logged": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "لا يتمّ تسجيل ضغطات المفاتيح"
+    "Keystrokes aren't logged" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا يتمّ تسجيل ضغطات المفاتيح"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tastenanschläge werden nicht protokolliert"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tastenanschläge werden nicht protokolliert"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keystrokes aren't logged"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keystrokes aren't logged"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Las pulsaciones no se registran"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las pulsaciones no se registran"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Las pulsaciones no se registran"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las pulsaciones no se registran"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ضربه‌های کلید ذخیره نمی‌شود"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ضربه‌های کلید ذخیره نمی‌شود"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Les frappes ne sont pas journalisées"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les frappes ne sont pas journalisées"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הקשות מקלדת אינן נשמרות"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הקשות מקלדת אינן נשמרות"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कीस्ट्रोक्स लॉग नहीं किए जाते"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "कीस्ट्रोक्स लॉग नहीं किए जाते"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Le digitazioni non vengono registrate"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le digitazioni non vengono registrate"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キー入力は記録されません"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キー入力は記録されません"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키 입력은 기록되지 않습니다"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "키 입력은 기록되지 않습니다"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Toetsaanslagen worden niet vastgelegd"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toetsaanslagen worden niet vastgelegd"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Naciśnięcia klawiszy nie są zapisywane"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Naciśnięcia klawiszy nie są zapisywane"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "As teclas digitadas não são registradas"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "As teclas digitadas não são registradas"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Нажатия клавиш не записываются"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нажатия клавиш не записываются"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "不会记录按键"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不会记录按键"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "不會記錄按鍵"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不會記錄按鍵"
           }
         }
       }
+    },
+    "Legend" : {
+
     },
-    "Let GIF search work in excluded apps": {
-      "localizations": {
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Let GIF search work in excluded apps"
+    "Let GIF search work in excluded apps" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "السماح بالبحث عن GIF في التطبيقات المستثناة"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF-Suche auch in ausgeschlossenen Apps zulassen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF-Suche auch in ausgeschlossenen Apps zulassen"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permitir la búsqueda de GIF en apps excluidas"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Let GIF search work in excluded apps"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permitir la búsqueda de GIF en apps excluidas"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permitir la búsqueda de GIF en apps excluidas"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Autoriser la recherche de GIF dans les apps exclues"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permitir la búsqueda de GIF en apps excluidas"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Consenti la ricerca di GIF nelle app escluse"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اجازه دادن جست‌وجوی GIF در برنامه‌های مستثنا"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permitir busca de GIF em apps excluídos"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autoriser la recherche de GIF dans les apps exclues"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "除外したアプリでも GIF 検索を有効にする"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "אפשר חיפוש GIF גם באפליקציות מוחרגות"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "在已排除的应用中也启用 GIF 搜索"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "बहिष्कृत ऐप्स में भी GIF खोज की अनुमति दें"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "在已排除的 App 中仍允許 GIF 搜尋"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Consenti la ricerca di GIF nelle app escluse"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "제외된 앱에서도 GIF 검색 허용"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "除外したアプリでも GIF 検索を有効にする"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "बहिष्कृत ऐप्स में भी GIF खोज की अनुमति दें"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "제외된 앱에서도 GIF 검색 허용"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Разрешать поиск GIF в исключённых приложениях"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF-zoeken toestaan in uitgesloten apps"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zezwalaj na wyszukiwanie GIF-ów w wykluczonych aplikacjach"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zezwalaj na wyszukiwanie GIF-ów w wykluczonych aplikacjach"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF-zoeken toestaan in uitgesloten apps"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permitir busca de GIF em apps excluídos"
           }
         },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "السماح بالبحث عن GIF في التطبيقات المستثناة"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Разрешать поиск GIF в исключённых приложениях"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اجازه دادن جست‌وجوی GIF در برنامه‌های مستثنا"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在已排除的应用中也启用 GIF 搜索"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "אפשר חיפוש GIF גם באפליקציות מוחרגות"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在已排除的 App 中仍允許 GIF 搜尋"
           }
         }
       }
     },
-    "Lets %@ anchor the picker next to your text cursor.": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "يتيح لـ %@ تثبيت أداة الاختيار بجوار مؤشر النص."
+    "Lets %@ anchor the picker next to your text cursor." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يتيح لـ %@ تثبيت أداة الاختيار بجوار مؤشر النص."
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Erlaubt %@, den Picker neben deinem Textcursor zu verankern."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erlaubt %@, den Picker neben deinem Textcursor zu verankern."
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lets %@ anchor the picker next to your text cursor."
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lets %@ anchor the picker next to your text cursor."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permite que %@ ancle el selector junto al cursor de texto."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permite que %@ ancle el selector junto al cursor de texto."
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permite que %@ ancle el selector junto al cursor de texto."
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permite que %@ ancle el selector junto al cursor de texto."
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "به %@ اجازه می‌دهد انتخابگر را کنار مکان‌نمای متن قرار دهد."
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "به %@ اجازه می‌دهد انتخابگر را کنار مکان‌نمای متن قرار دهد."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permet à %@ d'ancrer le sélecteur à côté de votre curseur de texte."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permet à %@ d'ancrer le sélecteur à côté de votre curseur de texte."
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מאפשר ל-%@ לעגן את הבורר ליד סמן הטקסט."
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "מאפשר ל-%@ לעגן את הבורר ליד סמן הטקסט."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ को आपके टेक्स्ट कर्सर के बगल में पिकर लगाने देता है।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ को आपके टेक्स्ट कर्सर के बगल में पिकर लगाने देता है।"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permette a %@ di ancorare il selettore accanto al cursore di testo."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permette a %@ di ancorare il selettore accanto al cursore di testo."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ がピッカーをテキストカーソルの隣に固定できるようになります。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ がピッカーをテキストカーソルの隣に固定できるようになります。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@이(가) 선택기를 텍스트 커서 옆에 고정할 수 있게 합니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@이(가) 선택기를 텍스트 커서 옆에 고정할 수 있게 합니다."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Laat %@ de kiezer naast je tekstcursor verankeren."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laat %@ de kiezer naast je tekstcursor verankeren."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pozwala aplikacji %@ umieszczać okno wyboru obok kursora."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pozwala aplikacji %@ umieszczać okno wyboru obok kursora."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permite que o %@ ancore o seletor ao lado do cursor de texto."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permite que o %@ ancore o seletor ao lado do cursor de texto."
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Позволяет %@ закреплять окно подбора рядом с курсором."
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Позволяет %@ закреплять окно подбора рядом с курсором."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "让 %@ 把选取器锚定在文本光标旁。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "让 %@ 把选取器锚定在文本光标旁。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "讓 %@ 將選取器固定在文字游標旁邊。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "讓 %@ 將選取器固定在文字游標旁邊。"
           }
         }
       }
     },
-    "Lets %@ watch keystrokes for `:` triggers. Nothing is logged.": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "يتيح لـ %@ مراقبة الضغطات بحثاً عن `:`. لا يُسجَّل شيء."
+    "Lets %@ watch keystrokes for `:` triggers. Nothing is logged." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يتيح لـ %@ مراقبة الضغطات بحثاً عن `:`. لا يُسجَّل شيء."
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Erlaubt %@, Tastenanschläge auf `:` zu beobachten. Es wird nichts protokolliert."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erlaubt %@, Tastenanschläge auf `:` zu beobachten. Es wird nichts protokolliert."
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lets %@ watch keystrokes for `:` triggers. Nothing is logged."
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lets %@ watch keystrokes for `:` triggers. Nothing is logged."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permite que %@ vigile las pulsaciones en busca del `:`. No se registra nada."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permite que %@ vigile las pulsaciones en busca del `:`. No se registra nada."
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permite que %@ vigile las pulsaciones en busca del `:`. No se registra nada."
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permite que %@ vigile las pulsaciones en busca del `:`. No se registra nada."
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "به %@ اجازه می‌دهد ضربه‌های `:` را پی بگیرد. هیچ‌چیز ذخیره نمی‌شود."
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "به %@ اجازه می‌دهد ضربه‌های `:` را پی بگیرد. هیچ‌چیز ذخیره نمی‌شود."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permet à %@ de surveiller les frappes pour détecter `:`. Rien n'est journalisé."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permet à %@ de surveiller les frappes pour détecter `:`. Rien n'est journalisé."
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מאפשר ל-%@ לעקוב אחר הקשות `:`. דבר לא נשמר."
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "מאפשר ל-%@ לעקוב אחר הקשות `:`. דבר לא נשמר."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ को `:` के लिए कीस्ट्रोक देखने देता है। कुछ भी लॉग नहीं होता।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ को `:` के लिए कीस्ट्रोक देखने देता है। कुछ भी लॉग नहीं होता।"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permette a %@ di osservare le digitazioni in cerca di `:`. Nulla viene registrato."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permette a %@ di osservare le digitazioni in cerca di `:`. Nulla viene registrato."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ が `:` のキー入力を監視できるようにします。何も記録されません。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ が `:` のキー入力を監視できるようにします。何も記録されません。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@이(가) `:` 입력을 감지하도록 합니다. 아무것도 기록되지 않습니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@이(가) `:` 입력을 감지하도록 합니다. 아무것도 기록되지 않습니다."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Laat %@ toetsaanslagen volgen voor `:`. Er wordt niets vastgelegd."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laat %@ toetsaanslagen volgen voor `:`. Er wordt niets vastgelegd."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pozwala aplikacji %@ obserwować naciśnięcia `:`. Nic nie jest zapisywane."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pozwala aplikacji %@ obserwować naciśnięcia `:`. Nic nie jest zapisywane."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permite que o %@ observe as teclas em busca de `:`. Nada é registrado."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permite que o %@ observe as teclas em busca de `:`. Nada é registrado."
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Позволяет %@ отслеживать нажатия `:`. Ничего не записывается."
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Позволяет %@ отслеживать нажатия `:`. Ничего не записывается."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "让 %@ 监听 `:` 触发键。不会记录任何内容。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "让 %@ 监听 `:` 触发键。不会记录任何内容。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "讓 %@ 監聽 `:` 觸發鍵。不會記錄任何內容。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "讓 %@ 監聽 `:` 觸發鍵。不會記錄任何內容。"
           }
         }
       }
     },
-    "Load more": {
-      "localizations": {
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Load more"
+    "Load more" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تحميل المزيد"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mehr laden"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mehr laden"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cargar más"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Load more"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cargar más"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cargar más"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Charger plus"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cargar más"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Carica altri"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بارگذاری بیشتر"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Carregar mais"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Charger plus"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "さらに読み込む"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "טען עוד"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "加载更多"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "और लोड करें"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "載入更多"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Carica altri"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "더 불러오기"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "さらに読み込む"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "और लोड करें"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "더 불러오기"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Загрузить ещё"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Meer laden"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Załaduj więcej"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Załaduj więcej"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Meer laden"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Carregar mais"
           }
         },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تحميل المزيد"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузить ещё"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بارگذاری بیشتر"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加载更多"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "טען עוד"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "載入更多"
           }
         }
       }
     },
-    "No GIFs found.": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "لم يُعثر على أي GIF."
+    "No GIFs found." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لم يُعثر على أي GIF."
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keine GIFs gefunden."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine GIFs gefunden."
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No GIFs found."
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No GIFs found."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se han encontrado GIF."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se han encontrado GIF."
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se encontraron GIF."
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se encontraron GIF."
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "هیچ GIF‌ای پیدا نشد."
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "هیچ GIF‌ای پیدا نشد."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aucun GIF trouvé."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun GIF trouvé."
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "לא נמצאו GIF-ים."
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "לא נמצאו GIF-ים."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कोई GIF नहीं मिला।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "कोई GIF नहीं मिला।"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nessun GIF trovato."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun GIF trovato."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF が見つかりませんでした。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF が見つかりませんでした。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF를 찾을 수 없습니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF를 찾을 수 없습니다."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Geen GIFs gevonden."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geen GIFs gevonden."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nie znaleziono GIF-ów."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie znaleziono GIF-ów."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nenhum GIF encontrado."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nenhum GIF encontrado."
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF не найдены."
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF не найдены."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "没有找到 GIF。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有找到 GIF。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "找不到 GIF。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到 GIF。"
           }
         }
       }
     },
-    "No ads, tracking, or subscriptions.": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "لا إعلانات، لا تتبّع، لا اشتراكات."
+    "No ads, tracking, or subscriptions." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا إعلانات، لا تتبّع، لا اشتراكات."
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keine Werbung, kein Tracking, keine Abos."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Werbung, kein Tracking, keine Abos."
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No ads, tracking, or subscriptions."
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No ads, tracking, or subscriptions."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sin anuncios, seguimiento ni suscripciones."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin anuncios, seguimiento ni suscripciones."
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sin anuncios, rastreo ni suscripciones."
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin anuncios, rastreo ni suscripciones."
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بدون تبلیغ، ردیابی یا اشتراک."
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بدون تبلیغ، ردیابی یا اشتراک."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pas de pubs, pas de pistage, pas d'abonnement."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pas de pubs, pas de pistage, pas d'abonnement."
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ללא פרסומות, מעקב או מנויים."
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ללא פרסומות, מעקב או מנויים."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कोई विज्ञापन, ट्रैकिंग या सदस्यता नहीं।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "कोई विज्ञापन, ट्रैकिंग या सदस्यता नहीं।"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Niente pubblicità, tracciamento o abbonamenti."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Niente pubblicità, tracciamento o abbonamenti."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "広告、トラッキング、サブスクリプションは一切ありません。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "広告、トラッキング、サブスクリプションは一切ありません。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "광고도, 추적도, 구독도 없습니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "광고도, 추적도, 구독도 없습니다."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Geen advertenties, tracking of abonnementen."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geen advertenties, tracking of abonnementen."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bez reklam, śledzenia i subskrypcji."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bez reklam, śledzenia i subskrypcji."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sem anúncios, rastreamento ou assinaturas."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sem anúncios, rastreamento ou assinaturas."
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Без рекламы, отслеживания и подписок."
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Без рекламы, отслеживания и подписок."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无广告、无追踪、无订阅。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无广告、无追踪、无订阅。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "無廣告、無追蹤、無訂閱。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無廣告、無追蹤、無訂閱。"
           }
         }
       }
     },
-    "No emoji for :%@:": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "لا توجد إيموجي لـ :%@:"
+    "No emoji for :%@:" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا توجد إيموجي لـ :%@:"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kein Emoji für :%@:"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kein Emoji für :%@:"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No emoji for :%@:"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No emoji for :%@:"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No hay emoji para :%@:"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay emoji para :%@:"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No hay emoji para :%@:"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay emoji para :%@:"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ایموجی‌ای برای :%@: یافت نشد"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ایموجی‌ای برای :%@: یافت نشد"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aucun émoji pour :%@:"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun émoji pour :%@:"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "אין אימוג'י עבור :%@:"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "אין אימוג'י עבור :%@:"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": ":%@: के लिए कोई इमोजी नहीं"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ":%@: के लिए कोई इमोजी नहीं"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nessuna emoji per :%@:"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna emoji per :%@:"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": ":%@: に対応する絵文字はありません"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ":%@: に対応する絵文字はありません"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": ":%@: 에 해당하는 이모지가 없습니다"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ":%@: 에 해당하는 이모지가 없습니다"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Geen emoji voor :%@:"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geen emoji voor :%@:"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Brak emoji dla :%@:"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Brak emoji dla :%@:"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nenhum emoji para :%@:"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nenhum emoji para :%@:"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Нет эмодзи для :%@:"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет эмодзи для :%@:"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "没有 :%@: 对应的 emoji"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有 :%@: 对应的 emoji"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "找不到 :%@: 對應的 emoji"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到 :%@: 對應的 emoji"
           }
         }
       }
     },
-    "Open settings": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "فتح الإعدادات"
+    "Open settings" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "فتح الإعدادات"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Einstellungen öffnen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einstellungen öffnen"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open settings"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open settings"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abrir ajustes"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir ajustes"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abrir ajustes"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir ajustes"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "باز کردن تنظیمات"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "باز کردن تنظیمات"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ouvrir les réglages"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouvrir les réglages"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "פתח הגדרות"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "פתח הגדרות"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "सेटिंग्स खोलें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "सेटिंग्स खोलें"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apri impostazioni"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apri impostazioni"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "設定を開く"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定を開く"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "설정 열기"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "설정 열기"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open instellingen"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open instellingen"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Otwórz ustawienia"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Otwórz ustawienia"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abrir ajustes"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir ajustes"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Открыть настройки"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Открыть настройки"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "打开设置"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开设置"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "打開設定"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打開設定"
           }
         }
       }
     },
-    "Open source and auditable": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مفتوح المصدر وقابل للمراجعة"
+    "Open source and auditable" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مفتوح المصدر وقابل للمراجعة"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open Source und überprüfbar"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Source und überprüfbar"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open source and auditable"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open source and auditable"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "De código abierto y auditable"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "De código abierto y auditable"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "De código abierto y auditable"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "De código abierto y auditable"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "متن‌باز و قابل بررسی"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "متن‌باز و قابل بررسی"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open source et vérifiable"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open source et vérifiable"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "קוד פתוח וניתן לביקורת"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "קוד פתוח וניתן לביקורת"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ओपन सोर्स और जाँच-योग्य"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ओपन सोर्स और जाँच-योग्य"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open source e verificabile"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open source e verificabile"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "オープンソースで監査可能"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オープンソースで監査可能"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "오픈 소스, 직접 확인 가능"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오픈 소스, 직접 확인 가능"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open source en controleerbaar"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open source en controleerbaar"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open source, można sprawdzić"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open source, można sprawdzić"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Código aberto e auditável"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Código aberto e auditável"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Открытый исходный код, можно проверить"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Открытый исходный код, можно проверить"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "开源,可审计"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "开源,可审计"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "開源、可審核"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開源、可審核"
           }
         }
       }
     },
-    "Pause for 1 hour": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إيقاف مؤقّت لمدّة ساعة"
+    "Pause" : {
+
+    },
+    "Pause for 1 hour" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إيقاف مؤقّت لمدّة ساعة"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eine Stunde pausieren"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eine Stunde pausieren"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pause for 1 hour"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pause for 1 hour"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pausar 1 hora"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pausar 1 hora"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pausar 1 hora"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pausar 1 hora"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "توقف برای ۱ ساعت"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "توقف برای ۱ ساعت"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mettre en pause 1 heure"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mettre en pause 1 heure"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "השהה לשעה אחת"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "השהה לשעה אחת"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1 घंटे के लिए रोकें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 घंटे के लिए रोकें"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pausa per 1 ora"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pausa per 1 ora"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1時間一時停止"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1時間一時停止"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1시간 동안 일시 중지"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1시간 동안 일시 중지"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1 uur pauzeren"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 uur pauzeren"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wstrzymaj na 1 godzinę"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wstrzymaj na 1 godzinę"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pausar por 1 hora"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pausar por 1 hora"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Пауза на 1 час"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пауза на 1 час"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "暂停 1 小时"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暂停 1 小时"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "暫停 1 小時"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暫停 1 小時"
           }
         }
       }
     },
-    "Pause until tomorrow": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إيقاف مؤقّت حتى الغد"
+    "Pause until tomorrow" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إيقاف مؤقّت حتى الغد"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bis morgen pausieren"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bis morgen pausieren"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pause until tomorrow"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pause until tomorrow"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pausar hasta mañana"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pausar hasta mañana"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pausar hasta mañana"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pausar hasta mañana"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "توقف تا فردا"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "توقف تا فردا"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mettre en pause jusqu'à demain"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mettre en pause jusqu'à demain"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "השהה עד מחר"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "השהה עד מחר"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कल तक के लिए रोकें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "कल तक के लिए रोकें"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pausa fino a domani"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pausa fino a domani"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "明日まで一時停止"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "明日まで一時停止"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "내일까지 일시 중지"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "내일까지 일시 중지"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pauzeer tot morgen"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pauzeer tot morgen"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wstrzymaj do jutra"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wstrzymaj do jutra"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pausar até amanhã"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pausar até amanhã"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Пауза до завтра"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пауза до завтра"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "暂停到明天"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暂停到明天"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "暫停到明天"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暫停到明天"
           }
         }
       }
     },
-    "Permissions": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الأذونات"
+    "Permissions" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الأذونات"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Berechtigungen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Berechtigungen"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permissions"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permissions"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permisos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permisos"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permisos"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permisos"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اجازه‌ها"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اجازه‌ها"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Autorisations"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autorisations"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הרשאות"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הרשאות"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "अनुमतियाँ"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "अनुमतियाँ"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permessi"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permessi"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "権限"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "権限"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "권한"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "권한"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Toestemmingen"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toestemmingen"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uprawnienia"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uprawnienia"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permissões"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permissões"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Разрешения"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Разрешения"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "权限"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "权限"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "權限"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "權限"
           }
         }
       }
     },
-    "Press the same shortcut again while paused to resume.": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اضغط الاختصار نفسه أثناء الإيقاف المؤقّت للاستئناف."
+    "Press the same shortcut again while paused to resume." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اضغط الاختصار نفسه أثناء الإيقاف المؤقّت للاستئناف."
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Drücke dieselbe Tastenkombination während der Pause erneut, um fortzufahren."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Drücke dieselbe Tastenkombination während der Pause erneut, um fortzufahren."
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Press the same shortcut again while paused to resume."
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Press the same shortcut again while paused to resume."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pulsa el mismo atajo de nuevo mientras está en pausa para reanudar."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pulsa el mismo atajo de nuevo mientras está en pausa para reanudar."
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apretá el mismo atajo de nuevo durante la pausa para reanudar."
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apretá el mismo atajo de nuevo durante la pausa para reanudar."
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "در حالت توقف، همان میان‌بر را دوباره فشار دهید تا ادامه یابد."
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "در حالت توقف، همان میان‌بر را دوباره فشار دهید تا ادامه یابد."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Appuyez à nouveau sur le même raccourci pendant la pause pour reprendre."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appuyez à nouveau sur le même raccourci pendant la pause pour reprendre."
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "לחץ שוב על אותו קיצור בעת ההשהיה כדי להמשיך."
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "לחץ שוב על אותו קיצור בעת ההשהיה כדי להמשיך."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "रुके होने पर वही शॉर्टकट दोबारा दबाने से फिर शुरू हो जाएगा।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "रुके होने पर वही शॉर्टकट दोबारा दबाने से फिर शुरू हो जाएगा।"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Premi di nuovo la stessa scorciatoia in pausa per riprendere."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Premi di nuovo la stessa scorciatoia in pausa per riprendere."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "一時停止中に同じショートカットをもう一度押すと再開します。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一時停止中に同じショートカットをもう一度押すと再開します。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "일시 중지 중에 같은 단축키를 다시 누르면 다시 시작됩니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "일시 중지 중에 같은 단축키를 다시 누르면 다시 시작됩니다."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Druk tijdens de pauze opnieuw op dezelfde sneltoets om te hervatten."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Druk tijdens de pauze opnieuw op dezelfde sneltoets om te hervatten."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Naciśnij ten sam skrót podczas wstrzymania, by wznowić."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Naciśnij ten sam skrót podczas wstrzymania, by wznowić."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pressione o mesmo atalho durante a pausa para retomar."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pressione o mesmo atalho durante a pausa para retomar."
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Нажмите тот же сочетание клавиш во время паузы, чтобы продолжить."
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нажмите тот же сочетание клавиш во время паузы, чтобы продолжить."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "暂停期间再次按相同的快捷键即可恢复。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暂停期间再次按相同的快捷键即可恢复。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "暫停期間再次按相同的快捷鍵即可恢復。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暫停期間再次按相同的快捷鍵即可恢復。"
           }
         }
       }
     },
-    "Prevent %@ from triggering inside these apps.": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "منع تشغيل %@ داخل هذه التطبيقات."
+    "Prevent %@ from triggering inside these apps." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "منع تشغيل %@ داخل هذه التطبيقات."
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verhindere, dass %@ in diesen Apps auslöst."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verhindere, dass %@ in diesen Apps auslöst."
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prevent %@ from triggering inside these apps."
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prevent %@ from triggering inside these apps."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Evita que %@ se active dentro de estas apps."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Evita que %@ se active dentro de estas apps."
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Evitá que %@ se active dentro de estas apps."
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Evitá que %@ se active dentro de estas apps."
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏%@ در این برنامه‌ها فعال نشود."
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏%@ در این برنامه‌ها فعال نشود."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Empêche %@ de se déclencher dans ces apps."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Empêche %@ de se déclencher dans ces apps."
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מנע מ-%@ לפעול בתוך אפליקציות אלו."
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "מנע מ-%@ לפעול בתוך אפליקציות אלו."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "इन ऐप्स के अंदर %@ को सक्रिय होने से रोकें।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "इन ऐप्स के अंदर %@ को सक्रिय होने से रोकें।"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Impedisci a %@ di attivarsi in queste app."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impedisci a %@ di attivarsi in queste app."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "これらのアプリ内で %@ が動作しないようにします。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "これらのアプリ内で %@ が動作しないようにします。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "이 앱들 안에서는 %@이(가) 작동하지 않도록 합니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 앱들 안에서는 %@이(가) 작동하지 않도록 합니다."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voorkom dat %@ in deze apps actief is."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voorkom dat %@ in deze apps actief is."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nie uruchamiaj %@ w tych aplikacjach."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie uruchamiaj %@ w tych aplikacjach."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Impede que %@ seja acionado dentro destes apps."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impede que %@ seja acionado dentro destes apps."
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Не запускать %@ внутри этих приложений."
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не запускать %@ внутри этих приложений."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "在这些 App 内不触发 %@。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在这些 App 内不触发 %@。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "在這些 App 內不觸發 %@。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在這些 App 內不觸發 %@。"
           }
         }
       }
     },
-    "Prevent %@ from triggering on these sites. `*` matches a subdomain.": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "منع تشغيل %@ على هذه المواقع. `*` يطابق نطاقاً فرعياً."
+    "Prevent %@ from triggering on these sites. `*` matches a subdomain." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "منع تشغيل %@ على هذه المواقع. `*` يطابق نطاقاً فرعياً."
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verhindere, dass %@ auf diesen Seiten auslöst. `*` steht für eine Subdomain."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verhindere, dass %@ auf diesen Seiten auslöst. `*` steht für eine Subdomain."
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prevent %@ from triggering on these sites. `*` matches a subdomain."
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prevent %@ from triggering on these sites. `*` matches a subdomain."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Evita que %@ se active en estos sitios. `*` representa un subdominio."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Evita que %@ se active en estos sitios. `*` representa un subdominio."
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Evitá que %@ se active en estos sitios. `*` representa un subdominio."
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Evitá que %@ se active en estos sitios. `*` representa un subdominio."
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏%@ در این سایت‌ها فعال نشود. `*` با زیردامنه‌ها مطابقت می‌کند."
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏%@ در این سایت‌ها فعال نشود. `*` با زیردامنه‌ها مطابقت می‌کند."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Empêche %@ de se déclencher sur ces sites. `*` correspond à un sous-domaine."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Empêche %@ de se déclencher sur ces sites. `*` correspond à un sous-domaine."
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מנע מ-%@ לפעול באתרים אלה. `*` מתאים לתת-דומיין."
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "מנע מ-%@ לפעול באתרים אלה. `*` מתאים לתת-דומיין."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "इन साइटों पर %@ को सक्रिय होने से रोकें। `*` एक उपडोमेन से मेल खाता है।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "इन साइटों पर %@ को सक्रिय होने से रोकें। `*` एक उपडोमेन से मेल खाता है।"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Impedisci a %@ di attivarsi su questi siti. `*` rappresenta un sottodominio."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impedisci a %@ di attivarsi su questi siti. `*` rappresenta un sottodominio."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "これらのサイトで %@ が動作しないようにします。`*` はサブドメインを表します。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "これらのサイトで %@ が動作しないようにします。`*` はサブドメインを表します。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "이 사이트들에서는 %@이(가) 작동하지 않도록 합니다. `*` 는 하위 도메인을 의미합니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 사이트들에서는 %@이(가) 작동하지 않도록 합니다. `*` 는 하위 도메인을 의미합니다."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voorkom dat %@ op deze sites actief is. `*` komt overeen met een subdomein."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voorkom dat %@ op deze sites actief is. `*` komt overeen met een subdomein."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nie uruchamiaj %@ na tych witrynach. `*` pasuje do subdomeny."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie uruchamiaj %@ na tych witrynach. `*` pasuje do subdomeny."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Impede que %@ seja acionado nestes sites. `*` corresponde a um subdomínio."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impede que %@ seja acionado nestes sites. `*` corresponde a um subdomínio."
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Не запускать %@ на этих сайтах. `*` соответствует поддомену."
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не запускать %@ на этих сайтах. `*` соответствует поддомену."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "在这些网站上不触发 %@。`*` 匹配子域名。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在这些网站上不触发 %@。`*` 匹配子域名。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "在這些網站上不觸發 %@。`*` 匹配子網域。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在這些網站上不觸發 %@。`*` 匹配子網域。"
           }
         }
       }
     },
-    "Privacy": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الخصوصية"
+    "Privacy" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الخصوصية"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Datenschutz"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Datenschutz"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Privacy"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacy"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Privacidad"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacidad"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Privacidad"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacidad"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حریم خصوصی"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حریم خصوصی"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confidentialité"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confidentialité"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "פרטיות"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "פרטיות"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "निजता"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "निजता"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Privacy"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacy"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "プライバシー"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プライバシー"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "개인정보"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "개인정보"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Privacy"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacy"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prywatność"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prywatność"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Privacidade"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacidade"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Конфиденциальность"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Конфиденциальность"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "隐私"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隐私"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "私隱"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "私隱"
           }
         }
       }
     },
-    "Privacy details…": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تفاصيل الخصوصية…"
+    "Privacy details…" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تفاصيل الخصوصية…"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Datenschutz-Details…"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Datenschutz-Details…"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Privacy details…"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacy details…"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Detalles de privacidad…"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detalles de privacidad…"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Detalles de privacidad…"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detalles de privacidad…"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "جزئیات حریم خصوصی…"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "جزئیات حریم خصوصی…"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Détails de confidentialité…"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Détails de confidentialité…"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "פרטי פרטיות…"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "פרטי פרטיות…"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "निजता विवरण…"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "निजता विवरण…"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dettagli sulla privacy…"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dettagli sulla privacy…"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "プライバシーの詳細…"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プライバシーの詳細…"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "개인정보 자세히…"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "개인정보 자세히…"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Privacydetails…"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacydetails…"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Szczegóły prywatności…"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Szczegóły prywatności…"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Detalhes de privacidade…"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detalhes de privacidade…"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Подробнее о конфиденциальности…"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подробнее о конфиденциальности…"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "隐私详情…"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隐私详情…"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "私隱詳情…"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "私隱詳情…"
           }
         }
       }
     },
-    "Quit %@": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إنهاء %@"
+    "Quit %@" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إنهاء %@"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ beenden"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ beenden"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Quit %@"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quit %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Salir de %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salir de %@"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Salir de %@"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salir de %@"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "خروج از %@"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "خروج از %@"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Quitter %@"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quitter %@"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "צא מ-%@"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "צא מ-%@"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ छोड़ें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ छोड़ें"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esci da %@"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esci da %@"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ を終了"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ を終了"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 종료"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 종료"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stop %@"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stop %@"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zakończ %@"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zakończ %@"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Encerrar %@"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Encerrar %@"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Завершить %@"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Завершить %@"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "退出 %@"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "退出 %@"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "結束 %@"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "結束 %@"
           }
         }
       }
     },
-    "Rank frequently used emoji higher": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ترتيب الإيموجي الأكثر استخداماً في الأعلى"
+    "Quit & Reopen" : {
+
+    },
+    "Rank frequently used emoji higher" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ترتيب الإيموجي الأكثر استخداماً في الأعلى"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Häufig verwendete Emoji höher einstufen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Häufig verwendete Emoji höher einstufen"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rank frequently used emoji higher"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rank frequently used emoji higher"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Priorizar los emoji que usas más"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Priorizar los emoji que usas más"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Priorizar los emojis que más usás"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Priorizar los emojis que más usás"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ایموجی‌های پرکاربرد بالاتر باشند"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ایموجی‌های پرکاربرد بالاتر باشند"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mettre en avant les émoji utilisés souvent"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mettre en avant les émoji utilisés souvent"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "דרג גבוה יותר אימוג'י שאתה משתמש בהם הרבה"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "דרג גבוה יותר אימוג'י שאתה משתמש בהם הרבה"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "अक्सर इस्तेमाल किए जाने वाले इमोजी ऊपर रखें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "अक्सर इस्तेमाल किए जाने वाले इमोजी ऊपर रखें"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dai priorità alle emoji più usate"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dai priorità alle emoji più usate"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "よく使う絵文字を上位に表示"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "よく使う絵文字を上位に表示"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "자주 쓰는 이모지를 위로"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "자주 쓰는 이모지를 위로"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Veelgebruikte emoji hoger sorteren"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Veelgebruikte emoji hoger sorteren"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pokazuj często używane emoji wyżej"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pokazuj często używane emoji wyżej"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Priorizar emoji usados com frequência"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Priorizar emoji usados com frequência"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Часто используемые эмодзи выше"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Часто используемые эмодзи выше"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "常用 emoji 排序靠前"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "常用 emoji 排序靠前"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "常用 emoji 排序靠前"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "常用 emoji 排序靠前"
           }
         }
       }
     },
-    "Report an issue": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الإبلاغ عن مشكلة"
+    "Report an issue" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الإبلاغ عن مشكلة"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Problem melden"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Problem melden"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Report an issue"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Report an issue"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Informar de un problema"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informar de un problema"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Informar un problema"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informar un problema"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "گزارش مشکل"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "گزارش مشکل"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Signaler un problème"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Signaler un problème"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "דווח על בעיה"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "דווח על בעיה"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "समस्या रिपोर्ट करें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "समस्या रिपोर्ट करें"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Segnala un problema"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Segnala un problema"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "問題を報告"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "問題を報告"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "문제 신고"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "문제 신고"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Meld een probleem"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Meld een probleem"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zgłoś problem"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zgłoś problem"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Relatar um problema"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relatar um problema"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Сообщить о проблеме"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сообщить о проблеме"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "报告问题"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "报告问题"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "回報問題"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "回報問題"
           }
         }
       }
     },
-    "Require `::` to search symbols": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اشترط `::` للبحث عن الرموز"
+    "Require `::` to search symbols" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اشترط `::` للبحث عن الرموز"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "`::` zum Suchen von Symbolen verlangen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`::` zum Suchen von Symbolen verlangen"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Require `::` to search symbols"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Require `::` to search symbols"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Requerir `::` para buscar símbolos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Requerir `::` para buscar símbolos"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Requerir `::` para buscar símbolos"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Requerir `::` para buscar símbolos"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "برای جست‌وجوی نمادها `::` لازم باشد"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "برای جست‌وجوی نمادها `::` لازم باشد"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exiger `::` pour rechercher des symboles"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exiger `::` pour rechercher des symboles"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "דרוש `::` כדי לחפש סמלים"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "דרוש `::` כדי לחפש סמלים"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "प्रतीक खोजने के लिए `::` अनिवार्य"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "प्रतीक खोजने के लिए `::` अनिवार्य"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Richiedi `::` per cercare simboli"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Richiedi `::` per cercare simboli"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "記号の検索に `::` を必須にする"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "記号の検索に `::` を必須にする"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "기호 검색 시 `::` 입력 필요"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기호 검색 시 `::` 입력 필요"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vereis `::` om symbolen te zoeken"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vereis `::` om symbolen te zoeken"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wymagaj `::` do wyszukiwania symboli"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wymagaj `::` do wyszukiwania symboli"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exigir `::` para buscar símbolos"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exigir `::` para buscar símbolos"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Требовать `::` для поиска символов"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Требовать `::` для поиска символов"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "搜索符号需要输入 `::`"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索符号需要输入 `::`"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "搜尋符號需要輸入 `::`"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋符號需要輸入 `::`"
           }
         }
       }
     },
-    "Reset all easter egg progress?": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "هل تريد إعادة تعيين كلّ تقدّم البيوض المفاجِئة؟"
+    "Reset all easter egg progress?" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "هل تريد إعادة تعيين كلّ تقدّم البيوض المفاجِئة؟"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Allen Easter-Egg-Fortschritt zurücksetzen?"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Allen Easter-Egg-Fortschritt zurücksetzen?"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reset all easter egg progress?"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reset all easter egg progress?"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "¿Restablecer el progreso de los huevos de pascua?"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Restablecer el progreso de los huevos de pascua?"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "¿Restablecer el progreso de los huevos de pascua?"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Restablecer el progreso de los huevos de pascua?"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تمام پیشرفت تخم‌مرغ‌های نوروزی پاک شود؟"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تمام پیشرفت تخم‌مرغ‌های نوروزی پاک شود؟"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Réinitialiser la progression des easter eggs ?"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réinitialiser la progression des easter eggs ?"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "לאפס את כל ההתקדמות בביצי הפסחא?"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "לאפס את כל ההתקדמות בביצי הפסחא?"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "क्या सभी ईस्टर एग प्रगति रीसेट कर दें?"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "क्या सभी ईस्टर एग प्रगति रीसेट कर दें?"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vuoi azzerare i progressi degli easter egg?"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vuoi azzerare i progressi degli easter egg?"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "イースターエッグの進捗をすべてリセットしますか?"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "イースターエッグの進捗をすべてリセットしますか?"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "이스터에그 진행 상황을 모두 초기화할까요?"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이스터에그 진행 상황을 모두 초기화할까요?"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Alle easter-egg-voortgang terugzetten?"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle easter-egg-voortgang terugzetten?"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zresetować cały postęp easter eggs?"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zresetować cały postęp easter eggs?"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Redefinir todo o progresso dos easter eggs?"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Redefinir todo o progresso dos easter eggs?"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Сбросить весь прогресс по пасхалкам?"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сбросить весь прогресс по пасхалкам?"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "重置所有彩蛋进度?"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重置所有彩蛋进度?"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "重設所有彩蛋進度?"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重設所有彩蛋進度?"
           }
         }
       }
     },
-    "Reset eggs": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إعادة تعيين البيوض"
+    "Reset eggs" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إعادة تعيين البيوض"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eggs zurücksetzen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eggs zurücksetzen"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reset eggs"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reset eggs"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restablecer huevos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restablecer huevos"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restablecer huevos"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restablecer huevos"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "پاک‌کردن تخم‌مرغ‌ها"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پاک‌کردن تخم‌مرغ‌ها"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Réinitialiser les eggs"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réinitialiser les eggs"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "אפס ביצים"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "אפס ביצים"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "एग रीसेट करें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "एग रीसेट करें"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Azzera gli egg"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Azzera gli egg"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "エッグをリセット"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エッグをリセット"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "에그 초기화"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "에그 초기화"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eggs herstellen"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eggs herstellen"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zresetuj eggs"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zresetuj eggs"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Redefinir eggs"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Redefinir eggs"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Сбросить пасхалки"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сбросить пасхалки"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "重置彩蛋"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重置彩蛋"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "重設彩蛋"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重設彩蛋"
           }
         }
       }
     },
-    "Reset eggs...": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إعادة تعيين البيوض…"
+    "Reset eggs..." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إعادة تعيين البيوض…"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eggs zurücksetzen…"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eggs zurücksetzen…"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reset eggs…"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reset eggs…"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restablecer huevos…"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restablecer huevos…"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restablecer huevos…"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restablecer huevos…"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "پاک‌کردن تخم‌مرغ‌ها…"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پاک‌کردن تخم‌مرغ‌ها…"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Réinitialiser les eggs…"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réinitialiser les eggs…"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "אפס ביצים…"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "אפס ביצים…"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "एग रीसेट करें…"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "एग रीसेट करें…"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Azzera gli egg…"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Azzera gli egg…"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "エッグをリセット…"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エッグをリセット…"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "에그 초기화…"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "에그 초기화…"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eggs herstellen…"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eggs herstellen…"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zresetuj eggs…"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zresetuj eggs…"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Redefinir eggs…"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Redefinir eggs…"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Сбросить пасхалки…"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сбросить пасхалки…"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "重置彩蛋…"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重置彩蛋…"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "重設彩蛋…"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重設彩蛋…"
           }
         }
       }
     },
-    "Resume": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "استئناف"
+    "Resume" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "استئناف"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fortsetzen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fortsetzen"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resume"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resume"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reanudar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reanudar"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reanudar"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reanudar"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ادامه"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ادامه"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reprendre"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reprendre"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "המשך"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "המשך"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "फिर शुरू करें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "फिर शुरू करें"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Riprendi"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Riprendi"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "再開"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再開"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "다시 시작"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다시 시작"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hervat"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hervat"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wznów"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wznów"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retomar"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retomar"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Продолжить"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Продолжить"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "继续"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "继续"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "繼續"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "繼續"
           }
         }
       }
     },
-    "Search GIFs…": {
-      "extractionState": "stale",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "البحث عن GIF…"
+    "Search GIFs…" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "البحث عن GIF…"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIFs suchen…"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIFs suchen…"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Search GIFs…"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search GIFs…"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buscar GIF…"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar GIF…"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buscar GIF…"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar GIF…"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "جست‌وجوی GIF…"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "جست‌وجوی GIF…"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rechercher des GIF…"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechercher des GIF…"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "חפש GIF…"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "חפש GIF…"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF खोजें…"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF खोजें…"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cerca GIF…"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerca GIF…"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF を検索…"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF を検索…"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF 검색…"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF 검색…"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zoek GIFs…"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoek GIFs…"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Szukaj GIF-ów…"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Szukaj GIF-ów…"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buscar GIF…"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar GIF…"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Найти GIF…"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Найти GIF…"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "搜索 GIF…"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索 GIF…"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "搜尋 GIF…"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋 GIF…"
           }
         }
       }
     },
-    "Searching…": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "جارٍ البحث…"
+    "Searching…" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "جارٍ البحث…"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Suche läuft…"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suche läuft…"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Searching…"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Searching…"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buscando…"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscando…"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buscando…"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscando…"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "در حال جست‌وجو…"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "در حال جست‌وجو…"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recherche…"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recherche…"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מחפש…"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "מחפש…"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "खोजा जा रहा है…"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "खोजा जा रहा है…"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ricerca in corso…"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ricerca in corso…"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "検索中…"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検索中…"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "검색 중…"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "검색 중…"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zoeken…"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoeken…"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wyszukiwanie…"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wyszukiwanie…"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buscando…"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscando…"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Идёт поиск…"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Идёт поиск…"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "搜索中…"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索中…"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "搜尋中…"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋中…"
           }
         }
       }
     },
-    "Settings…": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الإعدادات…"
+    "Settings…" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الإعدادات…"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Einstellungen…"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einstellungen…"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Settings…"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Settings…"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ajustes…"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajustes…"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ajustes…"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajustes…"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تنظیمات…"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تنظیمات…"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Réglages…"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réglages…"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הגדרות…"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הגדרות…"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "सेटिंग्स…"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "सेटिंग्स…"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Impostazioni…"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impostazioni…"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "設定…"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定…"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "설정…"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "설정…"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Instellingen…"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Instellingen…"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ustawienia…"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ustawienia…"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ajustes…"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajustes…"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Настройки…"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Настройки…"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "设置…"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设置…"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "設定…"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定…"
           }
         }
       }
+    },
+    "Show Details" : {
+
     },
-    "Show Onboarding": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "عرض الإعداد الترحيبي"
+    "Show Onboarding" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عرض الإعداد الترحيبي"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Einführung anzeigen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einführung anzeigen"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show Onboarding"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Onboarding"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mostrar la bienvenida"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar la bienvenida"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mostrar la bienvenida"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar la bienvenida"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نمایش راه‌اندازی اولیه"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نمایش راه‌اندازی اولیه"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Afficher l'onboarding"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher l'onboarding"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הצג מסך הצטרפות"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הצג מסך הצטרפות"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ऑनबोर्डिंग दिखाएँ"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ऑनबोर्डिंग दिखाएँ"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mostra l'onboarding"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra l'onboarding"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "オンボーディングを表示"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オンボーディングを表示"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "온보딩 보기"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "온보딩 보기"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Toon onboarding"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toon onboarding"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pokaż wprowadzenie"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pokaż wprowadzenie"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mostrar onboarding"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar onboarding"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Показать вступительный обзор"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показать вступительный обзор"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "显示引导"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示引导"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "顯示引導"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示引導"
           }
         }
       }
     },
-    "Show icon in menu bar": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إظهار الأيقونة في شريط القوائم"
+    "Show icon in menu bar" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إظهار الأيقونة في شريط القوائم"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Symbol in der Menüleiste anzeigen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symbol in der Menüleiste anzeigen"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show icon in menu bar"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show icon in menu bar"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mostrar icono en la barra de menús"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar icono en la barra de menús"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mostrar ícono en la barra de menús"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar ícono en la barra de menús"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نمایش آیکون در نوار منو"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نمایش آیکون در نوار منو"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Afficher l'icône dans la barre de menus"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher l'icône dans la barre de menus"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הצג צלמית בשורת התפריטים"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הצג צלמית בשורת התפריטים"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "मेन्यू बार में आइकन दिखाएँ"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "मेन्यू बार में आइकन दिखाएँ"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mostra l'icona nella barra dei menu"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra l'icona nella barra dei menu"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "メニューバーにアイコンを表示"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メニューバーにアイコンを表示"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "메뉴 막대에 아이콘 표시"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "메뉴 막대에 아이콘 표시"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Toon pictogram in menubalk"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toon pictogram in menubalk"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pokaż ikonę na pasku menu"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pokaż ikonę na pasku menu"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mostrar ícone na barra de menus"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar ícone na barra de menus"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Показывать значок в строке меню"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать значок в строке меню"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "在菜单栏中显示图标"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在菜单栏中显示图标"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "在選單列中顯示圖示"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在選單列中顯示圖示"
           }
         }
       }
     },
-    "Skin tone": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "لون البشرة"
+    "Skin tone" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لون البشرة"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hautton"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hautton"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Skin tone"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skin tone"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tono de piel"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tono de piel"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tono de piel"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tono de piel"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "رنگ پوست"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "رنگ پوست"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Teinte de peau"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Teinte de peau"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "גוון עור"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "גוון עור"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "त्वचा का रंग"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "त्वचा का रंग"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tono della pelle"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tono della pelle"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "肌の色"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "肌の色"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "피부색"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "피부색"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Huidtint"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Huidtint"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Odcień skóry"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Odcień skóry"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tom de pele"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tom de pele"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Тон кожи"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тон кожи"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "肤色"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "肤色"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "膚色"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "膚色"
           }
         }
       }
     },
-    "Start at login": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "البدء عند تسجيل الدخول"
+    "Start at login" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "البدء عند تسجيل الدخول"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Beim Anmelden starten"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beim Anmelden starten"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Start at login"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Start at login"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Iniciar al iniciar sesión"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciar al iniciar sesión"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Iniciar al iniciar sesión"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciar al iniciar sesión"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اجرا هنگام ورود"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اجرا هنگام ورود"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lancer à l'ouverture de session"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lancer à l'ouverture de session"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הפעל בעת הכניסה"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הפעל בעת הכניסה"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "लॉगिन पर शुरू करें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "लॉगिन पर शुरू करें"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Avvia all'accesso"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avvia all'accesso"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ログイン時に起動"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ログイン時に起動"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "로그인 시 시작"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "로그인 시 시작"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Start bij inloggen"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Start bij inloggen"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uruchamiaj przy logowaniu"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uruchamiaj przy logowaniu"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Iniciar ao fazer login"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciar ao fazer login"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Запускать при входе"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запускать при входе"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "登录时启动"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登录时启动"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "登入時啟動"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登入時啟動"
           }
         }
       }
     },
-    "Stats": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الإحصاءات"
+    "Stats" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الإحصاءات"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Statistiken"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Statistiken"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stats"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stats"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estadísticas"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estadísticas"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estadísticas"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estadísticas"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "آمار"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "آمار"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Statistiques"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Statistiques"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "סטטיסטיקות"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "סטטיסטיקות"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "आँकड़े"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "आँकड़े"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Statistiche"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Statistiche"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "統計"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "統計"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "통계"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "통계"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Statistieken"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Statistieken"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Statystyki"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Statystyki"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estatísticas"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estatísticas"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Статистика"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Статистика"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "统计"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "统计"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "統計"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "統計"
           }
         }
       }
     },
-    "Support Wells": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ادعم Wells"
+    "Stop" : {
+
+    },
+    "Support Wells" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ادعم Wells"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wells unterstützen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wells unterstützen"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Support Wells"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Support Wells"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apoya a Wells"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apoya a Wells"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apoyá a Wells"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apoyá a Wells"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "از Wells حمایت کنید"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "از Wells حمایت کنید"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Soutenir Wells"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Soutenir Wells"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "תמוך ב-Wells"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "תמוך ב-Wells"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wells का सहयोग करें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wells का सहयोग करें"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sostieni Wells"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sostieni Wells"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wells を支援する"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wells を支援する"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wells 후원하기"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wells 후원하기"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Steun Wells"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Steun Wells"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wesprzyj Wellsa"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wesprzyj Wellsa"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apoiar Wells"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apoiar Wells"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Поддержать Wells"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поддержать Wells"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "支持 Wells"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "支持 Wells"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "支持 Wells"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "支持 Wells"
           }
         }
       }
     },
-    "Symbols": {
-      "localizations": {
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Symbols"
+    "Symbols" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الرموز"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Symbole"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symbole"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Símbolos"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symbols"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Símbolos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Símbolos"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Symboles"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Símbolos"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Simboli"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نمادها"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Símbolos"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symboles"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "記号"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "סמלים"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "符号"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "प्रतीक"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "符號"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Simboli"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "기호"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "記号"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "प्रतीक"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기호"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Символы"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symbolen"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Symbole"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symbole"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Symbolen"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Símbolos"
           }
         },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الرموز"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Символы"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نمادها"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "符号"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "סמלים"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "符號"
           }
         }
       }
     },
-    "Thank you": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "شكراً"
+    "Thank you" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "شكراً"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Danke"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Danke"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Thank you"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thank you"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gracias"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gracias"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gracias"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gracias"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ممنون"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ممنون"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Merci"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Merci"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "תודה"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "תודה"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "धन्यवाद"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "धन्यवाद"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Grazie"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grazie"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ありがとう"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ありがとう"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "감사합니다"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "감사합니다"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bedankt"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bedankt"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dziękuję"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dziękuję"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Obrigado"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obrigado"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Спасибо"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Спасибо"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "谢谢"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "谢谢"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "謝謝"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "謝謝"
           }
         }
       }
     },
-    "This will erase your autocomplete stats and Top 8. Settings and exclusions won't be changed.": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "سيؤدّي ذلك إلى مسح إحصاءات الإكمال التلقائي وقائمة الـ Top 8 الخاصة بك. لن تتغيّر الإعدادات والاستثناءات."
+    "This will erase your autocomplete stats and Top 8. Settings and exclusions won't be changed." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "سيؤدّي ذلك إلى مسح إحصاءات الإكمال التلقائي وقائمة الـ Top 8 الخاصة بك. لن تتغيّر الإعدادات والاستثناءات."
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Damit werden deine Autovervollständigungs-Statistiken und Top 8 gelöscht. Einstellungen und Ausnahmen bleiben unverändert."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Damit werden deine Autovervollständigungs-Statistiken und Top 8 gelöscht. Einstellungen und Ausnahmen bleiben unverändert."
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This will erase your autocomplete stats and Top 8. Settings and exclusions won't be changed."
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This will erase your autocomplete stats and Top 8. Settings and exclusions won't be changed."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esto borrará tus estadísticas de autocompletado y tu Top 8. Los ajustes y exclusiones no cambiarán."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esto borrará tus estadísticas de autocompletado y tu Top 8. Los ajustes y exclusiones no cambiarán."
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esto borrará tus estadísticas de autocompletado y tu Top 8. Los ajustes y exclusiones no cambiarán."
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esto borrará tus estadísticas de autocompletado y tu Top 8. Los ajustes y exclusiones no cambiarán."
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "این کار آمار تکمیل خودکار و Top 8 شما را پاک می‌کند. تنظیمات و موارد مستثنا تغییری نمی‌کنند."
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "این کار آمار تکمیل خودکار و Top 8 شما را پاک می‌کند. تنظیمات و موارد مستثنا تغییری نمی‌کنند."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cela effacera vos statistiques d'autocomplétion et votre Top 8. Les réglages et exclusions ne changeront pas."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cela effacera vos statistiques d'autocomplétion et votre Top 8. Les réglages et exclusions ne changeront pas."
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "פעולה זו תמחק את סטטיסטיקות ההשלמה האוטומטית ואת ה-Top 8 שלך. ההגדרות וההחרגות יישארו כפי שהן."
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "פעולה זו תמחק את סטטיסטיקות ההשלמה האוטומטית ואת ה-Top 8 שלך. ההגדרות וההחרגות יישארו כפי שהן."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "इससे आपके ऑटोकम्प्लीट आँकड़े और टॉप 8 हट जाएँगे। सेटिंग्स और अपवर्जन नहीं बदलेंगे।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "इससे आपके ऑटोकम्प्लीट आँकड़े और टॉप 8 हट जाएँगे। सेटिंग्स और अपवर्जन नहीं बदलेंगे।"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verranno cancellate le statistiche di completamento automatico e la Top 8. Impostazioni ed esclusioni resteranno invariate."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verranno cancellate le statistiche di completamento automatico e la Top 8. Impostazioni ed esclusioni resteranno invariate."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "自動補完の統計と Top 8 を削除します。設定と除外リストは変更されません。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動補完の統計と Top 8 を削除します。設定と除外リストは変更されません。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "자동 완성 통계와 Top 8이(가) 삭제됩니다. 설정과 제외 항목은 변경되지 않습니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "자동 완성 통계와 Top 8이(가) 삭제됩니다. 설정과 제외 항목은 변경되지 않습니다."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hiermee verwijder je je autocomplete-statistieken en Top 8. Instellingen en uitsluitingen blijven onveranderd."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hiermee verwijder je je autocomplete-statistieken en Top 8. Instellingen en uitsluitingen blijven onveranderd."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wyczyści to twoje statystyki autouzupełniania i Top 8. Ustawienia i wykluczenia pozostaną bez zmian."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wyczyści to twoje statystyki autouzupełniania i Top 8. Ustawienia i wykluczenia pozostaną bez zmian."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Isso apagará suas estatísticas de autocompletar e o Top 8. Os ajustes e exclusões não serão alterados."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Isso apagará suas estatísticas de autocompletar e o Top 8. Os ajustes e exclusões não serão alterados."
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Это удалит вашу статистику автодополнения и Top 8. Настройки и исключения не изменятся."
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Это удалит вашу статистику автодополнения и Top 8. Настройки и исключения не изменятся."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "此操作将清除你的自动补全统计和 Top 8。设置和排除项不会改变。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此操作将清除你的自动补全统计和 Top 8。设置和排除项不会改变。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "此操作將清除你的自動完成統計和 Top 8。設定和排除項目不會改變。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此操作將清除你的自動完成統計和 Top 8。設定和排除項目不會改變。"
           }
         }
       }
     },
-    "This will erase your discovery progress and any per-egg counters. The eggs themselves still work — you'll just need to find them again.": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "سيؤدّي ذلك إلى مسح تقدّم اكتشافك وكل عدّادات البيوض الفردية. البيوض نفسها ستظلّ تعمل — ستحتاج فقط للعثور عليها من جديد."
+    "This will erase your discovery progress and any per-egg counters. The eggs themselves still work — you'll just need to find them again." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "سيؤدّي ذلك إلى مسح تقدّم اكتشافك وكل عدّادات البيوض الفردية. البيوض نفسها ستظلّ تعمل — ستحتاج فقط للعثور عليها من جديد."
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Damit werden dein Entdeckungs-Fortschritt und alle eggs-spezifischen Zähler gelöscht. Die Eggs selbst funktionieren weiter – du musst sie nur wieder finden."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Damit werden dein Entdeckungs-Fortschritt und alle eggs-spezifischen Zähler gelöscht. Die Eggs selbst funktionieren weiter – du musst sie nur wieder finden."
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This will erase your discovery progress and any per-egg counters. The eggs themselves still work — you'll just need to find them again."
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This will erase your discovery progress and any per-egg counters. The eggs themselves still work — you'll just need to find them again."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esto borrará tu progreso de descubrimiento y los contadores de cada egg. Los eggs siguen funcionando — solo tendrás que encontrarlos otra vez."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esto borrará tu progreso de descubrimiento y los contadores de cada egg. Los eggs siguen funcionando — solo tendrás que encontrarlos otra vez."
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esto borrará tu progreso de descubrimiento y los contadores de cada egg. Los eggs siguen funcionando — solo tendrás que encontrarlos otra vez."
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esto borrará tu progreso de descubrimiento y los contadores de cada egg. Los eggs siguen funcionando — solo tendrás que encontrarlos otra vez."
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "این کار پیشرفت کشف و شمارنده‌های هر تخم‌مرغ را پاک می‌کند. خود تخم‌مرغ‌ها همچنان کار می‌کنند — فقط باید دوباره پیدای‌شان کنید."
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "این کار پیشرفت کشف و شمارنده‌های هر تخم‌مرغ را پاک می‌کند. خود تخم‌مرغ‌ها همچنان کار می‌کنند — فقط باید دوباره پیدای‌شان کنید."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cela effacera votre progression et les compteurs propres à chaque egg. Les eggs continuent de fonctionner — il faudra juste les retrouver."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cela effacera votre progression et les compteurs propres à chaque egg. Les eggs continuent de fonctionner — il faudra juste les retrouver."
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "פעולה זו תמחק את התקדמות הגילוי ואת המונים של כל ביצה. הביצים עצמן ימשיכו לעבוד — פשוט תצטרך למצוא אותן שוב."
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "פעולה זו תמחק את התקדמות הגילוי ואת המונים של כל ביצה. הביצים עצמן ימשיכו לעבוד — פשוט תצטרך למצוא אותן שוב."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "इससे आपकी खोज प्रगति और हर एग के काउंटर मिट जाएँगे। एग खुद काम करते रहेंगे — आपको बस उन्हें फिर से ढूँढना होगा।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "इससे आपकी खोज प्रगति और हर एग के काउंटर मिट जाएँगे। एग खुद काम करते रहेंगे — आपको बस उन्हें फिर से ढूँढना होगा।"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verranno cancellati i tuoi progressi e tutti i contatori dei singoli egg. Gli egg continuano a funzionare — dovrai solo ritrovarli."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verranno cancellati i tuoi progressi e tutti i contatori dei singoli egg. Gli egg continuano a funzionare — dovrai solo ritrovarli."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "発見の進捗と各エッグごとのカウンターを削除します。エッグ自体は動作するので、また見つけ直してください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "発見の進捗と各エッグごとのカウンターを削除します。エッグ自体は動作するので、また見つけ直してください。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "발견 진행 상황과 에그별 카운터가 삭제됩니다. 에그 자체는 그대로 동작하니, 다시 찾으면 됩니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "발견 진행 상황과 에그별 카운터가 삭제됩니다. 에그 자체는 그대로 동작하니, 다시 찾으면 됩니다."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hiermee verwijder je je ontdekkings­voortgang en alle per-egg-tellers. De eggs zelf werken nog steeds — je hoeft ze gewoon opnieuw te vinden."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hiermee verwijder je je ontdekkings­voortgang en alle per-egg-tellers. De eggs zelf werken nog steeds — je hoeft ze gewoon opnieuw te vinden."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wyczyści to twój postęp odkrywania i liczniki poszczególnych easter eggs. Same eggs nadal działają — wystarczy je odkryć ponownie."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wyczyści to twój postęp odkrywania i liczniki poszczególnych easter eggs. Same eggs nadal działają — wystarczy je odkryć ponownie."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Isso apagará seu progresso de descoberta e os contadores de cada egg. Os eggs continuam funcionando — você só precisará encontrá-los de novo."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Isso apagará seu progresso de descoberta e os contadores de cada egg. Os eggs continuam funcionando — você só precisará encontrá-los de novo."
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Это удалит ваш прогресс открытий и все счётчики по конкретным пасхалкам. Сами пасхалки продолжат работать — просто найдёте их заново."
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Это удалит ваш прогресс открытий и все счётчики по конкретным пасхалкам. Сами пасхалки продолжат работать — просто найдёте их заново."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "此操作将清除你的发现进度和每个彩蛋的计数。彩蛋本身仍然有效 — 你只需重新发现它们。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此操作将清除你的发现进度和每个彩蛋的计数。彩蛋本身仍然有效 — 你只需重新发现它们。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "此操作將清除你的發現進度和每個彩蛋的計數。彩蛋本身仍然有效 — 你只需重新發現它們。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此操作將清除你的發現進度和每個彩蛋的計數。彩蛋本身仍然有效 — 你只需重新發現它們。"
           }
         }
       }
     },
-    "Type `:::` then a search term to insert a GIF from Giphy.": {
-      "localizations": {
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Type `:::` then a search term to insert a GIF from Giphy."
+    "Type `:::` then a search term to insert a GIF from Giphy." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اكتب `:::` ثم كلمة بحث لإدراج صورة GIF من Giphy."
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tippe `:::` und dann einen Suchbegriff, um ein GIF von Giphy einzufügen."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tippe `:::` und dann einen Suchbegriff, um ein GIF von Giphy einzufügen."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Escribe `:::` seguido de un término de búsqueda para insertar un GIF de Giphy."
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Type `:::` then a search term to insert a GIF from Giphy."
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Escribí `:::` seguido de un término de búsqueda para insertar un GIF de Giphy."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escribe `:::` seguido de un término de búsqueda para insertar un GIF de Giphy."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tape `:::` puis un terme de recherche pour insérer un GIF depuis Giphy."
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escribí `:::` seguido de un término de búsqueda para insertar un GIF de Giphy."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Digita `:::` seguito da un termine di ricerca per inserire un GIF da Giphy."
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏`:::` و سپس یک عبارت جست‌وجو تایپ کنید تا یک GIF از Giphy درج شود."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Digite `:::` e depois um termo de busca para inserir um GIF do Giphy."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tape `:::` puis un terme de recherche pour insérer un GIF depuis Giphy."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "`:::` の後に検索語を入力すると、Giphy から GIF を挿入できます。"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הקלד `:::` ואז ביטוי חיפוש כדי להוסיף GIF מ-Giphy."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "输入 `:::` 后跟搜索词,从 Giphy 插入 GIF。"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giphy से GIF डालने के लिए `:::` के बाद कोई खोज शब्द टाइप करें।"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "輸入 `:::` 後接搜尋字詞,即可從 Giphy 插入 GIF。"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Digita `:::` seguito da un termine di ricerca per inserire un GIF da Giphy."
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "`:::` 다음에 검색어를 입력하면 Giphy에서 GIF를 삽입합니다."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`:::` の後に検索語を入力すると、Giphy から GIF を挿入できます。"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giphy से GIF डालने के लिए `:::` के बाद कोई खोज शब्द टाइप करें।"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`:::` 다음에 검색어를 입력하면 Giphy에서 GIF를 삽입합니다."
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Введите `:::` и поисковый запрос, чтобы вставить GIF из Giphy."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Typ `:::` gevolgd door een zoekterm om een GIF van Giphy in te voegen."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wpisz `:::`, a następnie szukane hasło, aby wstawić GIF z Giphy."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wpisz `:::`, a następnie szukane hasło, aby wstawić GIF z Giphy."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Typ `:::` gevolgd door een zoekterm om een GIF van Giphy in te voegen."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Digite `:::` e depois um termo de busca para inserir um GIF do Giphy."
           }
         },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اكتب `:::` ثم كلمة بحث لإدراج صورة GIF من Giphy."
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Введите `:::` и поисковый запрос, чтобы вставить GIF из Giphy."
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏`:::` و سپس یک عبارت جست‌وجو تایپ کنید تا یک GIF از Giphy درج شود."
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "输入 `:::` 后跟搜索词,从 Giphy 插入 GIF。"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הקלד `:::` ואז ביטוי חיפוש כדי להוסיף GIF מ-Giphy."
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入 `:::` 後接搜尋字詞,即可從 Giphy 插入 GIF。"
           }
         }
       }
     },
-    "Type `:` to search for any emoji or symbol in seconds.": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اكتب `:` للبحث عن أيّ إيموجي أو رمز في ثوانٍ."
+    "Type `:` to search for any emoji or symbol in seconds." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اكتب `:` للبحث عن أيّ إيموجي أو رمز في ثوانٍ."
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tippe `:`, um in Sekunden ein Emoji oder Symbol zu finden."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tippe `:`, um in Sekunden ein Emoji oder Symbol zu finden."
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Type `:` to search for any emoji or symbol in seconds."
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Type `:` to search for any emoji or symbol in seconds."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Escribe `:` para buscar cualquier emoji o símbolo en segundos."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escribe `:` para buscar cualquier emoji o símbolo en segundos."
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Escribí `:` para buscar cualquier emoji o símbolo en segundos."
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escribí `:` para buscar cualquier emoji o símbolo en segundos."
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "برای جست‌وجوی هر ایموجی یا نماد در چند ثانیه، `:` را تایپ کنید."
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "برای جست‌وجوی هر ایموجی یا نماد در چند ثانیه، `:` را تایپ کنید."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tapez `:` pour trouver n'importe quel émoji ou symbole en quelques secondes."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tapez `:` pour trouver n'importe quel émoji ou symbole en quelques secondes."
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הקלד `:` כדי לחפש כל אימוג'י או סמל בשניות."
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הקלד `:` כדי לחפש כל אימוג'י או סמל בשניות."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "किसी भी इमोजी या प्रतीक को सेकंडों में खोजने के लिए `:` टाइप करें।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "किसी भी इमोजी या प्रतीक को सेकंडों में खोजने के लिए `:` टाइप करें।"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Digita `:` per cercare qualsiasi emoji o simbolo in pochi secondi."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Digita `:` per cercare qualsiasi emoji o simbolo in pochi secondi."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "`:` を入力すれば、絵文字や記号を数秒で検索できます。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`:` を入力すれば、絵文字や記号を数秒で検索できます。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "`:` 만 입력하면 몇 초 만에 이모지나 기호를 찾을 수 있습니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`:` 만 입력하면 몇 초 만에 이모지나 기호를 찾을 수 있습니다."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Typ `:` om in seconden elke emoji of symbool te zoeken."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Typ `:` om in seconden elke emoji of symbool te zoeken."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wpisz `:`, by w sekundę znaleźć dowolne emoji lub symbol."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wpisz `:`, by w sekundę znaleźć dowolne emoji lub symbol."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Digite `:` para buscar qualquer emoji ou símbolo em segundos."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Digite `:` para buscar qualquer emoji ou símbolo em segundos."
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Введите `:`, чтобы за секунды найти любое эмодзи или символ."
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Введите `:`, чтобы за секунды найти любое эмодзи или символ."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "输入 `:` 即可在数秒内搜索任意 emoji 或符号。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "输入 `:` 即可在数秒内搜索任意 emoji 或符号。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "輸入 `:` 即可在數秒內搜尋任意 emoji 或符號。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入 `:` 即可在數秒內搜尋任意 emoji 或符號。"
           }
         }
       }
     },
-    "Type some emoji and they'll show up here.": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اكتب بعض الإيموجي وستظهر هنا."
+    "Type some emoji and they'll show up here." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اكتب بعض الإيموجي وستظهر هنا."
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tippe ein paar Emoji – sie tauchen dann hier auf."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tippe ein paar Emoji – sie tauchen dann hier auf."
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Type some emoji and they'll show up here."
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Type some emoji and they'll show up here."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Escribe algunos emoji y aparecerán aquí."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escribe algunos emoji y aparecerán aquí."
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Escribí algunos emojis y aparecerán acá."
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escribí algunos emojis y aparecerán acá."
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "چند ایموجی تایپ کنید تا اینجا نمایش داده شوند."
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "چند ایموجی تایپ کنید تا اینجا نمایش داده شوند."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tapez quelques émoji et ils apparaîtront ici."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tapez quelques émoji et ils apparaîtront ici."
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הקלד כמה אימוג'י והם יופיעו כאן."
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הקלד כמה אימוג'י והם יופיעו כאן."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कुछ इमोजी टाइप करें, वे यहाँ दिखेंगे।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "कुछ इमोजी टाइप करें, वे यहाँ दिखेंगे।"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Digita qualche emoji e compariranno qui."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Digita qualche emoji e compariranno qui."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "絵文字をいくつか入力すると、ここに表示されます。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "絵文字をいくつか入力すると、ここに表示されます。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "이모지를 몇 개 입력하면 여기에 나타납니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이모지를 몇 개 입력하면 여기에 나타납니다."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Typ wat emoji en ze verschijnen hier."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Typ wat emoji en ze verschijnen hier."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wpisz kilka emoji, a pojawią się tutaj."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wpisz kilka emoji, a pojawią się tutaj."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Digite alguns emoji e eles aparecerão aqui."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Digite alguns emoji e eles aparecerão aqui."
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Введите несколько эмодзи — они появятся здесь."
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Введите несколько эмодзи — они появятся здесь."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "输入一些 emoji,它们就会显示在这里。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "输入一些 emoji,它们就会显示在这里。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "輸入一些 emoji,它們就會顯示在這裡。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入一些 emoji,它們就會顯示在這裡。"
           }
         }
       }
     },
-    "Type to search GIFs.": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اكتب للبحث عن GIF."
+    "Type to search GIFs." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اكتب للبحث عن GIF."
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tippe, um GIFs zu suchen."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tippe, um GIFs zu suchen."
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Type to search GIFs."
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Type to search GIFs."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Escribe para buscar GIF."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escribe para buscar GIF."
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Escribí para buscar GIF."
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escribí para buscar GIF."
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "برای جست‌وجوی GIF تایپ کنید."
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "برای جست‌وجوی GIF تایپ کنید."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tape pour rechercher des GIF."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tape pour rechercher des GIF."
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הקלד כדי לחפש GIF-ים."
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הקלד כדי לחפש GIF-ים."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF खोजने के लिए टाइप करें।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF खोजने के लिए टाइप करें।"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Digita per cercare GIF."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Digita per cercare GIF."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF を検索するには入力してください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF を検索するには入力してください。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GIF를 검색하려면 입력하세요."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF를 검색하려면 입력하세요."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Typ om GIFs te zoeken."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Typ om GIFs te zoeken."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wpisz, aby wyszukać GIF-y."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wpisz, aby wyszukać GIF-y."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Digite para buscar GIF."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Digite para buscar GIF."
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Введите запрос для поиска GIF."
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Введите запрос для поиска GIF."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "输入以搜索 GIF。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "输入以搜索 GIF。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "輸入以搜尋 GIF。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入以搜尋 GIF。"
           }
         }
       }
     },
-    "Update check failed": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "فشل التحقّق من التحديثات"
+    "Update check failed" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "فشل التحقّق من التحديثات"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Update-Prüfung fehlgeschlagen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Update-Prüfung fehlgeschlagen"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Update check failed"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Update check failed"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error al buscar actualizaciones"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error al buscar actualizaciones"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Falló la búsqueda de actualizaciones"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Falló la búsqueda de actualizaciones"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بررسی به‌روزرسانی شکست خورد"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بررسی به‌روزرسانی شکست خورد"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Échec de la vérification des mises à jour"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Échec de la vérification des mises à jour"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "בדיקת העדכון נכשלה"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "בדיקת העדכון נכשלה"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "अपडेट जाँच विफल"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "अपडेट जाँच विफल"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verifica aggiornamenti non riuscita"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verifica aggiornamenti non riuscita"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アップデートの確認に失敗しました"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アップデートの確認に失敗しました"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "업데이트 확인 실패"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "업데이트 확인 실패"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Update controleren mislukt"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Update controleren mislukt"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sprawdzanie aktualizacji nieudane"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sprawdzanie aktualizacji nieudane"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Falha ao verificar atualizações"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Falha ao verificar atualizações"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Не удалось проверить обновления"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось проверить обновления"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "检查更新失败"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "检查更新失败"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "檢查更新失敗"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檢查更新失敗"
           }
         }
       }
     },
-    "Usage counts, settings, and your exclusion list are stored locally. %@ doesn't send any telemetry or usage data back to our server—we don't even have a server 🙂": {
-      "extractionState": "stale",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تُحفظ أعداد الاستخدام والإعدادات وقائمة الاستثناء محلياً. لا يُرسل %@ أيّ بيانات قياس أو استخدام إلى خادم — لا يوجد لدينا خادم أصلاً 🙂"
+    "Usage counts, settings, and your exclusion list are stored locally. %@ doesn't send any telemetry or usage data back to our server—we don't even have a server 🙂" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تُحفظ أعداد الاستخدام والإعدادات وقائمة الاستثناء محلياً. لا يُرسل %@ أيّ بيانات قياس أو استخدام إلى خادم — لا يوجد لدينا خادم أصلاً 🙂"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nutzungszähler, Einstellungen und deine Ausnahmeliste werden lokal gespeichert. %@ sendet keine Telemetrie- oder Nutzungsdaten an einen Server – wir haben nicht mal einen 🙂"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nutzungszähler, Einstellungen und deine Ausnahmeliste werden lokal gespeichert. %@ sendet keine Telemetrie- oder Nutzungsdaten an einen Server – wir haben nicht mal einen 🙂"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Usage counts, settings, and your exclusion list are stored locally. %@ doesn't send any telemetry or usage data back to our server—we don't even have a server 🙂"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usage counts, settings, and your exclusion list are stored locally. %@ doesn't send any telemetry or usage data back to our server—we don't even have a server 🙂"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Los contadores de uso, los ajustes y tu lista de exclusiones se guardan localmente. %@ no envía telemetría ni datos de uso a un servidor — ni siquiera tenemos servidor 🙂"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los contadores de uso, los ajustes y tu lista de exclusiones se guardan localmente. %@ no envía telemetría ni datos de uso a un servidor — ni siquiera tenemos servidor 🙂"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Los contadores de uso, los ajustes y tu lista de exclusiones se guardan localmente. %@ no envía telemetría ni datos de uso a un servidor — ni siquiera tenemos servidor 🙂"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los contadores de uso, los ajustes y tu lista de exclusiones se guardan localmente. %@ no envía telemetría ni datos de uso a un servidor — ni siquiera tenemos servidor 🙂"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "شمارنده‌های استفاده، تنظیمات و فهرست مستثنیات شما به‌صورت محلی ذخیره می‌شوند. %@ هیچ داده‌ای را به سرور ارسال نمی‌کند — اصلاً ما سروری نداریم 🙂"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "شمارنده‌های استفاده، تنظیمات و فهرست مستثنیات شما به‌صورت محلی ذخیره می‌شوند. %@ هیچ داده‌ای را به سرور ارسال نمی‌کند — اصلاً ما سروری نداریم 🙂"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Les compteurs d'utilisation, les réglages et votre liste d'exclusions restent en local. %@ n'envoie aucune télémétrie ni donnée d'usage à un serveur — on n'a même pas de serveur 🙂"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les compteurs d'utilisation, les réglages et votre liste d'exclusions restent en local. %@ n'envoie aucune télémétrie ni donnée d'usage à un serveur — on n'a même pas de serveur 🙂"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ספירת השימוש, ההגדרות ורשימת ההחרגות נשמרות מקומית. %@ לא שולח שום נתוני טלמטריה או שימוש לשרת — אין לנו אפילו שרת 🙂"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ספירת השימוש, ההגדרות ורשימת ההחרגות נשמרות מקומית. %@ לא שולח שום נתוני טלמטריה או שימוש לשרת — אין לנו אפילו שרת 🙂"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "उपयोग गिनती, सेटिंग्स और आपकी अपवर्जन सूची स्थानीय रूप से सेव होती है। %@ कोई टेलीमेट्री या उपयोग डेटा सर्वर पर नहीं भेजता — हमारे पास सर्वर ही नहीं है 🙂"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "उपयोग गिनती, सेटिंग्स और आपकी अपवर्जन सूची स्थानीय रूप से सेव होती है। %@ कोई टेलीमेट्री या उपयोग डेटा सर्वर पर नहीं भेजता — हमारे पास सर्वर ही नहीं है 🙂"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I contatori d'uso, le impostazioni e l'elenco delle esclusioni restano in locale. %@ non invia telemetria o dati di utilizzo a un server — non abbiamo nemmeno un server 🙂"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I contatori d'uso, le impostazioni e l'elenco delle esclusioni restano in locale. %@ non invia telemetria o dati di utilizzo a un server — non abbiamo nemmeno un server 🙂"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "使用回数、設定、除外リストはローカルに保存されます。%@ はテレメトリや利用データをサーバーに送信しません — そもそもサーバーがありません 🙂"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用回数、設定、除外リストはローカルに保存されます。%@ はテレメトリや利用データをサーバーに送信しません — そもそもサーバーがありません 🙂"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "사용 횟수, 설정, 제외 목록은 모두 로컬에 저장됩니다. %@은(는) 어떤 텔레메트리나 사용 데이터도 서버로 보내지 않습니다 — 서버 자체가 없어요 🙂"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "사용 횟수, 설정, 제외 목록은 모두 로컬에 저장됩니다. %@은(는) 어떤 텔레메트리나 사용 데이터도 서버로 보내지 않습니다 — 서버 자체가 없어요 🙂"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gebruiksstatistieken, instellingen en je uitsluitingslijst worden lokaal opgeslagen. %@ stuurt geen telemetrie of gebruiksgegevens naar een server — we hebben niet eens een server 🙂"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gebruiksstatistieken, instellingen en je uitsluitingslijst worden lokaal opgeslagen. %@ stuurt geen telemetrie of gebruiksgegevens naar een server — we hebben niet eens een server 🙂"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liczniki użycia, ustawienia i lista wykluczeń są zapisywane lokalnie. %@ nie wysyła żadnej telemetrii ani danych użycia — nie mamy nawet serwera 🙂"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Liczniki użycia, ustawienia i lista wykluczeń są zapisywane lokalnie. %@ nie wysyła żadnej telemetrii ani danych użycia — nie mamy nawet serwera 🙂"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Os contadores de uso, os ajustes e sua lista de exclusões ficam no seu Mac. %@ não envia telemetria nem dados de uso para um servidor — a gente nem tem servidor 🙂"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Os contadores de uso, os ajustes e sua lista de exclusões ficam no seu Mac. %@ não envia telemetria nem dados de uso para um servidor — a gente nem tem servidor 🙂"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Счётчики использования, настройки и список исключений хранятся локально. %@ не отправляет телеметрию и данные использования — у нас даже сервера нет 🙂"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Счётчики использования, настройки и список исключений хранятся локально. %@ не отправляет телеметрию и данные использования — у нас даже сервера нет 🙂"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "使用次数、设置和你的排除列表都存在本地。%@ 不会将任何遥测或使用数据发送到服务器 — 我们连服务器都没有 🙂"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用次数、设置和你的排除列表都存在本地。%@ 不会将任何遥测或使用数据发送到服务器 — 我们连服务器都没有 🙂"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "使用次數、設定和你的排除清單都存在本機。%@ 不會將任何遙測或使用資料傳送到伺服器 — 我們根本沒有伺服器 🙂"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用次數、設定和你的排除清單都存在本機。%@ 不會將任何遙測或使用資料傳送到伺服器 — 我們根本沒有伺服器 🙂"
           }
         }
       }
+    },
+    "Usage counts, settings, and your exclusion list are stored locally. %@ doesn't send any telemetry or usage data back to our server—we don't even have a server 🙂\n\nException: GIF search sends your query to Giphy." : {
+
     },
-    "Usage counts, settings, and your exclusion list are stored locally. %@ doesn't send any telemetry or usage data back to our server—we don't even have a server 🙂\n\nException: GIF search sends your query to Giphy.": {},
-    "Used to detect `:` triggers. Nothing else.": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "يُستخدم فقط لاكتشاف اختصارات `:`. لا شيء غير ذلك."
+    "Used to detect `:` triggers. Nothing else." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يُستخدم فقط لاكتشاف اختصارات `:`. لا شيء غير ذلك."
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wird nur zum Erkennen von `:`-Triggern verwendet. Mehr nicht."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wird nur zum Erkennen von `:`-Triggern verwendet. Mehr nicht."
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Used to detect `:` triggers. Nothing else."
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Used to detect `:` triggers. Nothing else."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Se usa para detectar el `:`. Nada más."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se usa para detectar el `:`. Nada más."
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Se usa para detectar el `:`. Nada más."
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se usa para detectar el `:`. Nada más."
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "فقط برای تشخیص `:` استفاده می‌شود. هیچ‌چیز دیگر."
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "فقط برای تشخیص `:` استفاده می‌شود. هیچ‌چیز دیگر."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sert à détecter les déclencheurs `:`. Rien d'autre."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sert à détecter les déclencheurs `:`. Rien d'autre."
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "משמש לזיהוי `:`. שום דבר נוסף."
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "משמש לזיהוי `:`. שום דבר נוסף."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "केवल `:` ट्रिगर्स पहचानने के लिए। और कुछ नहीं।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "केवल `:` ट्रिगर्स पहचानने के लिए। और कुछ नहीं।"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Serve solo a rilevare il `:`. Nient'altro."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Serve solo a rilevare il `:`. Nient'altro."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "`:` の検出にのみ使用します。それ以外には使いません。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`:` の検出にのみ使用します。それ以外には使いません。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "`:` 입력 감지에만 사용합니다. 그 외에는 쓰이지 않습니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`:` 입력 감지에만 사용합니다. 그 외에는 쓰이지 않습니다."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wordt alleen gebruikt om `:` te detecteren. Verder niets."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wordt alleen gebruikt om `:` te detecteren. Verder niets."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Służy do wykrywania `:`. Nic więcej."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Służy do wykrywania `:`. Nic więcej."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Usado para detectar o `:`. Nada mais."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usado para detectar o `:`. Nada mais."
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Используется только для обнаружения `:`. И больше ничего."
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Используется только для обнаружения `:`. И больше ничего."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "仅用于检测 `:` 触发键,无其他用途。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仅用于检测 `:` 触发键,无其他用途。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "僅用於偵測 `:` 觸發鍵,無其他用途。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "僅用於偵測 `:` 觸發鍵,無其他用途。"
           }
         }
       }
     },
-    "User since": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مستخدم منذ"
+    "User since" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مستخدم منذ"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nutzer seit"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nutzer seit"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "User since"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "User since"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Usuario desde"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usuario desde"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Usuario desde"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usuario desde"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کاربر از"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "کاربر از"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Utilisateur depuis"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utilisateur depuis"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "משתמש מאז"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "משתמש מאז"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "उपयोगकर्ता बने"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "उपयोगकर्ता बने"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Utente dal"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utente dal"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "利用開始"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "利用開始"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "사용 시작일"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "사용 시작일"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gebruiker sinds"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gebruiker sinds"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Użytkownik od"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Użytkownik od"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Usuário desde"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usuário desde"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Пользователь с"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пользователь с"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "用户起始"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用户起始"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "用戶起始"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用戶起始"
           }
         }
       }
     },
-    "Version %@ (%@)": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الإصدار %1$@ (%2$@)"
+    "Version %@ (%@)" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الإصدار %1$@ (%2$@)"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Version %1$@ (%2$@)"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version %1$@ (%2$@)"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Version %1$@ (%2$@)"
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Version %1$@ (%2$@)"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Version %1$@ (%2$@)"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version %1$@ (%2$@)"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versión %1$@ (%2$@)"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versión %1$@ (%2$@)"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versión %1$@ (%2$@)"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versión %1$@ (%2$@)"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نسخهٔ %1$@ (%2$@)"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نسخهٔ %1$@ (%2$@)"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Version %1$@ (%2$@)"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version %1$@ (%2$@)"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "גרסה %1$@ (%2$@)"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "גרסה %1$@ (%2$@)"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "संस्करण %1$@ (%2$@)"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "संस्करण %1$@ (%2$@)"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versione %1$@ (%2$@)"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versione %1$@ (%2$@)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "バージョン %1$@ (%2$@)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バージョン %1$@ (%2$@)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "버전 %1$@ (%2$@)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "버전 %1$@ (%2$@)"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versie %1$@ (%2$@)"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versie %1$@ (%2$@)"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wersja %1$@ (%2$@)"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wersja %1$@ (%2$@)"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versão %1$@ (%2$@)"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versão %1$@ (%2$@)"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Версия %1$@ (%2$@)"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Версия %1$@ (%2$@)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "版本 %1$@ (%2$@)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "版本 %1$@ (%2$@)"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "版本 %1$@ (%2$@)"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "版本 %1$@ (%2$@)"
           }
         }
       }
     },
-    "View source": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "عرض المصدر"
+    "View source" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عرض المصدر"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Quellcode ansehen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quellcode ansehen"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "View source"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View source"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ver el código"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ver el código"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ver el código"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ver el código"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مشاهدهٔ کد"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مشاهدهٔ کد"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voir le code source"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voir le code source"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "צפה בקוד"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "צפה בקוד"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "स्रोत देखें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "स्रोत देखें"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vedi il codice"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vedi il codice"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ソースを見る"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ソースを見る"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "소스 보기"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "소스 보기"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bekijk broncode"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bekijk broncode"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zobacz kod"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zobacz kod"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ver o código"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ver o código"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Открыть исходники"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Открыть исходники"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "查看源代码"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查看源代码"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "檢視原始碼"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檢視原始碼"
           }
         }
       }
     },
-    "Watches keystrokes for the `:` trigger.": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "يراقب الضغطات بحثاً عن `:`."
+    "Watches keystrokes for the `:` trigger." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يراقب الضغطات بحثاً عن `:`."
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Beobachtet Tastenanschläge auf den `:`-Trigger."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beobachtet Tastenanschläge auf den `:`-Trigger."
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Watches keystrokes for the `:` trigger."
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Watches keystrokes for the `:` trigger."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vigila las pulsaciones en busca del `:`."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vigila las pulsaciones en busca del `:`."
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vigila las pulsaciones en busca del `:`."
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vigila las pulsaciones en busca del `:`."
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ضربه‌های `:` را پی می‌گیرد."
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ضربه‌های `:` را پی می‌گیرد."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Surveille les frappes pour détecter le déclencheur `:`."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Surveille les frappes pour détecter le déclencheur `:`."
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "עוקב אחר הקשות `:`."
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "עוקב אחר הקשות `:`."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "`:` ट्रिगर के लिए कीस्ट्रोक देखता है।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`:` ट्रिगर के लिए कीस्ट्रोक देखता है।"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Osserva le digitazioni in cerca del `:`."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Osserva le digitazioni in cerca del `:`."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "`:` のキー入力を監視します。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`:` のキー入力を監視します。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "`:` 입력을 감지합니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`:` 입력을 감지합니다."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Volgt toetsaanslagen voor `:`."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Volgt toetsaanslagen voor `:`."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Obserwuje naciśnięcia `:`."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obserwuje naciśnięcia `:`."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Observa as teclas em busca do `:`."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Observa as teclas em busca do `:`."
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Отслеживает нажатия `:`."
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отслеживает нажатия `:`."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "监听 `:` 触发键。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "监听 `:` 触发键。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "監聽 `:` 觸發鍵。"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "監聽 `:` 觸發鍵。"
           }
         }
       }
     },
-    "Website": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الموقع الإلكتروني"
+    "Website" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الموقع الإلكتروني"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Website"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Website"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Website"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Website"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sitio web"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sitio web"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sitio web"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sitio web"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "وب‌سایت"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "وب‌سایت"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Site web"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Site web"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "אתר"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "אתר"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "वेबसाइट"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "वेबसाइट"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sito web"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sito web"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ウェブサイト"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウェブサイト"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "웹사이트"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "웹사이트"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Website"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Website"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Witryna"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Witryna"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Site"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Site"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Сайт"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сайт"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网站"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "网站"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "網站"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "網站"
           }
         }
       }
     },
-    "You're all set": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "كلّ شيء جاهز"
+    "You're all set" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "كلّ شيء جاهز"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Alles bereit"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alles bereit"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You're all set"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You're all set"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Todo listo"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todo listo"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Todo listo"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todo listo"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "همه‌چیز آماده است"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "همه‌چیز آماده است"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tout est prêt"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tout est prêt"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הכל מוכן"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הכל מוכן"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "सब तैयार है"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "सब तैयार है"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tutto pronto"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tutto pronto"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "準備完了です"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "準備完了です"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "모든 준비가 끝났어요"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모든 준비가 끝났어요"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Alles staat klaar"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alles staat klaar"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wszystko gotowe"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wszystko gotowe"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tudo pronto"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tudo pronto"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Готово к работе"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Готово к работе"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "一切就绪"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一切就绪"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "一切就緒"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一切就緒"
           }
         }
       }
     },
-    "Your data stays on this Mac": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تبقى بياناتك على هذا الـ Mac"
+    "Your data stays on this Mac" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تبقى بياناتك على هذا الـ Mac"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deine Daten bleiben auf diesem Mac"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deine Daten bleiben auf diesem Mac"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your data stays on this Mac"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your data stays on this Mac"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tus datos se quedan en este Mac"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tus datos se quedan en este Mac"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tus datos se quedan en esta Mac"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tus datos se quedan en esta Mac"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "داده‌های شما روی همین Mac می‌ماند"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "داده‌های شما روی همین Mac می‌ماند"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vos données restent sur ce Mac"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vos données restent sur ce Mac"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הנתונים שלך נשארים על ה-Mac הזה"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הנתונים שלך נשארים על ה-Mac הזה"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "आपका डेटा इसी Mac पर रहता है"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "आपका डेटा इसी Mac पर रहता है"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I tuoi dati restano su questo Mac"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I tuoi dati restano su questo Mac"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "データはこの Mac から出ません"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "データはこの Mac から出ません"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "데이터는 이 Mac에만 머무릅니다"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "데이터는 이 Mac에만 머무릅니다"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Je gegevens blijven op deze Mac"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Je gegevens blijven op deze Mac"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Twoje dane zostają na tym Macu"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Twoje dane zostają na tym Macu"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seus dados ficam neste Mac"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seus dados ficam neste Mac"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ваши данные остаются на этом Mac"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ваши данные остаются на этом Mac"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "你的数据只留在这台 Mac 上"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你的数据只留在这台 Mac 上"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "你的資料只留在這台 Mac 上"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你的資料只留在這台 Mac 上"
           }
         }
       }
     },
-    "Your top 8": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "أفضل 8 لديك"
+    "Your top 8" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أفضل 8 لديك"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deine Top 8"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deine Top 8"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your top 8"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your top 8"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tu Top 8"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu Top 8"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tu Top 8"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu Top 8"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "هشت برتر شما"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "هشت برتر شما"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Votre Top 8"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Votre Top 8"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ה-Top 8 שלך"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ה-Top 8 שלך"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "आपका टॉप 8"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "आपका टॉप 8"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La tua Top 8"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La tua Top 8"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "あなたのトップ 8"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "あなたのトップ 8"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "내 Top 8"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "내 Top 8"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jouw Top 8"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jouw Top 8"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Twój Top 8"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Twój Top 8"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seu Top 8"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seu Top 8"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Твой Топ 8"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Твой Топ 8"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "你的 Top 8"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你的 Top 8"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "你的 Top 8"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你的 Top 8"
           }
         }
       }
     },
-    "`:::` overrides the exclusion list.": {
-      "localizations": {
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "`:::` overrides the exclusion list."
+    "`:::` overrides the exclusion list." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏`:::` يتجاوز قائمة الاستثناءات."
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "`:::` umgeht die Ausschlussliste."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`:::` umgeht die Ausschlussliste."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "`:::` ignora la lista de exclusiones."
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`:::` overrides the exclusion list."
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "`:::` ignora la lista de exclusiones."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`:::` ignora la lista de exclusiones."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "`:::` ignore la liste d'exclusions."
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`:::` ignora la lista de exclusiones."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "`:::` ignora l'elenco delle esclusioni."
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏`:::` فهرست استثناها را نادیده می‌گیرد."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "`:::` ignora a lista de exclusões."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`:::` ignore la liste d'exclusions."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "`:::` は除外リストを無視します。"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‏`:::` עוקף את רשימת ההחרגות."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "`:::` 会忽略排除列表。"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`:::` बहिष्कार सूची को नज़रअंदाज़ करता है।"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "`:::` 會略過排除清單。"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`:::` ignora l'elenco delle esclusioni."
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "`:::`은(는) 제외 목록을 무시합니다."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`:::` は除外リストを無視します。"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "`:::` बहिष्कार सूची को नज़रअंदाज़ करता है।"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`:::`은(는) 제외 목록을 무시합니다."
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "`:::` обходит список исключений."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`:::` negeert de uitsluitingslijst."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "`:::` pomija listę wykluczeń."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`:::` pomija listę wykluczeń."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "`:::` negeert de uitsluitingslijst."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`:::` ignora a lista de exclusões."
           }
         },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏`:::` يتجاوز قائمة الاستثناءات."
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`:::` обходит список исключений."
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏`:::` فهرست استثناها را نادیده می‌گیرد."
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`:::` 会忽略排除列表。"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‏`:::` עוקף את רשימת ההחרגות."
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`:::` 會略過排除清單。"
           }
         }
       }
     },
-    "copy": {
-      "extractionState": "stale",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نسخ"
+    "copy" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نسخ"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "kopieren"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "kopieren"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "copy"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "copy"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "copiar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "copiar"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "copiar"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "copiar"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کپی"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "کپی"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "copier"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "copier"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "העתק"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "העתק"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कॉपी"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "कॉपी"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "copia"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "copia"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "コピー"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コピー"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "복사"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "복사"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "kopieer"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "kopieer"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "kopiuj"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "kopiuj"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "copiar"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "copiar"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "копировать"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "копировать"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "复制"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "复制"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "複製"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製"
           }
         }
       }
     },
-    "dismiss": {},
-    "e.g. mail.google.com or *.notion.so": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مثلاً: mail.google.com أو *.notion.so"
+    "dismiss" : {
+
+    },
+    "e.g. mail.google.com or *.notion.so" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مثلاً: mail.google.com أو *.notion.so"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "z. B. mail.google.com oder *.notion.so"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "z. B. mail.google.com oder *.notion.so"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "e.g. mail.google.com or *.notion.so"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "e.g. mail.google.com or *.notion.so"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "p. ej. mail.google.com o *.notion.so"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "p. ej. mail.google.com o *.notion.so"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "p. ej. mail.google.com o *.notion.so"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "p. ej. mail.google.com o *.notion.so"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مثلاً mail.google.com یا *.notion.so"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مثلاً mail.google.com یا *.notion.so"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "p. ex. mail.google.com ou *.notion.so"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "p. ex. mail.google.com ou *.notion.so"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "למשל mail.google.com או *.notion.so"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "למשל mail.google.com או *.notion.so"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "उदा. mail.google.com या *.notion.so"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "उदा. mail.google.com या *.notion.so"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "es. mail.google.com o *.notion.so"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "es. mail.google.com o *.notion.so"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "例: mail.google.com または *.notion.so"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "例: mail.google.com または *.notion.so"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "예: mail.google.com 또는 *.notion.so"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "예: mail.google.com 또는 *.notion.so"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "bijv. mail.google.com of *.notion.so"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "bijv. mail.google.com of *.notion.so"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "np. mail.google.com lub *.notion.so"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "np. mail.google.com lub *.notion.so"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ex.: mail.google.com ou *.notion.so"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ex.: mail.google.com ou *.notion.so"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "напр. mail.google.com или *.notion.so"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "напр. mail.google.com или *.notion.so"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "例如 mail.google.com 或 *.notion.so"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "例如 mail.google.com 或 *.notion.so"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "例如 mail.google.com 或 *.notion.so"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "例如 mail.google.com 或 *.notion.so"
           }
         }
       }
+    },
+    "insert" : {
+
     },
-    "insert": {},
-    "navigate": {
-      "extractionState": "stale",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تنقّل"
+    "navigate" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تنقّل"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "navigieren"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "navigieren"
           }
         },
-        "en-GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "navigate"
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "navigate"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "navegar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "navegar"
           }
         },
-        "es-419": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "navegar"
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "navegar"
           }
         },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حرکت"
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حرکت"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "naviguer"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "naviguer"
           }
         },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ניווט"
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ניווט"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "नेविगेट"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "नेविगेट"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "naviga"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "naviga"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "移動"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移動"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "이동"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이동"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "navigeer"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "navigeer"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "nawiguj"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "nawiguj"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "navegar"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "navegar"
           }
         },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "перемещение"
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "перемещение"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "移动"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移动"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "移動"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移動"
           }
         }
       }
     }
   },
-  "version": "1.0"
+  "version" : "1.0"
 }

--- a/Sources/Mojito/App/AppDelegate.swift
+++ b/Sources/Mojito/App/AppDelegate.swift
@@ -1,4 +1,5 @@
 import AppKit
+import ApplicationServices
 import Combine
 import KeyboardShortcuts
 import os.log
@@ -33,6 +34,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         NSApp.setActivationPolicy(.accessory)
         installMainMenu()
         applyAppIcon()
+
+        // Bound every AX query globally. Without this, a revoked Accessibility
+        // grant (or a hung target app) makes synchronous AX calls on the
+        // keystroke path block forever — and since the event-tap callback runs
+        // on the main thread, that freezes the keyboard system-wide. Set on the
+        // system-wide element, it's the default timeout for all AX messages.
+        AXUIElementSetMessagingTimeout(AXUIElementCreateSystemWide(), 0.5)
 
         permissions.startMonitoring()
         engine.attach(permissions: permissions)
@@ -86,6 +94,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             .sink { [weak self] _ in
                 self?.onboardingController.close()
                 self?.engine.start()
+                // Drop the onboarding fast-poll back to the baseline cadence.
+                self?.permissions.startMonitoring()
             }
             .store(in: &observers)
 

--- a/Sources/Mojito/Onboarding/OnboardingRoot.swift
+++ b/Sources/Mojito/Onboarding/OnboardingRoot.swift
@@ -13,10 +13,27 @@ struct OnboardingRoot: View {
     }
 
     @EnvironmentObject private var permissions: PermissionsCoordinator
-    @State private var step: Step = .welcome
+    @State private var step: Step
     /// `.trailing` = forward, `.leading` = back.
     @State private var transitionEdge: Edge = .trailing
     @FocusState private var focused: Bool
+
+    init() {
+        _step = State(initialValue: Self.resumeStep())
+    }
+
+    /// Where to open onboarding. A fresh Accessibility grant sometimes only
+    /// registers after a quit+reopen, so we persist the current step and
+    /// resume there rather than bouncing the user back to the welcome screen.
+    /// The step is cleared on completion; the celebratory final step is never
+    /// resumed into.
+    private static func resumeStep() -> Step {
+        if let raw = UserDefaults.standard.object(forKey: PrefsKey.onboardingStep) as? Int,
+           let saved = Step(rawValue: raw), saved != .done {
+            return saved
+        }
+        return .welcome
+    }
 
     var body: some View {
         ZStack {
@@ -50,8 +67,9 @@ struct OnboardingRoot: View {
             permissions.startMonitoring(interval: 0.5)
             focused = true
         }
-        .onChange(of: permissions.accessibility) { _, _ in advanceIfPermissionsSatisfied() }
-        .onChange(of: permissions.inputMonitoring) { _, _ in advanceIfPermissionsSatisfied() }
+        .onChange(of: step) { _, new in
+            UserDefaults.standard.set(new.rawValue, forKey: PrefsKey.onboardingStep)
+        }
         .onKeyPress(.return) {
             if primaryEnabled { primaryAction() }
             return .handled
@@ -109,9 +127,14 @@ struct OnboardingRoot: View {
     }
 
     private func finishAndOpenSettings() {
-        UserDefaults.standard.set(true, forKey: PrefsKey.onboardingComplete)
-        NotificationCenter.default.post(name: .mojitoOnboardingFinished, object: nil)
+        completeOnboarding()
         NotificationCenter.default.post(name: .mojitoShouldOpenSettings, object: nil)
+    }
+
+    private func completeOnboarding() {
+        UserDefaults.standard.set(true, forKey: PrefsKey.onboardingComplete)
+        UserDefaults.standard.removeObject(forKey: PrefsKey.onboardingStep)
+        NotificationCenter.default.post(name: .mojitoOnboardingFinished, object: nil)
     }
 
     private var primaryLabel: String {
@@ -131,11 +154,9 @@ struct OnboardingRoot: View {
 
     private func primaryAction() {
         if step.isLast {
-            UserDefaults.standard.set(true, forKey: PrefsKey.onboardingComplete)
-            NotificationCenter.default.post(name: .mojitoOnboardingFinished, object: nil)
+            completeOnboarding()
         } else {
             goForward()
-            advanceIfPermissionsSatisfied()
         }
     }
 
@@ -149,15 +170,6 @@ struct OnboardingRoot: View {
         guard let prev = Step(rawValue: step.rawValue - 1) else { return }
         transitionEdge = .leading
         withAnimation(.easeInOut(duration: 0.32)) { step = prev }
-    }
-
-    /// Auto-skip past the permissions step when both are already granted
-    /// (manual entry, or live grant during the step).
-    private func advanceIfPermissionsSatisfied() {
-        guard step == .permissions,
-              permissions.accessibility,
-              permissions.inputMonitoring else { return }
-        goForward()
     }
 
     private func oppositeEdge(of edge: Edge) -> Edge {

--- a/Sources/Mojito/Onboarding/OnboardingScreens.swift
+++ b/Sources/Mojito/Onboarding/OnboardingScreens.swift
@@ -413,8 +413,21 @@ struct PermissionsStep: View {
             }
             .frame(maxWidth: 480)
 
-            Button("Privacy details…") { showPrivacyDetails = true }
-                .buttonStyle(.link)
+            VStack(spacing: 6) {
+                Button("Privacy details…") { showPrivacyDetails = true }
+                    .buttonStyle(.link)
+
+                // A fresh grant sometimes only registers on a clean launch.
+                if !(accessibilityGranted && inputMonitoringGranted) {
+                    HStack(spacing: 4) {
+                        Text("Already allowed but still not detected?")
+                            .foregroundStyle(.secondary)
+                        Button("Quit & Reopen") { AppRelauncher.relaunch() }
+                            .buttonStyle(.link)
+                    }
+                    .font(.system(size: 13))
+                }
+            }
 
             Spacer(minLength: 0)
         }

--- a/Sources/Mojito/Permissions/PermissionsCoordinator.swift
+++ b/Sources/Mojito/Permissions/PermissionsCoordinator.swift
@@ -10,6 +10,7 @@ final class PermissionsCoordinator: ObservableObject {
 
     private var timer: Timer?
     private var distributedObserver: NSObjectProtocol?
+    private var activeObserver: NSObjectProtocol?
 
     init() {
         refresh()
@@ -20,16 +21,29 @@ final class PermissionsCoordinator: ObservableObject {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            // The notification fires slightly before AXIsProcessTrusted()
+            // The notification fires slightly before the AX subsystem
             // flips, so refresh now AND a moment later.
             self?.refresh()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { self?.refresh() }
+        }
+        // Changing an Accessibility grant means switching to System Settings
+        // and back. The trust state can lag a live toggle, so re-derive it
+        // whenever we regain focus — by then the change has settled.
+        activeObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.refresh()
         }
     }
 
     deinit {
         if let distributedObserver {
             DistributedNotificationCenter.default().removeObserver(distributedObserver)
+        }
+        if let activeObserver {
+            NotificationCenter.default.removeObserver(activeObserver)
         }
     }
 

--- a/Sources/Mojito/Permissions/PermissionsCoordinator.swift
+++ b/Sources/Mojito/Permissions/PermissionsCoordinator.swift
@@ -47,23 +47,22 @@ final class PermissionsCoordinator: ObservableObject {
         }
     }
 
-    /// AX uses the distributed notification, so this timer is really
-    /// just for catching Input Monitoring toggles. 5s is slow enough not
-    /// to churn IPC but fast enough for a quick green checkmark.
-    private static let slowPollInterval: TimeInterval = 5.0
+    /// Polls on for the app's lifetime — not just until granted. Revoking
+    /// Accessibility *while running* must be caught promptly: the keystroke
+    /// tap teardown is driven off `accessibility` flipping false, and the
+    /// distributed notification alone is private + unreliable for revocation.
+    /// 2s keeps the freeze window after a revoke short without churning IPC
+    /// (both checks are cheap, local).
+    private static let slowPollInterval: TimeInterval = 2.0
 
     func startMonitoring(interval: TimeInterval = slowPollInterval) {
         refresh()
-        // Stop polling once granted; revocation re-enters via
-        // `handleInputMonitoringLost()`.
-        if allGranted {
-            stopMonitoring()
-            return
-        }
         timer?.invalidate()
         let t = Timer(timeInterval: interval, repeats: true) { [weak self] _ in
             Task { @MainActor in self?.refresh() }
         }
+        // Let the OS coalesce these wakeups — detection latency isn't tight.
+        t.tolerance = interval / 4
         RunLoop.main.add(t, forMode: .common)
         timer = t
     }
@@ -83,9 +82,6 @@ final class PermissionsCoordinator: ObservableObject {
         if im != inputMonitoring {
             inputMonitoring = im
             DebugRecorder.record(.permissions, im ? "inputGranted" : "inputRevoked")
-        }
-        if accessibility && inputMonitoring {
-            stopMonitoring()
         }
     }
 

--- a/Sources/Mojito/Util/AppRelauncher.swift
+++ b/Sources/Mojito/Util/AppRelauncher.swift
@@ -1,0 +1,21 @@
+import AppKit
+
+enum AppRelauncher {
+    /// Relaunches the app in place. A detached shell waits for this process
+    /// to fully exit before reopening, so `SingleInstanceCoordinator` doesn't
+    /// see a live same-bundle peer and make the newcomer quit. Used when a
+    /// fresh Accessibility/Input Monitoring grant only registers on a clean
+    /// launch.
+    static func relaunch() {
+        let pid = ProcessInfo.processInfo.processIdentifier
+        let path = Bundle.main.bundlePath
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/bin/sh")
+        task.arguments = [
+            "-c",
+            "while /bin/kill -0 \(pid) 2>/dev/null; do sleep 0.1; done; /usr/bin/open \"\(path)\"",
+        ]
+        try? task.run()
+        NSApp.terminate(nil)
+    }
+}

--- a/Sources/Mojito/Util/AppRelauncher.swift
+++ b/Sources/Mojito/Util/AppRelauncher.swift
@@ -8,12 +8,14 @@ enum AppRelauncher {
     /// launch.
     static func relaunch() {
         let pid = ProcessInfo.processInfo.processIdentifier
-        let path = Bundle.main.bundlePath
+        // Single-quote the path for the shell, escaping any embedded quote, so
+        // a `"`/`$`/backtick in the bundle path can't break out or expand.
+        let quotedPath = "'" + Bundle.main.bundlePath.replacingOccurrences(of: "'", with: "'\\''") + "'"
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/bin/sh")
         task.arguments = [
             "-c",
-            "while /bin/kill -0 \(pid) 2>/dev/null; do sleep 0.1; done; /usr/bin/open \"\(path)\"",
+            "while /bin/kill -0 \(pid) 2>/dev/null; do sleep 0.1; done; /usr/bin/open \(quotedPath)",
         ]
         try? task.run()
         NSApp.terminate(nil)

--- a/Sources/Mojito/Util/PrefsKey.swift
+++ b/Sources/Mojito/Util/PrefsKey.swift
@@ -2,6 +2,10 @@ import Foundation
 
 enum PrefsKey {
     static let onboardingComplete    = "mojito.onboarding.complete"
+    /// Last onboarding step shown, so a quit+reopen (sometimes needed for a
+    /// fresh Accessibility grant to register) resumes mid-flow instead of
+    /// restarting at the welcome screen. Raw value of `OnboardingRoot.Step`.
+    static let onboardingStep        = "mojito.onboarding.step"
     static let pausedUntil           = "mojito.paused.until"
     static let launchAtLogin         = "mojito.launchAtLogin"
     /// When false, the menu-bar status item is suppressed; users reach


### PR DESCRIPTION
Investigates github #66 (Accessibility permission shown inverted on macOS 26 Tahoe) and fixes the underlying detection problems — including a serious system-wide keyboard freeze found along the way.

## Root cause

`AXIsProcessTrusted()` returns a per-process value that doesn't reliably update live when the System Settings toggle changes, and the app stopped polling permissions once granted — relying only on the private, best-effort `com.apple.accessibility.api` notification. So a live grant/revoke could go undetected, leaving the displayed state stale (reads as "inverted"). There is no Tahoe "inverted bool" OS regression.

While verifying, a worse bug surfaced: revoking Accessibility **while the app was running froze the keyboard system-wide**. The CGEventTap callback runs synchronously on the main thread, and the keystroke path makes synchronous AX queries (secure-field check, browser-URL detection, caret location) with **no messaging timeout** — so once AX was denied those calls blocked forever and the tap could never return.

## Changes

- **Re-check permissions on `didBecomeActive`** — returning from System Settings always re-derives current state, in both directions.
- **Poll permissions for the app's lifetime** (every 2s, with a coalescing tolerance) instead of stopping once granted, so a live revoke is detected and `reconcile()` tears down the tap. Also fixes Settings → Permissions never updating after a live revoke.
- **Global AX messaging timeout (0.5s)** set on the system-wide element at launch — no AX query can block the main thread (and thus the keystroke tap) indefinitely. Hard guarantee against the freeze.
- **Onboarding: no auto-skip of the permissions step**, and the current step is persisted so a quit+reopen (sometimes needed for a fresh grant to register) resumes on the permissions page instead of restarting at welcome.
- **"Quit & Reopen" affordance** on the permissions step for grants that only take effect on a clean launch (relaunches in place; waits for the old process to exit so SingleInstanceCoordinator doesn't bounce the newcomer).

## Test plan

- Toggle Accessibility off/on in System Settings → Settings/onboarding state and the menu-bar icon track it within ~2s; returning focus updates instantly.
- With Mojito running and working, revoke Accessibility → keyboard stays responsive (no indefinite freeze), state flips to "Allow".
- Onboarding: reach the permissions step, grant + quit & reopen → resumes on the permissions step.
- Unit suite green via the pre-push hook (`scripts/run-tests.sh`). The permission/AX/event-tap paths aren't unit-testable (need a live AX-permitted environment) and were verified manually.

Refs W-264
Fixes #66