### PR TITLE
W-290: keep emoji suppressed in excluded apps after a sub-threshold backspace

### DIFF
--- a/Sources/Mojito/App/Engine.swift
+++ b/Sources/Mojito/App/Engine.swift
@@ -351,6 +351,18 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
         return captureIsExcluded ? false : consumesKey
     }
 
+    /// Exclusion verdict for the active capture. Prefers the flag cached at
+    /// `:` time; falls back to re-deriving from `captureContext` so an emoji
+    /// action can never slip through if the flag was somehow cleared while the
+    /// capture is still live. No AX call — `captureContext` was snapshotted
+    /// when capture began, and a real app/focus change cancels the capture
+    /// outright, so the snapshot stays authoritative for the capture's life.
+    private var captureExcluded: Bool {
+        if captureIsExcluded { return true }
+        guard let ctx = captureContext else { return false }
+        return exclusions.isExcluded(bundleID: ctx.bundleID, url: ctx.url)
+    }
+
     private func apply(action: TriggerAction) {
         switch action {
         case .none:
@@ -359,13 +371,19 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
         case .closePicker:
             viewModel.reset()
             pickerWindow.hide()
+            // Backspacing below the picker threshold (or demoting `::` symbols
+            // scope) emits .closePicker while the SM stays in .capturing. The
+            // capture metadata — exclusion flag, focus snapshot — must survive
+            // so typing back up to the threshold still respects the exclusion
+            // and focus checks. Only tear it down once the SM has gone idle.
+            if case .capturing = stateMachine.state { break }
             captureContext = nil
             captureFocusSnapshot = nil
             captureFocusPID = nil
             captureIsExcluded = false
 
         case .openPicker(let q, let scope):
-            if captureIsExcluded { break }
+            if captureExcluded { break }
             updateResults(query: q, scope: scope)
             // Defer one tick: the keystroke moves the caret in the focused
             // app after the tap callback returns. AX returns stale coords if
@@ -373,7 +391,7 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
             scheduleRepositionAndShow()
 
         case .refreshPicker(let q, let scope):
-            if captureIsExcluded { break }
+            if captureExcluded { break }
             updateResults(query: q, scope: scope)
             scheduleRepositionAndShow()
 
@@ -381,7 +399,7 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
             if delta > 0 { viewModel.selectNext() } else { viewModel.selectPrevious() }
 
         case .insertEmoji(let q, let mode, let scope):
-            if captureIsExcluded { break }
+            if captureExcluded { break }
             // `.exactMatch` passed the closing `:` through to the focused
             // app — wait one tick for it to land before deleting `:query:`.
             // `.fromPicker` consumed the key, so we can act immediately.

--- a/Tests/MojitoTests/TriggerStateMachineTests.swift
+++ b/Tests/MojitoTests/TriggerStateMachineTests.swift
@@ -124,6 +124,24 @@ struct TriggerStateMachineTests {
         #expect(sm.state == .capturing(query: "f"))
     }
 
+    @Test func subThresholdBackspaceStaysCapturingThenReopens() {
+        // W-290 invariant: a sub-threshold backspace emits .closePicker but
+        // the SM stays in .capturing. The Engine relies on this to keep the
+        // capture's exclusion flag / focus snapshot alive — if the SM went
+        // idle here, the metadata would (correctly) be torn down. Typing back
+        // up to the threshold must re-open the picker on the SAME capture.
+        var sm = TriggerStateMachine()
+        _ = sm.handle(.colon)
+        _ = sm.handle(.nameChar("f"))
+        _ = sm.handle(.nameChar("o"))  // .openPicker("fo")
+        let close = sm.handle(.backspace)
+        #expect(close.action == .closePicker)
+        #expect(sm.state == .capturing(query: "f"))
+        let reopen = sm.handle(.nameChar("o"))
+        #expect(reopen.action == .openPicker(query: "fo", scope: .normal))
+        #expect(sm.state == .capturing(query: "fo"))
+    }
+
     @Test func backspaceFromEmptyQueryEndsCapture() {
         var sm = TriggerStateMachine()
         _ = sm.handle(.colon)

--- a/Tests/MojitoTests/TriggerStateMachineTests.swift
+++ b/Tests/MojitoTests/TriggerStateMachineTests.swift
@@ -125,7 +125,7 @@ struct TriggerStateMachineTests {
     }
 
     @Test func subThresholdBackspaceStaysCapturingThenReopens() {
-        // W-290 invariant: a sub-threshold backspace emits .closePicker but
+        // Invariant: a sub-threshold backspace emits .closePicker but
         // the SM stays in .capturing. The Engine relies on this to keep the
         // capture's exclusion flag / focus snapshot alive — if the SM went
         // idle here, the metadata would (correctly) be torn down. Typing back


### PR DESCRIPTION
## Summary

Fixes a bug where Mojito's emoji picker could fire in an **excluded app** (the report came in against Slack) after a backspace correction.

**Root cause:** backspacing a capture below the 2-char picker threshold makes `TriggerStateMachine` emit `.closePicker` *while staying in `.capturing`*. `Engine.apply(.closePicker)` unconditionally reset `captureIsExcluded` (and the focus snapshot), so when the user typed back up to the threshold — the `:a` → backspace → `:ab` correction the debug report captured (`engine.colon excluded=true`, then `picker.open` ~2s later) — the picker reopened in the excluded app.

## Fix (two layers)

1. **Root cause** — `.closePicker` now only tears down capture metadata once the state machine has actually returned to `.idle` (`if case .capturing = stateMachine.state { break }`). The exclusion flag and focus snapshot survive a sub-threshold backspace.
2. **Defense-in-depth** — `.openPicker` / `.refreshPicker` / `.insertEmoji` now consult a `captureExcluded` helper that re-derives the verdict from the captured context if the cached flag is somehow false. No extra AX call (context was snapshotted at `:` time). Allowlist mode is covered for free since `isExcluded()` already returns `true` for non-allowlisted apps.

GIF search (`:::`) is untouched — it routes through separate actions, so `gifBypassExclusions` users keep GIF search in excluded apps.

## Test plan

- [x] `scripts/run-tests.sh` — clean build, full suite green
- [x] Added `subThresholdBackspaceStaysCapturingThenReopens` pinning the SM invariant the fix relies on
- Manual: in an excluded app, `:a` → backspace → `:ab` shows no picker; `:::` still opens GIF search there; picker still works normally in a non-excluded app after a backspace/retype.

Refs W-290