### PR TITLE
W-314: surface the £ sign, and expose all macOS-renderable symbols (W-315)

### DIFF
--- a/Sources/Mojito/EmojiDB/SymbolsDatabase.swift
+++ b/Sources/Mojito/EmojiDB/SymbolsDatabase.swift
@@ -41,6 +41,15 @@ enum SymbolsDatabase {
         for range in symbolRanges {
             for codepoint in range {
                 guard let scalar = Unicode.Scalar(codepoint) else { continue }
+                // Skip non-graphic scalars (soft hyphen, format/control marks,
+                // unassigned slots in the swept ranges) — they'd otherwise pass
+                // the font-render gate as invisible blank rows.
+                switch scalar.properties.generalCategory {
+                case .control, .format, .surrogate, .privateUse, .unassigned:
+                    continue
+                default:
+                    break
+                }
                 let char = textPresentation(String(scalar))
                 if seenCharacters.contains(char) { continue }
                 guard let name = scalar.properties.name, !name.isEmpty else { continue }
@@ -124,7 +133,13 @@ enum SymbolsDatabase {
     }
 
     /// Covers the macOS emoji picker's "Symbols" category and adjacent blocks.
+    /// Letter blocks (Latin accents, Cyrillic, CJK ideographs) are deliberately
+    /// excluded — the per-keystroke fuzzy scan walks this whole corpus, so the
+    /// ~90k ideographs alone would push search from µs into ms. Greek stays:
+    /// its letters double as math/science symbols.
     private static let symbolRanges: [ClosedRange<Int>] = [
+        0x00A1...0x00BF,    // Latin-1 symbols (£ ¥ § ± ² ³ µ ¶ ¼ ½ ¾ ¿ « » ¬ …)
+        0x0370...0x03FF,    // Greek & Coptic (α β γ … Ω)
         0x2000...0x206F,    // General punctuation
         0x2070...0x209F,    // Super/subscripts
         0x20A0...0x20CF,    // Currency
@@ -143,10 +158,12 @@ enum SymbolsDatabase {
         0x2700...0x27BF,    // Dingbats (✓ ✗ ❤ ✉ ✏)
         0x27C0...0x27EF,    // Misc math A
         0x27F0...0x27FF,    // Supp arrows A
+        0x2800...0x28FF,    // Braille patterns
         0x2900...0x297F,    // Supp arrows B
         0x2980...0x29FF,    // Misc math B
         0x2A00...0x2AFF,    // Supp math
         0x2B00...0x2BFF,    // Misc symbols and arrows
+        0x3000...0x303F,    // CJK symbols & punctuation (、。「」《》)
         0x1F000...0x1F02F,  // Mahjong tiles
         0x1F030...0x1F09F,  // Domino tiles
         0x1F0A0...0x1F0FF,  // Playing cards
@@ -199,6 +216,63 @@ enum SymbolsDatabase {
         .init(character: "£",  shortcodes: ["pound", "sterling", "gbp"]),
         .init(character: "¢",  shortcodes: ["cent", "cents"]),
         .init(character: "¥",  shortcodes: ["yen", "yuan", "rmb"]),
+
+        // Fractions & superscripts. Swept too (Latin-1), but the Unicode names
+        // ("VULGAR FRACTION ONE HALF", "SUPERSCRIPT TWO") read terribly in the
+        // picker — give them the labels people search for.
+        .init(character: "½",  shortcodes: ["half", "one_half"]),
+        .init(character: "¼",  shortcodes: ["quarter", "one_quarter"]),
+        .init(character: "¾",  shortcodes: ["three_quarters"]),
+        .init(character: "²",  shortcodes: ["squared", "sup2"]),
+        .init(character: "³",  shortcodes: ["cubed", "sup3"]),
+        .init(character: "¹",  shortcodes: ["sup1"]),
+
+        // Greek. Cleaner than the swept names, and the sweep can't be searched
+        // by "lambda" at all — Unicode spells U+03BB "GREEK SMALL LETTER LAMDA".
+        // Capitalized aliases (Δ → "Delta") read distinct from lowercase in the
+        // picker. ⌥-typeable letters that look like Latin (Α Β Ε…) are left to
+        // the sweep.
+        .init(character: "α",  shortcodes: ["alpha"]),
+        .init(character: "β",  shortcodes: ["beta"]),
+        .init(character: "γ",  shortcodes: ["gamma"]),
+        .init(character: "δ",  shortcodes: ["delta"]),
+        .init(character: "ε",  shortcodes: ["epsilon"]),
+        .init(character: "ζ",  shortcodes: ["zeta"]),
+        .init(character: "η",  shortcodes: ["eta"]),
+        .init(character: "θ",  shortcodes: ["theta"]),
+        .init(character: "ι",  shortcodes: ["iota"]),
+        .init(character: "κ",  shortcodes: ["kappa"]),
+        .init(character: "λ",  shortcodes: ["lambda"]),
+        .init(character: "μ",  shortcodes: ["mu"]),
+        .init(character: "ν",  shortcodes: ["nu"]),
+        .init(character: "ξ",  shortcodes: ["xi"]),
+        .init(character: "ο",  shortcodes: ["omicron"]),
+        .init(character: "ρ",  shortcodes: ["rho"]),
+        .init(character: "σ",  shortcodes: ["sigma"]),
+        .init(character: "ς",  shortcodes: ["final_sigma"]),
+        .init(character: "τ",  shortcodes: ["tau"]),
+        .init(character: "υ",  shortcodes: ["upsilon"]),
+        .init(character: "φ",  shortcodes: ["phi"]),
+        .init(character: "χ",  shortcodes: ["chi"]),
+        .init(character: "ψ",  shortcodes: ["psi"]),
+        .init(character: "ω",  shortcodes: ["omega"]),
+        .init(character: "Γ",  shortcodes: ["Gamma"]),
+        .init(character: "Δ",  shortcodes: ["Delta"]),
+        .init(character: "Θ",  shortcodes: ["Theta"]),
+        .init(character: "Λ",  shortcodes: ["Lambda"]),
+        .init(character: "Ξ",  shortcodes: ["Xi"]),
+        .init(character: "Π",  shortcodes: ["Pi"]),
+        .init(character: "Σ",  shortcodes: ["Sigma"]),
+        .init(character: "Φ",  shortcodes: ["Phi"]),
+        .init(character: "Ψ",  shortcodes: ["Psi"]),
+        .init(character: "Ω",  shortcodes: ["Omega", "ohm"]),
+
+        // Latin-1 punctuation people can't easily type
+        .init(character: "¡",  shortcodes: ["inverted_exclamation", "spanish_exclamation"]),
+        .init(character: "¿",  shortcodes: ["inverted_question", "spanish_question"]),
+        .init(character: "µ",  shortcodes: ["micro"]),
+        .init(character: "«",  shortcodes: ["lguillemet", "guillemet_left"]),
+        .init(character: "»",  shortcodes: ["rguillemet", "guillemet_right"]),
 
         // Marks & misc
         .init(character: "✓",  shortcodes: ["check_mark", "tick"]),

--- a/Sources/Mojito/EmojiDB/SymbolsDatabase.swift
+++ b/Sources/Mojito/EmojiDB/SymbolsDatabase.swift
@@ -192,6 +192,14 @@ enum SymbolsDatabase {
         .init(character: "π",  shortcodes: ["pi"]),
         .init(character: "°",  shortcodes: ["degree"]),
 
+        // Currency. The Latin-1 currency signs (£ ¢ ¥, U+00A2–A5) fall
+        // outside every block in `symbolRanges`, so without an explicit
+        // entry they never reach the picker at all. The synonyms are terms
+        // the Unicode name alone ("POUND SIGN") wouldn't fuzzy-match.
+        .init(character: "£",  shortcodes: ["pound", "sterling", "gbp"]),
+        .init(character: "¢",  shortcodes: ["cent", "cents"]),
+        .init(character: "¥",  shortcodes: ["yen", "yuan", "rmb"]),
+
         // Marks & misc
         .init(character: "✓",  shortcodes: ["check_mark", "tick"]),
         .init(character: "✗",  shortcodes: ["x_mark", "cross"]),

--- a/Tests/MojitoTests/SymbolsDatabaseTests.swift
+++ b/Tests/MojitoTests/SymbolsDatabaseTests.swift
@@ -54,6 +54,44 @@ struct SymbolsDatabaseTests {
         }
     }
 
+    @Test func curatedSymbolsAreFindableBySearchTerm() {
+        // Curated aliases give clean, searchable labels for glyphs whose Unicode
+        // names are awkward or wrong. Notably "lambda": U+03BB's Unicode name is
+        // "GREEK SMALL LETTER LAMDA", so the sweep alone can't match "lambda".
+        let expected: [(term: String, character: String)] = [
+            ("lambda", "λ"), ("delta", "δ"), ("Delta", "Δ"), ("omega", "ω"),
+            ("half", "½"), ("squared", "²"), ("cubed", "³"),
+            ("spanish_question", "¿"), ("micro", "µ"),
+        ]
+        for (term, character) in expected {
+            let hit = SymbolsDatabaseTests.indexed.first(where: { $0.emoji.shortcodes.contains(term) })
+            #expect(hit?.emoji.character == character, "expected \(character) for \"\(term)\"")
+        }
+    }
+
+    @Test func newlySweptBlocksAreReachable() {
+        // Blocks below U+2000 (and Braille / CJK punctuation) used to fall
+        // outside symbolRanges entirely. Spot-check one scalar from each.
+        func present(_ cp: UInt32) -> Bool {
+            SymbolsDatabaseTests.indexed.contains(where: {
+                $0.emoji.character.unicodeScalars.first?.value == cp
+            })
+        }
+        #expect(present(0x2801), "Braille ⠁")
+        #expect(present(0x300C), "CJK bracket 「")
+        #expect(present(0x00BD), "fraction ½")
+        #expect(present(0x03C9), "greek ω")
+    }
+
+    @Test func nonGraphicScalarsAreExcluded() {
+        // The general-category guard must drop soft hyphen (U+00AD, format) so
+        // it doesn't surface as an invisible blank row.
+        let softHyphen = SymbolsDatabaseTests.indexed.contains(where: {
+            $0.emoji.character.unicodeScalars.first?.value == 0x00AD
+        })
+        #expect(!softHyphen)
+    }
+
     @Test func curatedShortcodeStillResolves() {
         // The character mutation must not break the existing shortcode-
         // based lookup the curated aliases rely on.

--- a/Tests/MojitoTests/SymbolsDatabaseTests.swift
+++ b/Tests/MojitoTests/SymbolsDatabaseTests.swift
@@ -39,6 +39,21 @@ struct SymbolsDatabaseTests {
         #expect(!SymbolsDatabaseTests.indexed.contains(where: { $0.emoji.hexcode == hex }))
     }
 
+    @Test func latin1CurrencySignsAreReachable() {
+        // £ ¢ ¥ live at U+00A2–A5, outside every range in `symbolRanges`, so
+        // they only reach the picker through a curated alias. Each must be
+        // findable by the terms people actually type, not just its Unicode name.
+        let expected: [(term: String, character: String)] = [
+            ("pound", "£"), ("sterling", "£"), ("gbp", "£"),
+            ("cent", "¢"),
+            ("yen", "¥"), ("yuan", "¥"),
+        ]
+        for (term, character) in expected {
+            let hit = SymbolsDatabaseTests.indexed.first(where: { $0.emoji.shortcodes.contains(term) })
+            #expect(hit?.emoji.character == character, "expected \(character) for \"\(term)\"")
+        }
+    }
+
     @Test func curatedShortcodeStillResolves() {
         // The character mutation must not break the existing shortcode-
         // based lookup the curated aliases rely on.


### PR DESCRIPTION
## Summary
The symbol picker's programmatic sweep (`SymbolsDatabase.symbolRanges`) started at U+2000, so it silently skipped whole blocks of glyphs macOS renders natively.

**W-314** — £ ¢ ¥ live at U+00A2–A5 in Latin-1 Supplement, outside every swept block, so the pound sign was absent from the picker entirely (no search term surfaced it).

**W-315** — rather than patch in just the currency signs, expose every symbol/punctuation/technical glyph macOS can render:
- Added to `symbolRanges`: **Latin-1 symbols** (U+00A1–BF: ¡ ¿ ½ ¼ ¾ ¹ ² ³ µ « » ¬ …), **Greek & Coptic** (U+0370–03FF — only `π` was reachable before), **Braille** (U+2800–28FF), **CJK Symbols & Punctuation** (U+3000–303F: 、。「」《》).
- Added a **general-category guard** so control/format/unassigned scalars don't slip in as invisible blank rows (e.g. soft hyphen).
- **Curated clean labels** where the Unicode name is awkward or wrong — notably Greek: U+03BB's Unicode name is "GREEK SMALL LETTER LAMDA", so the sweep alone could never be searched by "lambda". Also fractions (½ ¼ ¾), superscripts (² → `squared`, ³ → `cubed`), and capitalized Greek aliases (Δ → `Delta`) that read distinct from lowercase.

Letter blocks (Latin accents, Cyrillic, CJK/Hangul ideographs) are deliberately excluded — the per-keystroke fuzzy scan walks the whole corpus, so the ~90k ideographs would push search from µs into ms. Corpus grows **2736 → 3182** (+446).

## Test plan
- `scripts/run-tests.sh` green, including new `SymbolsDatabaseTests` coverage for Greek/fractions/superscripts (search-term resolution), Braille + CJK-punctuation presence, and the blank-row guard.
- Manual: `:pound`, `:lambda`, `:Delta`, `:half`, `:squared`, `:omega` all resolve in the live picker.

Refs W-314
Refs W-315