### PR TITLE
W-292: backfill CHANGELOG.md with historical release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,55 @@ updater.
 
 Plus various fixes and improvements.
 
+## v1.0.8
+
+- Fixed a full-screen effect that could appear oversized on large / 4K displays.
+
+## v1.0.7
+
+- **About → Copy Debug Info** — an anonymized debug report to make support easier.
+- **Symbols** — picker entries force text presentation, and un-renderable glyphs are dropped from the corpus.
+- **GIF picker** — faster: search and thumbnail loads share one connection.
+- **Fixes**
+  - Keystrokes pass through correctly during capture in excluded apps and when there's no picker result.
+  - Picker keeps its top padding when scrolled to the top.
+- Easter-egg additions and polish.
+
+## v1.0.6
+
+Added easter eggs. Find them.
+
+## v1.0.5
+
+**Fix:** GIF search (`:::`) now actually works in the released app. v1.0.4 shipped without the Giphy API key packaged, so the panel showed "API key required" on every search. The key is now baked into builds.
+
+## v1.0.4
+
+**GIF search.** Type `:::` in any text field to pop a Giphy-backed search panel. Arrow keys + Enter to insert inline. Translated into all 19 locales.
+
+Toggle off (or restrict to non-excluded apps) under **Settings → General** and **Settings → Exclusions**. Privacy detail: when on, your query goes to Giphy.
+
+## v1.0.3
+
+**Now available in 18 more languages** 🌍
+
+Mojito's interface is translated into 18 new locales (full list in the GitHub repo). Translations were LLM-drafted and will improve as native speakers review them — corrections welcome.
+
+Plus a help hint for the macOS 26 menu-bar visibility toggle, and small UI polish.
+
+## v1.0.2
+
+- **Smarter emoji search.** Typing `:eye` now surfaces `:eyes:` and `:eye:` ahead of longer shortcodes containing `eye`. Prefix matches now always rank above mid-string matches, regardless of how often you've used the others.
+- **Hide the menu bar icon.** New "Show icon in menu bar" preference in Settings → General. When hidden, reopen Settings by launching Mojito from Finder or Spotlight.
+- **Tidied Settings layout.** "Rank frequently used emoji higher" moved into the Emoji section. The menu-bar hint now appears inline below the toggle that triggers it.
+- **iMessage no longer excluded by default.** Add it to your exclusions list if you prefer the old behavior.
+
+Plus a little easter-egg polish.
+
+## v1.0.1
+
+Bug fixes and polish.
+
 ## v1.0.0
 
 Initial release.


### PR DESCRIPTION
## Summary

`CHANGELOG.md` shipped (in #79) with only the v1.1.0 and v1.0.0 sections. `scripts/release.sh` extracts each `## vX.Y.Z` block as the single source of truth for the GitHub Release body and the in-app Sparkle update notes, so every released version should have a section. This backfills v1.0.1 → v1.0.8 from the published GitHub release notes, matching the existing format (no dates, no repeated version heading — `release.sh` prepends `## Mojito X.Y.Z` itself).

## Test plan

- Format-only change; no code touched.
- Spot-check: `awk -v header="## v1.0.4" '$0==header{c=1;next} c&&/^## /{exit} c{print}' CHANGELOG.md` extracts the v1.0.4 body cleanly.

Refs: W-292