### PR TITLE
W-313: paste GIFs as a file URL so they animate in Slack/Discord

### DIFF
--- a/Sources/Mojito/GifPicker/GifClipboard.swift
+++ b/Sources/Mojito/GifPicker/GifClipboard.swift
@@ -1,32 +1,101 @@
 import AppKit
 import Foundation
 
-/// Writes the bytes of an animated GIF to the system pasteboard.
+/// Writes an animated GIF to the system pasteboard so a synthetic ⌘V lands it
+/// in the focused app — animation intact.
 ///
-/// `com.compuserve.gif` is the UTI receivers sniff for animated paste —
-/// Slack, Discord, iMessage, Mail all animate from it. We also include a
-/// `public.tiff` still as a fallback for receivers that pick image types
-/// without GIF awareness.
+/// The load-bearing representation is a **file URL** to a temp `.gif`, not raw
+/// image bytes. Electron/Chromium apps (Slack, Discord) flatten any inline
+/// pasteboard *image* to a single static frame when they read it; handed a
+/// file instead, they run it through their normal upload path (same as
+/// drag-drop) and it animates. `com.compuserve.gif` raw bytes ride along as a
+/// fallback for apps that paste inline image data and honor the GIF UTI (Mail).
+/// We deliberately do NOT write a TIFF/PNG still — that's exactly the static
+/// frame Chromium was grabbing.
 @MainActor
 enum GifClipboard {
     /// Fetches the GIF bytes from `url` and writes them to the pasteboard.
-    /// Returns true on success.
-    static func copy(from url: URL) async -> Bool {
+    /// `name` (the search query) flavors the staged filename a chat app shows
+    /// on upload, e.g. `giphy-fire.gif`. Returns true on success.
+    static func copy(from url: URL, name: String) async -> Bool {
         do {
             let (data, _) = try await URLSession.shared.data(from: url)
-            return write(data: data)
+            return write(data: data, name: name)
         } catch {
             return false
         }
     }
 
-    static func write(data: Data) -> Bool {
+    static func write(data: Data, name: String) -> Bool {
+        guard let fileURL = stageTempFile(data: data, name: name) else { return false }
+
         let pb = NSPasteboard.general
         pb.clearContents()
-        let ok = pb.setData(data, forType: NSPasteboard.PasteboardType("com.compuserve.gif"))
-        if let image = NSImage(data: data), let tiff = image.tiffRepresentation {
-            _ = pb.setData(tiff, forType: .tiff)
+        let item = NSPasteboardItem()
+        // File URL first — the representation chat apps upload + animate.
+        item.setString(fileURL.absoluteString, forType: .fileURL)
+        // Raw GIF bytes for inline-image receivers that honor the GIF UTI.
+        item.setData(data, forType: NSPasteboard.PasteboardType("com.compuserve.gif"))
+        // Tell clipboard managers not to record this transient write.
+        item.setString("", forType: NSPasteboard.PasteboardType("org.nspasteboard.TransientType"))
+        return pb.writeObjects([item])
+    }
+
+    /// Writes the GIF to a temp file we can hand off as a file URL. Receivers
+    /// may read the file asynchronously after the paste, so we don't delete it
+    /// immediately — instead we sweep stale pastes on the way in. Each paste
+    /// gets its own subdir so the readable, non-unique filename can't clobber
+    /// an earlier paste of a different GIF that a chat app is still uploading.
+    /// Returns nil if staging fails.
+    private static func stageTempFile(data: Data, name: String) -> URL? {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("Mojito-GIFs", isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            sweepStaleEntries(in: root)
+            let dir = root.appendingPathComponent(UUID().uuidString, isDirectory: true)
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let slug = safeFileBase(name)
+            let fileName = slug.isEmpty ? "giphy.gif" : "giphy-\(slug).gif"
+            let fileURL = dir.appendingPathComponent(fileName)
+            try data.write(to: fileURL)
+            return fileURL
+        } catch {
+            return nil
         }
-        return ok
+    }
+
+    /// Turns the search query into a safe, readable filename fragment: keep
+    /// alphanumerics, collapse every other run to a single `-`, trim, cap
+    /// length. May return "" (caller falls back to a bare `giphy.gif`).
+    private static func safeFileBase(_ name: String) -> String {
+        var out = ""
+        var lastWasDash = false
+        for ch in name.lowercased() {
+            if ch.isLetter || ch.isNumber || ch == "_" {
+                out.append(ch)
+                lastWasDash = false
+            } else if !lastWasDash {
+                out.append("-")
+                lastWasDash = true
+            }
+        }
+        let trimmed = out.trimmingCharacters(in: CharacterSet(charactersIn: "-_"))
+        return String(trimmed.prefix(60))
+    }
+
+    /// Deletes staged pastes older than a few minutes — long enough that a
+    /// recent paste's receiver has surely finished reading, short enough that
+    /// the temp dir doesn't grow without bound across a session.
+    private static func sweepStaleEntries(in dir: URL) {
+        let cutoff = Date(timeIntervalSinceNow: -300)
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: [.contentModificationDateKey]
+        ) else { return }
+        for url in entries {
+            let modified = (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
+            if let modified, modified < cutoff {
+                try? FileManager.default.removeItem(at: url)
+            }
+        }
     }
 }

--- a/Sources/Mojito/GifPicker/GifPickerWindow.swift
+++ b/Sources/Mojito/GifPicker/GifPickerWindow.swift
@@ -166,9 +166,10 @@ final class GifPickerWindow {
     private func handlePick(_ asset: GifAsset, paste: Bool, deleteCount: Int) {
         copyTask?.cancel()
         let url = asset.originalURL
+        let name = viewModel.query
         hide()
         copyTask = Task {
-            let copied = await GifClipboard.copy(from: url)
+            let copied = await GifClipboard.copy(from: url, name: name)
             await MainActor.run {
                 if copied { onGifInserted?() }
                 guard copied, paste else { return }


### PR DESCRIPTION
## Problem

Picking a GIF from the `:::` picker and pasting into Slack (and other Electron/Chromium apps) inserted only the **first frame as a static PNG**. Reported in W-313 / #85.

## Cause

`GifClipboard.write` put a `public.tiff` still on the pasteboard (first frame of `NSImage(data:).tiffRepresentation`) alongside the raw GIF bytes. Chromium's clipboard reader flattens any inline pasteboard *image* to a single frame, and that TIFF handed it the static frame directly (macOS coerces it to PNG on request). The code hadn't changed since the feature shipped — it's Chromium's reader behavior biting a latent weakness.

## Fix

Paste the GIF **as a file**, not as image bytes:

- Stage the downloaded GIF to a temp `.gif` and put a `public.file-url` on the pasteboard. Slack/Discord run a pasted file through their normal upload path (same as drag-drop), so it animates.
- Keep `com.compuserve.gif` raw bytes as an inline-image fallback for apps that honor the GIF UTI (Mail).
- **Drop the `public.tiff` still** — that was the static frame.
- Mark the write transient (`org.nspasteboard.TransientType`) so clipboard managers ignore it.

The temp file is named from the search query (`giphy-<query>.gif`) inside a per-paste UUID subdir, so chat apps show a readable upload name and two GIFs from the same search can't clobber each other on disk mid-upload. Stale subdirs are swept (>5 min) on each write.

## Test plan

- [x] Slack — `:::`, search, Enter → GIF **animates**, filename reads `giphy-<query>.gif` (verified locally)
- [x] Discord — same
- [x] Mail / Notes (rich text) — inline GIF via fallback
- Note: pasting into a plain-text field now yields the `file://…giphy.gif` path text (those fields can't hold an image anyway — degenerate case)

Refs: W-313