### PR TITLE
W-285: make debug reports self-diagnosing

### DIFF
--- a/Sources/Mojito/App/Engine.swift
+++ b/Sources/Mojito/App/Engine.swift
@@ -231,6 +231,7 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
         UserDefaults.standard.set(0, forKey: PrefsKey.totalEmojiInserted)
         UserDefaults.standard.set(0, forKey: PrefsKey.totalSymbolInserted)
         UserDefaults.standard.set(0, forKey: PrefsKey.totalGifInserted)
+        UserDefaults.standard.set(0, forKey: PrefsKey.totalEmoticonInserted)
     }
 
     private func reconcile() {
@@ -894,6 +895,14 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
         EasterEggTracker.record(.k42)
     }
 
+    /// Pure diagnostic tally — no milestone eggs ride on it, so no seeding.
+    /// Lets the debug report show whether emoticon conversions are landing.
+    private func bumpEmoticonCounter() {
+        let defaults = UserDefaults.standard
+        defaults.set(defaults.integer(forKey: PrefsKey.totalEmoticonInserted) + 1,
+                     forKey: PrefsKey.totalEmoticonInserted)
+    }
+
     private func seedEmojiTotal() -> Int {
         usage.reduce(0) { $1.key.hasPrefix("SYM_") ? $0 : $0 + $1.value }
     }
@@ -942,6 +951,7 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
             ? match.emoji
             : match.emoji + String(terminator)
         TextInserter.replace(charactersToDelete: charsToDelete, with: replacement)
+        bumpEmoticonCounter()
 
         let original = ":" + query + String(terminator)
         pendingEmoticonUndo = EmoticonUndo(
@@ -962,6 +972,7 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
         }
         DebugRecorder.record(.emoticon, "ambientImmediate")
         TextInserter.replace(charactersToDelete: word.count, with: emoji)
+        bumpEmoticonCounter()
 
         pendingEmoticonUndo = EmoticonUndo(
             emojiInserted: emoji,
@@ -985,6 +996,7 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
         let charsToDelete = word.count + 1
         let replacement = emoji + String(terminator)
         TextInserter.replace(charactersToDelete: charsToDelete, with: replacement)
+        bumpEmoticonCounter()
 
         let original = word + String(terminator)
         pendingEmoticonUndo = EmoticonUndo(

--- a/Sources/Mojito/Debug/DebugRecorder.swift
+++ b/Sources/Mojito/Debug/DebugRecorder.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 
 /// Categories that surface in the debug report. Keep the set small —
@@ -32,31 +33,60 @@ struct DebugEvent {
 @MainActor
 enum DebugRecorder {
     private static let capacity = 200
+    /// Focus changes live in their own small ring so a burst of app
+    /// switching can't evict the action events that actually explain a bug —
+    /// app-switch churn easily dominates a flat buffer.
+    private static let focusCapacity = 40
     private static let kindMaxLen = 24
     private static let valueMaxLen = 32
     private static var buffer: [DebugEvent] = []
+    private static var focusBuffer: [DebugEvent] = []
 
     static func record(
         _ category: DebugCategory,
         _ kind: String,
         _ metadata: [String: String] = [:]
     ) {
+        var meta = metadata
+        // Stamp which app was frontmost so every action line answers
+        // "where did this happen" on its own — no cross-referencing the
+        // focus.app lines. focus.app already names the app via `bundleID`,
+        // so leave it (and any explicit `app`) untouched.
+        if meta["app"] == nil, meta["bundleID"] == nil,
+           let front = NSWorkspace.shared.frontmostApplication?.bundleIdentifier {
+            meta["app"] = front
+        }
         let event = DebugEvent(
             timestamp: Date(),
             category: category,
             kind: clamp(kind, max: kindMaxLen),
-            metadata: metadata.mapValues { clamp($0, max: valueMaxLen) }
+            metadata: meta.mapValues { clamp($0, max: valueMaxLen) }
         )
-        buffer.append(event)
-        if buffer.count > capacity {
-            buffer.removeFirst(buffer.count - capacity)
+        if category == .focus {
+            focusBuffer.append(event)
+            if focusBuffer.count > focusCapacity {
+                focusBuffer.removeFirst(focusBuffer.count - focusCapacity)
+            }
+        } else {
+            buffer.append(event)
+            if buffer.count > capacity {
+                buffer.removeFirst(buffer.count - capacity)
+            }
         }
     }
 
-    /// Newest-last; callers (DebugReport) take the tail.
+    /// Action events (everything but focus changes). Newest-last; callers
+    /// (DebugReport) take the tail.
     static func snapshot() -> [DebugEvent] { buffer }
 
-    static func reset() { buffer.removeAll() }
+    /// Focus-change events, kept separate so they get a small fixed budget
+    /// in the report instead of swamping the action history.
+    static func focusSnapshot() -> [DebugEvent] { focusBuffer }
+
+    static func reset() {
+        buffer.removeAll()
+        focusBuffer.removeAll()
+    }
 
     /// Drops non-printable ASCII and caps length. Keeps the buffer free
     /// of multibyte payloads that could smuggle out user text.

--- a/Sources/Mojito/Debug/DebugReport.swift
+++ b/Sources/Mojito/Debug/DebugReport.swift
@@ -137,6 +137,7 @@ enum DebugReport {
         s += "- totals.emojiInserted: \(d.integer(forKey: PrefsKey.totalEmojiInserted))\n"
         s += "- totals.symbolInserted: \(d.integer(forKey: PrefsKey.totalSymbolInserted))\n"
         s += "- totals.gifInserted: \(d.integer(forKey: PrefsKey.totalGifInserted))\n"
+        s += "- totals.emoticonInserted: \(d.integer(forKey: PrefsKey.totalEmoticonInserted))\n"
         return s
     }
 
@@ -234,11 +235,16 @@ enum DebugReport {
     }
 
     private static func activitySection(now: Date) -> String {
-        let events = DebugRecorder.snapshot().suffix(100)
+        // Action events get the lion's share; focus changes are capped so a
+        // session of heavy app-switching can't crowd them out. Merge the two
+        // streams back into chronological order for reading.
+        let actions = DebugRecorder.snapshot().suffix(85)
+        let focus = DebugRecorder.focusSnapshot().suffix(15)
+        let events = (actions + focus).sorted { $0.timestamp < $1.timestamp }
         guard let oldest = events.first else {
             return "## Activity log\n- (empty)\n"
         }
-        var s = "## Activity log (last \(events.count))\n"
+        var s = "## Activity log (\(actions.count) action, \(focus.count) focus)\n"
         for event in events {
             let dt = event.timestamp.timeIntervalSince(oldest.timestamp)
             let meta = event.metadata

--- a/Sources/Mojito/Inserter/TextInserter.swift
+++ b/Sources/Mojito/Inserter/TextInserter.swift
@@ -11,46 +11,66 @@ enum TextInserter {
     static let synthMarker: Int64 = 0x4D4F4A49544F  // ASCII "MOJITO"
 
     static func replace(charactersToDelete: Int, with string: String) {
+        var posted = true
         for _ in 0..<charactersToDelete {
-            postKey(virtualKey: 0x33, flags: [])  // kVK_Delete
+            posted = postKey(virtualKey: 0x33, flags: []) && posted  // kVK_Delete
         }
 
-        let downEvent = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: true)
-        let upEvent   = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: false)
-
-        let utf16 = Array(string.utf16)
-        utf16.withUnsafeBufferPointer { buf in
-            downEvent?.keyboardSetUnicodeString(stringLength: buf.count, unicodeString: buf.baseAddress)
-            upEvent?.keyboardSetUnicodeString(stringLength: buf.count, unicodeString: buf.baseAddress)
+        if let downEvent = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: true),
+           let upEvent = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: false) {
+            let utf16 = Array(string.utf16)
+            utf16.withUnsafeBufferPointer { buf in
+                downEvent.keyboardSetUnicodeString(stringLength: buf.count, unicodeString: buf.baseAddress)
+                upEvent.keyboardSetUnicodeString(stringLength: buf.count, unicodeString: buf.baseAddress)
+            }
+            downEvent.setIntegerValueField(.eventSourceUserData, value: synthMarker)
+            upEvent.setIntegerValueField(.eventSourceUserData, value: synthMarker)
+            downEvent.post(tap: .cghidEventTap)
+            upEvent.post(tap: .cghidEventTap)
+        } else {
+            posted = false
         }
-        downEvent?.setIntegerValueField(.eventSourceUserData, value: synthMarker)
-        upEvent?.setIntegerValueField(.eventSourceUserData, value: synthMarker)
-        downEvent?.post(tap: .cghidEventTap)
-        upEvent?.post(tap: .cghidEventTap)
+        // Grapheme count (not contents) — enough to see the path ran and
+        // with what shape, while staying clear of the no-user-text rule.
+        DebugRecorder.record(.insert, "replace", [
+            "del": "\(charactersToDelete)",
+            "len": "\(string.count)",
+            "posted": "\(posted)",
+        ])
     }
 
     /// Easter-egg path: erase the typed `:keyword` without replacement.
     static func deleteBackward(_ count: Int) {
+        var posted = true
         for _ in 0..<count {
-            postKey(virtualKey: 0x33, flags: [])  // kVK_Delete
+            posted = postKey(virtualKey: 0x33, flags: []) && posted  // kVK_Delete
         }
+        DebugRecorder.record(.insert, "delete", ["count": "\(count)", "posted": "\(posted)"])
     }
 
     /// Synth ⌘V into the focused app — used by the GIF picker to paste the
     /// selected GIF inline after writing it to the clipboard. Works in any
     /// text field that accepts the standard "paste" action.
     static func pasteFromClipboard() {
-        postKey(virtualKey: 0x09, flags: .maskCommand)  // kVK_ANSI_V
+        let posted = postKey(virtualKey: 0x09, flags: .maskCommand)  // kVK_ANSI_V
+        DebugRecorder.record(.insert, "paste", ["posted": "\(posted)"])
     }
 
-    private static func postKey(virtualKey: CGKeyCode, flags: CGEventFlags) {
-        let down = CGEvent(keyboardEventSource: nil, virtualKey: virtualKey, keyDown: true)
-        let up   = CGEvent(keyboardEventSource: nil, virtualKey: virtualKey, keyDown: false)
-        down?.flags = flags
-        up?.flags = flags
-        down?.setIntegerValueField(.eventSourceUserData, value: synthMarker)
-        up?.setIntegerValueField(.eventSourceUserData, value: synthMarker)
-        down?.post(tap: .cghidEventTap)
-        up?.post(tap: .cghidEventTap)
+    /// Returns false if either CGEvent couldn't be created — the clearest
+    /// observable failure of the synthetic-event path (it can't tell us
+    /// whether a created event was actually delivered).
+    @discardableResult
+    private static func postKey(virtualKey: CGKeyCode, flags: CGEventFlags) -> Bool {
+        guard let down = CGEvent(keyboardEventSource: nil, virtualKey: virtualKey, keyDown: true),
+              let up = CGEvent(keyboardEventSource: nil, virtualKey: virtualKey, keyDown: false) else {
+            return false
+        }
+        down.flags = flags
+        up.flags = flags
+        down.setIntegerValueField(.eventSourceUserData, value: synthMarker)
+        up.setIntegerValueField(.eventSourceUserData, value: synthMarker)
+        down.post(tap: .cghidEventTap)
+        up.post(tap: .cghidEventTap)
+        return true
     }
 }

--- a/Sources/Mojito/Util/PrefsKey.swift
+++ b/Sources/Mojito/Util/PrefsKey.swift
@@ -56,4 +56,8 @@ enum PrefsKey {
     static let totalEmojiInserted    = "mojito.totals.emojiInserted"
     static let totalSymbolInserted   = "mojito.totals.symbolInserted"
     static let totalGifInserted      = "mojito.totals.gifInserted"
+    /// Lifetime emoticon conversions (`:)` → 🙂, ambient `<3` → ❤️). Pure
+    /// diagnostic tally — no milestone achievements ride on it — so the
+    /// debug report can show whether conversions are landing at all.
+    static let totalEmoticonInserted = "mojito.totals.emoticonInserted"
 }

--- a/Tests/MojitoTests/DebugReportTests.swift
+++ b/Tests/MojitoTests/DebugReportTests.swift
@@ -71,6 +71,30 @@ struct DebugReportTests {
         #expect(regex.firstMatch(in: prefs, range: range) == nil, "prefs leaks an absolute date")
     }
 
+    @Test func prefsShowsEmoticonTotal() {
+        DebugRecorder.reset()
+        let out = DebugReport.markdown()
+        #expect(out.contains("totals.emoticonInserted:"))
+    }
+
+    @Test func focusChurnDoesNotEvictActionEvents() {
+        DebugRecorder.reset()
+        // Action events recorded *before* a long burst of app-switching.
+        // The old flat last-100 window dropped these; the split rings keep
+        // them since focus changes can no longer crowd the action history.
+        DebugRecorder.record(.emoticon, "convert", ["consumesTerminator": "true"])
+        DebugRecorder.record(.insert, "replace", ["del": "3", "len": "1"])
+        for i in 0..<100 {
+            DebugRecorder.record(.focus, "app", ["bundleID": "com.example.app\(i % 3)"])
+        }
+        let out = DebugReport.markdown()
+        #expect(out.contains("emoticon.convert"), "action events evicted by focus churn")
+        #expect(out.contains("insert.replace"))
+        // Focus lines are capped so they can't swamp the log.
+        let focusLines = out.components(separatedBy: "focus.app").count - 1
+        #expect(focusLines <= 15, "focus lines not capped: \(focusLines)")
+    }
+
     @Test func activityLogClampsLongMetadataValues() {
         DebugRecorder.reset()
         let huge = String(repeating: "X", count: 1024)


### PR DESCRIPTION
## Why

A real "it doesn't work" report (#76) came with a full debug dump that was *almost* enough to root-cause — but it couldn't distinguish "user never typed a query" from a genuine synthetic-insertion failure, and the activity log was ~60% app-switch spam crowding out the events that mattered. This makes the next report self-diagnosing.

## Changes

- **Inserter telemetry.** `TextInserter.replace/delete/paste` each record one activity-log line (`del`, `len` = replacement grapheme count, `posted` = whether the CGEvents were creatable). The insert path was previously completely silent, so we couldn't tell if it ran.
- **App context on every action event.** `DebugRecorder` auto-stamps `app=<frontmost bundleID>` (skips `focus.app`, which already names the app). "Works in X, dead in Y" is now visible without cross-referencing focus lines.
- **Focus events get their own ring** (cap 40) + a 15-line render budget, merged chronologically with up to 85 action lines — heavy app-switching can no longer evict the action history.
- **`totals.emoticonInserted`** added to the Prefs block (emoji/symbol/gif were counted; emoticons weren't, so we couldn't see whether conversions were landing).

Everything stays inside the report's privacy model: counts, lengths, bundleIDs, booleans — never user text.

## Test plan

- `scripts/run-tests.sh` — full suite green.
- `DebugReportTests`: existing anonymization / 32 KB cap / section-presence / clamp checks still pass; added `prefsShowsEmoticonTotal` and `focusChurnDoesNotEvictActionEvents` (7/7).

Refs W-285