### PR TITLE
W-316: pre-1.2.0 review fixes (browser delete-count, current cache, dedup)

### DIFF
--- a/Sources/Mojito/App/Engine.swift
+++ b/Sources/Mojito/App/Engine.swift
@@ -253,12 +253,19 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
         viewModel.reset()
         pickerWindow.hide()
         gifPickerWindow.hide()
+        clearCaptureState()
+        DebugRecorder.record(.picker, "cancel")
+    }
+
+    /// Reset the per-capture bookkeeping (context, focused-field snapshot,
+    /// excluded flag, browser delete count). Window + state-machine teardown is
+    /// left to the caller — those differ per entry point.
+    private func clearCaptureState() {
         captureContext = nil
         captureFocusSnapshot = nil
         captureFocusPID = nil
         captureIsExcluded = false
         browserDeleteCount = 0
-        DebugRecorder.record(.picker, "cancel")
     }
 
     func attach(permissions: PermissionsCoordinator) {
@@ -685,10 +692,7 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
             viewModel.reset()
             pickerWindow.hide()
             stateMachine.emptyPickerActive = false
-            captureContext = nil
-            captureFocusSnapshot = nil
-            captureFocusPID = nil
-            captureIsExcluded = false
+            clearCaptureState()
             // The `?` from `:?` was swallowed; type it back so the focused app
             // shows the literal `:?` after Esc.
             TextInserter.replace(charactersToDelete: 0, with: "?")
@@ -790,7 +794,10 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
         gifPickerWindow.hide()
         let deleteCount: Int
         if case .capturing(let q) = stateMachine.state {
-            deleteCount = q.count + 1  // the typed `:query`
+            // Erase the typed `:query` — or `::query` in symbols scope. Mirrors
+            // the keyboard Browse-row path in apply(.insertEmoji).
+            let leading = stateMachine.captureScope == .symbolsOnly ? 2 : 1
+            deleteCount = q.count + leading
         } else {
             deleteCount = 0
         }
@@ -828,7 +835,7 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
         let copy = !(captureContext?.focusedFieldIsEditable ?? true)
         collapseBrowser()
         guard let emoji else { return }
-        let glyph = characterWithSkinTone(emoji)
+        let glyph = emoji.tonedGlyph
         if copy {
             copyToClipboard(glyph)
         } else {
@@ -851,11 +858,7 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
         stateMachine.reset()
         viewModel.reset()
         pickerWindow.hide()
-        captureContext = nil
-        captureFocusSnapshot = nil
-        captureFocusPID = nil
-        captureIsExcluded = false
-        browserDeleteCount = 0
+        clearCaptureState()
     }
 
     private func updateResults(query: String, scope: CaptureScope) {
@@ -923,11 +926,11 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
             }
             if scored.emoji.hexcode == FuzzyMatcher.k02Hex {
                 guard let pick = database.all.randomElement() else { return }
-                TextInserter.replace(charactersToDelete: charsToDelete, with: characterWithSkinTone(pick))
+                TextInserter.replace(charactersToDelete: charsToDelete, with: pick.tonedGlyph)
                 EasterEggTracker.record(.k02)
                 return  // random rolls shouldn't bias future search
             }
-            TextInserter.replace(charactersToDelete: charsToDelete, with: characterWithSkinTone(scored.emoji))
+            TextInserter.replace(charactersToDelete: charsToDelete, with: scored.emoji.tonedGlyph)
             recordUsage(emoji: scored.emoji)
             SeasonalGates.fire(for: scored.emoji)
 
@@ -968,7 +971,7 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
                 }
             }
             if let exact = database.exact(key) {
-                TextInserter.replace(charactersToDelete: charsToDelete, with: characterWithSkinTone(exact))
+                TextInserter.replace(charactersToDelete: charsToDelete, with: exact.tonedGlyph)
                 recordUsage(emoji: exact)
                 SeasonalGates.fire(for: exact)
                 return
@@ -1304,11 +1307,6 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
         return true
     }
 
-    private func characterWithSkinTone(_ emoji: Emoji) -> String {
-        let tone = SkinTone.current
-        guard emoji.supportsSkinTone else { return emoji.character }
-        return tone.apply(to: emoji.character)
-    }
 }
 
 /// Cmd+Z or Backspace within `Engine.emoticonUndoWindow` reverses this.

--- a/Sources/Mojito/Browser/EmojiBrowserViewModel.swift
+++ b/Sources/Mojito/Browser/EmojiBrowserViewModel.swift
@@ -63,13 +63,20 @@ final class EmojiBrowserViewModel: ObservableObject {
         self.symbolsEnabled = UserDefaults.standard.bool(forKey: PrefsKey.symbolsEnabled)
         let built = Self.build(database: database, quickAccess: quickAccess, usage: self.usage)
         self.sections = built
-        self.flat = built.flatMap { $0.cells.map(\.emoji) }
+        let flat = built.flatMap { $0.cells.map(\.emoji) }
+        self.flat = flat
+        self.current = flat  // query starts empty → whole library
         self.activeCategory = built.first?.category ?? .smileysPeople
     }
 
     /// The addressable list for selection + keyboard nav: search results when
-    /// searching, else the whole library in section order.
-    var current: [Emoji] {
+    /// searching, else the whole library in section order. Cached — recomputed
+    /// only when the query changes (setQuery/selectCategory). The view body
+    /// reads it several times per render, so it must not re-run the fuzzy
+    /// search on each access.
+    @Published private(set) var current: [Emoji]
+
+    private func computeCurrent() -> [Emoji] {
         let trimmed = query.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty else { return flat }
         return FuzzyMatcher.search(
@@ -92,6 +99,7 @@ final class EmojiBrowserViewModel: ObservableObject {
 
     func setQuery(_ newQuery: String) {
         query = newQuery
+        current = computeCurrent()
         selectedIndex = 0
         scrollTarget = 0  // back to top on every query change
     }
@@ -101,6 +109,7 @@ final class EmojiBrowserViewModel: ObservableObject {
     func selectCategory(_ category: EmojiCategory) {
         let wasSearching = isSearching
         query = ""
+        current = computeCurrent()  // → whole library
         if let section = sections.first(where: { $0.category == category }) {
             selectedIndex = section.startIndex
         }

--- a/Sources/Mojito/Browser/InlineBrowserView.swift
+++ b/Sources/Mojito/Browser/InlineBrowserView.swift
@@ -206,9 +206,7 @@ struct InlineBrowserView: View {
 
     private func cell(_ emoji: Emoji, index: Int) -> some View {
         let isSelected = index == browser.selectedIndex
-        let glyph = emoji.supportsSkinTone
-            ? SkinTone.current.apply(to: emoji.character)
-            : emoji.character
+        let glyph = emoji.tonedGlyph
         return Text(glyph)
             .font(.system(size: 25))  // match the pill's glyph size
             .frame(maxWidth: .infinity)

--- a/Sources/Mojito/EmojiDB/Emoji.swift
+++ b/Sources/Mojito/EmojiDB/Emoji.swift
@@ -64,3 +64,13 @@ struct Emoji: Decodable, Identifiable, Hashable {
         case localizedShortcodes = "l"
     }
 }
+
+extension Emoji {
+    /// The glyph with the user's chosen skin tone applied, or the bare glyph
+    /// when this emoji has no skin-tone variants (symbols, sentinels, ZWJ
+    /// sequences that don't take a modifier). The single place insertion and
+    /// every preview cell resolve a tone.
+    var tonedGlyph: String {
+        supportsSkinTone ? SkinTone.current.apply(to: character) : character
+    }
+}

--- a/Sources/Mojito/KeyMonitor/TriggerStateMachine.swift
+++ b/Sources/Mojito/KeyMonitor/TriggerStateMachine.swift
@@ -148,6 +148,10 @@ struct TriggerStateMachine {
     var pillEmojiCount: Int = 0
 
     private var currentScope: CaptureScope = .normal
+    /// The active capture's scope. Read by the Engine's global-hotkey browser
+    /// entry, which synthesizes a pick outside the normal action flow and needs
+    /// to know whether the field holds `:query` or `::query`.
+    var captureScope: CaptureScope { currentScope }
 
     private var konamiProgress: Int = 0
     private enum KonamiStep { case up, down, left, right, b, a }

--- a/Sources/Mojito/Picker/PickerView.swift
+++ b/Sources/Mojito/Picker/PickerView.swift
@@ -170,9 +170,7 @@ private struct PickerRow: View {
             )
         } else {
             // Preview with the user's chosen skin tone.
-            let display = scored.emoji.supportsSkinTone
-                ? SkinTone.current.apply(to: scored.emoji.character)
-                : scored.emoji.character
+            let display = scored.emoji.tonedGlyph
             return AnyView(
                 Text(display)
                     .font(.system(size: 18))
@@ -288,9 +286,7 @@ private struct CompactCell: View {
     }
 
     private var glyph: String {
-        scored.emoji.supportsSkinTone
-            ? SkinTone.current.apply(to: scored.emoji.character)
-            : scored.emoji.character
+        scored.emoji.tonedGlyph
     }
 }
 

--- a/Sources/Mojito/Settings/QuickAccessSettings.swift
+++ b/Sources/Mojito/Settings/QuickAccessSettings.swift
@@ -149,7 +149,7 @@ struct QuickAccessSection: View {
     }
 
     private func displayGlyph(_ emoji: Emoji) -> String {
-        emoji.supportsSkinTone ? SkinTone.current.apply(to: emoji.character) : emoji.character
+        emoji.tonedGlyph
     }
 }
 


### PR DESCRIPTION
## Summary
Four fixes from the pre-release code review of `v1.1.1..main`, ahead of cutting **1.2.0**:

1. **`showBrowser()` delete-count off-by-one** — the global-hotkey browser entry hardcoded `q.count + 1`, while the keyboard "Browse" row uses a scope-aware `+2` for `.symbolsOnly`. With double-colon-for-symbols enabled, opening the browser via hotkey mid-`::query` left a stray leading `:`. Now reads the capture scope via a new `TriggerStateMachine.captureScope`.
4. **`EmojiBrowserViewModel.current` cached** — was a computed property re-running a full `FuzzyMatcher.search` on every read (the view body touches it several times per render). Now recomputed only on query change.
5. **Extracted `Engine.clearCaptureState()`** from the three capture-reset sites; the Esc-restoring-`?` path now also clears `browserDeleteCount` (was omitted).
6. **`Emoji.tonedGlyph`** — promoted the skin-tone glyph resolution out of `Engine.characterWithSkinTone` and the three duplicated SwiftUI cells into one extension.

## Test plan
- `scripts/run-tests.sh` green.
- No behavior change for default settings; #1 only affected the `::` symbols + global-hotkey combination.

Refs W-316