### PR TITLE
W-320: Arrow emoticons convert flush against text (hyphen arrows) + safety controls

### DIFF
--- a/Sources/Mojito/App/Engine.swift
+++ b/Sources/Mojito/App/Engine.swift
@@ -81,6 +81,11 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
         // The pill is summoned by `:?` when Quick Access is enabled.
         let qaEnabled = (UserDefaults.standard.object(forKey: PrefsKey.quickAccessEnabled) as? Bool) ?? true
         self.stateMachine.quickAccessTrigger = qaEnabled ? "?" : nil
+        // Arrows are inert unless both emoticons and the arrow sub-toggle are on
+        // — gating in the SM means a disabled arrow never defers or consumes a
+        // following char (which would otherwise be dropped when the insert is
+        // suppressed downstream).
+        self.stateMachine.arrowConversionEnabled = Engine.arrowConversionActive()
 
         // Click-away behaves like Esc but doesn't consume the click.
         pickerWindow.onClickAway = { [weak self] in
@@ -178,8 +183,17 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
                 self.stateMachine.symbolsDoubleColonEnabled = self.symbolsEnabled && self.symbolsRequireDoubleColon
                 let qaEnabled = (UserDefaults.standard.object(forKey: PrefsKey.quickAccessEnabled) as? Bool) ?? true
                 self.stateMachine.quickAccessTrigger = qaEnabled ? "?" : nil
+                self.stateMachine.arrowConversionEnabled = Engine.arrowConversionActive()
             }
         }
+    }
+
+    /// Arrow conversion runs only when emoticons *and* the arrow sub-toggle are
+    /// both on. Read fresh (cheap, off the keystroke path).
+    private static func arrowConversionActive() -> Bool {
+        let emoticonsOn = (UserDefaults.standard.object(forKey: PrefsKey.emoticonsEnabled) as? Bool) ?? true
+        let arrowsOn = (UserDefaults.standard.object(forKey: PrefsKey.arrowConversionEnabled) as? Bool) ?? true
+        return emoticonsOn && arrowsOn
     }
 
     deinit {
@@ -1249,7 +1263,9 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
     /// final field reads `←x` instead of `<←`.
     private func handleAmbientEmoticonImmediate(word: String, trailing: String) {
         let enabled = (UserDefaults.standard.object(forKey: PrefsKey.emoticonsEnabled) as? Bool) ?? true
-        guard enabled, let emoji = AmbientEmoticonTable.emoji(for: word) else {
+        guard enabled,
+              Engine.arrowConversionActive() || !AmbientEmoticonTable.isArrow(word),
+              let emoji = AmbientEmoticonTable.emoji(for: word) else {
             pendingEmoticonUndo = nil
             return
         }
@@ -1270,7 +1286,9 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
     /// followed by a terminator, looked up in `AmbientEmoticonTable`.
     private func handleAmbientEmoticon(word: String, terminator: Character) {
         let enabled = (UserDefaults.standard.object(forKey: PrefsKey.emoticonsEnabled) as? Bool) ?? true
-        guard enabled, let emoji = AmbientEmoticonTable.emoji(for: word) else {
+        guard enabled,
+              Engine.arrowConversionActive() || !AmbientEmoticonTable.isArrow(word),
+              let emoji = AmbientEmoticonTable.emoji(for: word) else {
             pendingEmoticonUndo = nil
             return
         }

--- a/Sources/Mojito/App/Engine.swift
+++ b/Sources/Mojito/App/Engine.swift
@@ -62,6 +62,10 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
     /// advanced when the handler fires, the user typed past us and we skip the
     /// undo entry.
     private var inputSeq: Int = 0
+    /// `inputSeq` of the most recent digit keystroke. Lets the deferred heart
+    /// insert skip itself when a digit lands immediately after (`<30`) before
+    /// the conversion (and its undo entry) has even been created.
+    private var lastDigitSeq: Int = -1
     private static let emoticonUndoWindow: TimeInterval = 3.0
     /// Chars of typed `:` to erase before a browser pick is synthesized
     /// (1 when opened from the pill's chevron, 0 from the menu).
@@ -369,6 +373,7 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
 
     private func process(input: TriggerInput) -> Bool {
         inputSeq &+= 1
+        if case .nameChar(let c) = input, c.isNumber { lastDigitSeq = inputSeq }
         // BSOD-style "press any key" effects pre-empt everything; the key is
         // consumed so it doesn't leak into the focused app underneath.
         if case .idle = stateMachine.state, EffectDismisser.topWantsAnyKey() {
@@ -397,6 +402,19 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
                 return true
             }
             return false
+        }
+
+        // `<3`→❤️ fires eagerly so a heart at the end of a message lands. If a
+        // digit follows once the heart has rendered, the user meant a number
+        // (`<30`): rebuild `<3` + the digit in one replacement and consume the
+        // key, so the restore and the digit can't interleave (the race that
+        // produced `❤️<3`). Faster follow-ups are caught by the skip in the
+        // deferred insert, before the heart renders.
+        if case .idle = stateMachine.state, case .nameChar(let c) = input, c.isNumber,
+           let undo = pendingEmoticonUndo,
+           AmbientEmoticonTable.revocableByTrailingDigit(undo.originalText),
+           performEmoticonUndoIfFresh(appending: String(c)) {
+            return true
         }
 
         // Any other keystroke closes the undo window. Otherwise the entry
@@ -569,6 +587,15 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
             let seqAtDispatch = inputSeq
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) { [weak self] in
                 guard let self else { return }
+                // `<3` typed flush before a digit (`<30`) means a number — if
+                // that digit was the very next keystroke, skip the conversion
+                // entirely so it stays literal. (A digit typed after a longer
+                // pause, once ❤️ has rendered, just yields `❤️0` — reverting it
+                // in-flight tangles with the async insert, so we don't.)
+                if AmbientEmoticonTable.revocableByTrailingDigit(word),
+                   self.lastDigitSeq == seqAtDispatch &+ 1 {
+                    return
+                }
                 self.handleAmbientEmoticonImmediate(word: word, trailing: trailing)
                 if self.inputSeq != seqAtDispatch { self.pendingEmoticonUndo = nil }
             }
@@ -1310,7 +1337,11 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
     }
 
     /// Returns true if an undo fired (caller should consume the key).
-    private func performEmoticonUndoIfFresh() -> Bool {
+    /// `appending` is tacked onto the restored original in the *same*
+    /// replacement — used by the `<30` rescue to fold the triggering digit in
+    /// atomically, so the restore can't interleave with a real keystroke.
+    @discardableResult
+    private func performEmoticonUndoIfFresh(appending suffix: String = "") -> Bool {
         guard let entry = pendingEmoticonUndo else { return false }
         if Date().timeIntervalSince(entry.insertedAt) > Self.emoticonUndoWindow {
             pendingEmoticonUndo = nil
@@ -1325,7 +1356,7 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
         // Grapheme-count, not UTF-16: macOS deletes a ZWJ sequence as one
         // backspace and TextInserter sends one per grapheme.
         let emojiLen = entry.emojiInserted.count
-        TextInserter.replace(charactersToDelete: emojiLen, with: entry.originalText)
+        TextInserter.replace(charactersToDelete: emojiLen, with: entry.originalText + suffix)
         pendingEmoticonUndo = nil
         DebugRecorder.record(.emoticon, "undo")
         return true

--- a/Sources/Mojito/EmojiDB/AmbientEmoticonTable.swift
+++ b/Sources/Mojito/EmojiDB/AmbientEmoticonTable.swift
@@ -20,11 +20,40 @@ enum AmbientEmoticonTable {
         "<-":   "←",
         "<->":  "↔",
         "=>":   "⇒",
+        "<=":   "⇐",
         "<=>":  "⇔",
     ]
 
     static func emoji(for word: String) -> String? {
         map[word]
+    }
+
+    /// The arrow family — the only ambient emoticons allowed to fire when
+    /// typed flush against text (`Foo->Bar`), matched as a trailing suffix of
+    /// the buffer. Everything else stays boundary-gated so it can't eat into
+    /// prose. Derived as the keys built solely from arrow punctuation, so it
+    /// tracks the map automatically.
+    private static let arrowChars: Set<Character> = ["-", "<", ">", "="]
+    static let arrowKeys: Set<String> = Set(map.keys.filter { $0.allSatisfy(arrowChars.contains) })
+
+    /// The longest arrow key that is a suffix of `buffer`, if any. Lets the
+    /// state machine pull `->` out of `Foo->` without a leading boundary.
+    static func arrowSuffix(of buffer: String) -> String? {
+        var best: String?
+        for key in arrowKeys where buffer.hasSuffix(key) {
+            if best == nil || key.count > best!.count { best = key }
+        }
+        return best
+    }
+
+    /// True if appending more chars to `arrow` could still reach a longer
+    /// arrow key (`<-` → `<->`, `<=` → `<=>`) — used to defer firing the
+    /// shorter match until the next keystroke decides.
+    static func hasLongerArrow(extending arrow: String) -> Bool {
+        for key in arrowKeys where key.count > arrow.count && key.hasPrefix(arrow) {
+            return true
+        }
+        return false
     }
 
     /// Fire the moment a non-alphanumeric-led entry completes (`<3`,

--- a/Sources/Mojito/EmojiDB/AmbientEmoticonTable.swift
+++ b/Sources/Mojito/EmojiDB/AmbientEmoticonTable.swift
@@ -19,9 +19,6 @@ enum AmbientEmoticonTable {
         "->":   "→",
         "<-":   "←",
         "<->":  "↔",
-        "=>":   "⇒",
-        "<=":   "⇐",
-        "<=>":  "⇔",
     ]
 
     static func emoji(for word: String) -> String? {
@@ -31,10 +28,16 @@ enum AmbientEmoticonTable {
     /// The arrow family — the only ambient emoticons allowed to fire when
     /// typed flush against text (`Foo->Bar`), matched as a trailing suffix of
     /// the buffer. Everything else stays boundary-gated so it can't eat into
-    /// prose. Derived as the keys built solely from arrow punctuation, so it
-    /// tracks the map automatically.
-    private static let arrowChars: Set<Character> = ["-", "<", ">", "="]
+    /// prose. `=`-based forms (`=>`, `<=`) are deliberately excluded: they
+    /// collide with code operators and comparisons. Derived as the keys built
+    /// solely from arrow punctuation, so it tracks the map automatically.
+    private static let arrowChars: Set<Character> = ["-", "<", ">"]
     static let arrowKeys: Set<String> = Set(map.keys.filter { $0.allSatisfy(arrowChars.contains) })
+
+    /// Whether `word` is an arrow-family key — used to gate the whole arrow
+    /// feature behind the "Convert text arrows" setting without touching the
+    /// other ambient emoticons.
+    static func isArrow(_ word: String) -> Bool { arrowKeys.contains(word) }
 
     /// The longest arrow key that is a suffix of `buffer`, if any. Lets the
     /// state machine pull `->` out of `Foo->` without a leading boundary.

--- a/Sources/Mojito/EmojiDB/AmbientEmoticonTable.swift
+++ b/Sources/Mojito/EmojiDB/AmbientEmoticonTable.swift
@@ -39,6 +39,14 @@ enum AmbientEmoticonTable {
     /// other ambient emoticons.
     static func isArrow(_ word: String) -> Bool { arrowKeys.contains(word) }
 
+    /// Emoticons that end in a digit (`<3` → ❤️, `</3` → 💔). These fire
+    /// eagerly so they land at the end of a message, but a digit typed right
+    /// after means the user meant a number (`<30`), so the Engine reverts the
+    /// conversion when that happens.
+    static func revocableByTrailingDigit(_ word: String) -> Bool {
+        (word.last?.isNumber ?? false) && map[word] != nil
+    }
+
     /// The longest arrow key that is a suffix of `buffer`, if any. Lets the
     /// state machine pull `->` out of `Foo->` without a leading boundary.
     static func arrowSuffix(of buffer: String) -> String? {

--- a/Sources/Mojito/Exclusions/DefaultExclusions.swift
+++ b/Sources/Mojito/Exclusions/DefaultExclusions.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum DefaultExclusions {
     /// Apps that already have native `:emoji:` autocomplete.
-    static let bundleIDs: [String] = [
+    static let nativeAutocompleteApps: [String] = [
         "com.tinyspeck.slackmacgap",          // Slack
         "com.hnc.Discord",                    // Discord
         "notion.id",                          // Notion (mac)
@@ -15,6 +15,43 @@ enum DefaultExclusions {
         "com.tdesktop.Telegram",              // Telegram Desktop
         "com.readdle.smartemail-Mac",         // Spark
     ]
+
+    /// Editors, IDEs, and terminals. Text-arrow conversion (`->`, `<-`)
+    /// collides with code operators (`ptr->x`, Go/R `<-`), so Mojito stays
+    /// out of dev tools by default. Folded into existing installs once via
+    /// the migration in `ExclusionStore` (see `devToolExclusionsSeeded`).
+    static let developerTools: [String] = [
+        "com.apple.dt.Xcode",                 // Xcode
+        "com.microsoft.VSCode",               // VS Code
+        "com.microsoft.VSCodeInsiders",       // VS Code Insiders
+        "com.vscodium",                       // VSCodium
+        "com.todesktop.230313mzl4w4u92",      // Cursor
+        "dev.zed.Zed",                        // Zed
+        "com.sublimetext.4",                  // Sublime Text 4
+        "com.sublimetext.3",                  // Sublime Text 3
+        "com.apple.Terminal",                 // Terminal
+        "com.googlecode.iterm2",              // iTerm2
+        "com.mitchellh.ghostty",              // Ghostty
+        "net.kovidgoyal.kitty",               // kitty
+        "io.alacritty",                       // Alacritty
+        "com.github.wez.wezterm",             // WezTerm
+        "co.zeit.hyper",                      // Hyper
+        "com.jetbrains.intellij",             // IntelliJ IDEA
+        "com.jetbrains.intellij.ce",          // IntelliJ IDEA CE
+        "com.jetbrains.pycharm",              // PyCharm
+        "com.jetbrains.pycharm.ce",           // PyCharm CE
+        "com.jetbrains.WebStorm",             // WebStorm
+        "com.jetbrains.goland",               // GoLand
+        "com.jetbrains.rubymine",             // RubyMine
+        "com.jetbrains.CLion",                // CLion
+        "com.jetbrains.PhpStorm",             // PhpStorm
+        "com.jetbrains.rider",                // Rider
+        "com.google.android.studio",          // Android Studio
+        "com.panic.Nova",                     // Nova
+    ]
+
+    /// Everything excluded by default (both rationales).
+    static let bundleIDs: [String] = nativeAutocompleteApps + developerTools
 
     /// Websites with native shortcode support.
     static let urlPatterns: [String] = [

--- a/Sources/Mojito/Exclusions/ExclusionStore.swift
+++ b/Sources/Mojito/Exclusions/ExclusionStore.swift
@@ -32,12 +32,24 @@ final class ExclusionStore: ObservableObject {
             mode = .denylist
         }
 
-        let initialBundles: Set<String>
+        var initialBundles: Set<String>
         if let raw = defaults.array(forKey: PrefsKey.excludedBundleIDs) as? [String] {
             initialBundles = Set(raw)
         } else {
             initialBundles = Set(DefaultExclusions.bundleIDs)
             defaults.set(Array(initialBundles), forKey: PrefsKey.excludedBundleIDs)
+        }
+        // One-time, additive: fold the developer-tool defaults into existing
+        // installs (new installs already got them via the seed above). Guarded
+        // so any of these a user later removes won't reappear. No-op for
+        // allowlist-mode users until they switch back to a denylist.
+        if !defaults.bool(forKey: PrefsKey.devToolExclusionsSeeded) {
+            let merged = initialBundles.union(DefaultExclusions.developerTools)
+            if merged != initialBundles {
+                initialBundles = merged
+                defaults.set(Array(initialBundles), forKey: PrefsKey.excludedBundleIDs)
+            }
+            defaults.set(true, forKey: PrefsKey.devToolExclusionsSeeded)
         }
         bundleIDs = initialBundles
 

--- a/Sources/Mojito/KeyMonitor/TriggerStateMachine.swift
+++ b/Sources/Mojito/KeyMonitor/TriggerStateMachine.swift
@@ -389,6 +389,13 @@ struct TriggerStateMachine {
             return .passthrough
 
         case (.idle, .cancelChar(let c)):
+            // A pending arrow (`<-`/`<=`) resolves against whatever comes next.
+            // A terminator can't extend it to `<->`/`<=>`, so it fires here and
+            // carries the terminator through as `trailing` — this is what makes
+            // `Foo<- ` convert (the whole-word lookup below would miss `Foo<-`).
+            if let fire = resolvePendingFire(with: c) {
+                return fire
+            }
             if Self.ambientTerminators.contains(c) {
                 // Terminator — look up the buffered word, then reset.
                 let word = idleWord
@@ -405,9 +412,6 @@ struct TriggerStateMachine {
             }
             // Non-terminator punctuation (`<`, `>`, `)`, `(`, `_`, …) is
             // part of an emoticon body. Append and keep accumulating.
-            if let fire = resolvePendingFire(with: c) {
-                return fire
-            }
             idleWord += String(c)
             lastIdleKeystrokeAt = Date()
             if let fire = checkImmediateAmbientFire() {
@@ -764,12 +768,27 @@ struct TriggerStateMachine {
     /// in `pendingImmediateFire` so the next keystroke gets the chance to
     /// reach the longer match.
     private mutating func checkImmediateAmbientFire() -> TriggerOutput? {
-        guard AmbientEmoticonTable.shouldFireImmediately(idleWord),
-              let emoji = AmbientEmoticonTable.emoji(for: idleWord) else {
-            return nil
+        // Arrows match as a trailing suffix of the buffer, so they fire flush
+        // against text (`Foo->Bar`) — the matched key is what gets deleted, so
+        // the preceding `Foo` survives. Deferral (`<-` → `<->`) carries over.
+        if let arrow = AmbientEmoticonTable.arrowSuffix(of: idleWord),
+           let emoji = AmbientEmoticonTable.emoji(for: arrow) {
+            if AmbientEmoticonTable.hasLongerArrow(extending: arrow) {
+                pendingImmediateFire = (word: arrow, emoji: emoji)
+                return nil
+            }
+            idleWord = ""
+            lastIdleKeystrokeAt = nil
+            pendingImmediateFire = nil
+            return TriggerOutput(
+                action: .insertAmbientEmoticon(word: arrow, trailing: ""),
+                consumesKey: false
+            )
         }
-        if AmbientEmoticonTable.hasLongerMatch(for: idleWord) {
-            pendingImmediateFire = (word: idleWord, emoji: emoji)
+        // Every other punctuation-led emoticon (`<3`, `</3`, `>:)`, …) still
+        // requires the whole buffer to *be* the emoticon — i.e. a leading word
+        // boundary — so it can't eat into prose (`Hi<3` stays literal).
+        guard AmbientEmoticonTable.shouldFireImmediately(idleWord) else {
             return nil
         }
         let word = idleWord
@@ -790,8 +809,10 @@ struct TriggerStateMachine {
     private mutating func resolvePendingFire(with c: Character) -> TriggerOutput? {
         guard let pending = pendingImmediateFire else { return nil }
         let combined = pending.word + String(c)
-        let extendsToward = AmbientEmoticonTable.shouldFireImmediately(combined)
-            || AmbientEmoticonTable.hasLongerMatch(for: combined)
+        // Deferred matches are always arrows; keep accumulating only if this
+        // char completes a longer arrow or still leads toward one.
+        let extendsToward = AmbientEmoticonTable.arrowKeys.contains(combined)
+            || AmbientEmoticonTable.hasLongerArrow(extending: combined)
         if extendsToward { return nil }
         let word = pending.word
         pendingImmediateFire = nil

--- a/Sources/Mojito/KeyMonitor/TriggerStateMachine.swift
+++ b/Sources/Mojito/KeyMonitor/TriggerStateMachine.swift
@@ -131,6 +131,13 @@ struct TriggerStateMachine {
     /// When true, `::` upgrades the capture to symbols-only instead of cancelling.
     var symbolsDoubleColonEnabled: Bool = false
 
+    /// Gates the arrow family (`->`, `<-`, `<->`). When false, arrows are
+    /// inert — never matched as a suffix, never deferred, never consume a
+    /// following char — so they read as plain text. The Engine sets it from
+    /// `PrefsKey.arrowConversionEnabled`. Other ambient emoticons (`<3`, …)
+    /// are unaffected.
+    var arrowConversionEnabled: Bool = true
+
     /// The character that, typed right after a bare `:`, opens the Quick Access
     /// pill (e.g. `?` → `:?`). `nil` disables it. The Engine sets it from
     /// `PrefsKey.quickAccessTriggerChar`. Must be a `.cancelChar`-class glyph
@@ -771,7 +778,8 @@ struct TriggerStateMachine {
         // Arrows match as a trailing suffix of the buffer, so they fire flush
         // against text (`Foo->Bar`) — the matched key is what gets deleted, so
         // the preceding `Foo` survives. Deferral (`<-` → `<->`) carries over.
-        if let arrow = AmbientEmoticonTable.arrowSuffix(of: idleWord),
+        if arrowConversionEnabled,
+           let arrow = AmbientEmoticonTable.arrowSuffix(of: idleWord),
            let emoji = AmbientEmoticonTable.emoji(for: arrow) {
             if AmbientEmoticonTable.hasLongerArrow(extending: arrow) {
                 pendingImmediateFire = (word: arrow, emoji: emoji)
@@ -787,8 +795,11 @@ struct TriggerStateMachine {
         }
         // Every other punctuation-led emoticon (`<3`, `</3`, `>:)`, …) still
         // requires the whole buffer to *be* the emoticon — i.e. a leading word
-        // boundary — so it can't eat into prose (`Hi<3` stays literal).
-        guard AmbientEmoticonTable.shouldFireImmediately(idleWord) else {
+        // boundary — so it can't eat into prose (`Hi<3` stays literal). Arrows
+        // are excluded here: when the toggle is on they're handled above; when
+        // off they must stay literal even though they're punctuation-led.
+        guard AmbientEmoticonTable.shouldFireImmediately(idleWord),
+              !AmbientEmoticonTable.isArrow(idleWord) else {
             return nil
         }
         let word = idleWord

--- a/Sources/Mojito/Settings/GeneralSettings.swift
+++ b/Sources/Mojito/Settings/GeneralSettings.swift
@@ -7,6 +7,7 @@ struct GeneralSettingsView: View {
     @AppStorage(PrefsKey.useFrequencyBoost) private var useFrequencyBoost: Bool = true
     @AppStorage(PrefsKey.skinTone) private var skinToneRaw: String = SkinTone.default.rawValue
     @AppStorage(PrefsKey.emoticonsEnabled) private var emoticonsEnabled: Bool = true
+    @AppStorage(PrefsKey.arrowConversionEnabled) private var arrowConversionEnabled: Bool = true
     @AppStorage(PrefsKey.symbolsEnabled) private var symbolsEnabled: Bool = false
     @AppStorage(PrefsKey.symbolsRequireDoubleColon) private var symbolsRequireDoubleColon: Bool = false
     @AppStorage(PrefsKey.gifSearchEnabled) private var gifSearchEnabled: Bool = true
@@ -62,6 +63,11 @@ struct GeneralSettingsView: View {
                     .toggleStyle(.switch)
                 Toggle("Convert emoticons (`:D` → 😃)", isOn: $emoticonsEnabled)
                     .toggleStyle(.switch)
+                if emoticonsEnabled {
+                    Toggle("Convert text arrows (`->` → →)", isOn: $arrowConversionEnabled)
+                        .toggleStyle(.switch)
+                        .padding(.leading, 20)
+                }
             }
 
             QuickAccessSection()

--- a/Sources/Mojito/Util/PrefsKey.swift
+++ b/Sources/Mojito/Util/PrefsKey.swift
@@ -14,6 +14,11 @@ enum PrefsKey {
     static let useFrequencyBoost     = "mojito.search.frequencyBoost"
     static let excludedBundleIDs     = "mojito.excludeBundleIDs"     // [String]
     static let excludedURLPatterns   = "mojito.excludeURLPatterns"   // [String]
+    /// One-time flag: developer-tool bundle IDs have been folded into the
+    /// excluded list. Lets existing installs pick up the editor/terminal
+    /// defaults once (arrow conversion collides with code operators) without
+    /// re-adding any the user later removes.
+    static let devToolExclusionsSeeded = "mojito.exclusions.devToolsSeeded"
     /// `denylist` (default) = block apps/sites in the excluded lists.
     /// `allowlist` = block everything except apps/sites in the allowed lists.
     /// In allowlist mode a URL-pattern match implicitly allows the browser
@@ -38,6 +43,9 @@ enum PrefsKey {
     static let skinTone              = "mojito.skinTone"
     /// `:D` → 😃 conversion.
     static let emoticonsEnabled      = "mojito.emoticonsEnabled"
+    /// Sub-toggle of `emoticonsEnabled`: text-arrow conversion (`->` → →,
+    /// `<-` → ←, `<->` → ↔). Default on; off leaves arrows as literal text.
+    static let arrowConversionEnabled = "mojito.arrowConversionEnabled"
     /// Experimental Symbols (★ ⌘ ⌥ …) included in fuzzy search.
     static let symbolsEnabled        = "mojito.symbolsEnabled"
     /// `:foo` = emoji only; `::foo` = symbols. Keeps the noisy symbols

--- a/Tests/MojitoTests/AmbientEmoticonTableTests.swift
+++ b/Tests/MojitoTests/AmbientEmoticonTableTests.swift
@@ -56,6 +56,18 @@ struct AmbientEmoticonTableTests {
         #expect(!AmbientEmoticonTable.hasLongerArrow(extending: "<->"))
     }
 
+    @Test func revocableByTrailingDigitCoversOnlyHearts() {
+        // Drives the `<30` rescue: a digit right after these reverts the
+        // conversion. Only the digit-ending hearts qualify.
+        #expect(AmbientEmoticonTable.revocableByTrailingDigit("<3"))
+        #expect(AmbientEmoticonTable.revocableByTrailingDigit("</3"))
+        #expect(!AmbientEmoticonTable.revocableByTrailingDigit("->"))
+        #expect(!AmbientEmoticonTable.revocableByTrailingDigit(">:)"))
+        #expect(!AmbientEmoticonTable.revocableByTrailingDigit("XD"))
+        // Not a known emoticon, even though it ends in a digit.
+        #expect(!AmbientEmoticonTable.revocableByTrailingDigit("<30"))
+    }
+
     @Test func caseVariantsAreSeparateKeys() {
         // "XD"/"xD" are registered; "Xd"/"xd" are not.
         #expect(AmbientEmoticonTable.emoji(for: "Xd") == nil)

--- a/Tests/MojitoTests/AmbientEmoticonTableTests.swift
+++ b/Tests/MojitoTests/AmbientEmoticonTableTests.swift
@@ -20,27 +20,31 @@ struct AmbientEmoticonTableTests {
         #expect(AmbientEmoticonTable.emoji(for: "->") == "→")
         #expect(AmbientEmoticonTable.emoji(for: "<-") == "←")
         #expect(AmbientEmoticonTable.emoji(for: "<->") == "↔")
-        #expect(AmbientEmoticonTable.emoji(for: "=>") == "⇒")
-        #expect(AmbientEmoticonTable.emoji(for: "<=") == "⇐")
-        #expect(AmbientEmoticonTable.emoji(for: "<=>") == "⇔")
+        // `=`-based arrows are intentionally NOT mapped — they collide with
+        // code operators and comparisons (`<=`, `=>`, spaceship `<=>`).
+        #expect(AmbientEmoticonTable.emoji(for: "=>") == nil)
+        #expect(AmbientEmoticonTable.emoji(for: "<=") == nil)
+        #expect(AmbientEmoticonTable.emoji(for: "<=>") == nil)
     }
 
-    @Test func arrowKeysAreJustThePunctuationArrows() {
-        // Derived from the map — only keys built solely from arrow punctuation.
-        #expect(AmbientEmoticonTable.arrowKeys == ["->", "<-", "<->", "=>", "<=", "<=>"])
+    @Test func arrowKeysAreJustTheHyphenArrows() {
+        // Derived from the map — only keys built solely from `- < >`.
+        #expect(AmbientEmoticonTable.arrowKeys == ["->", "<-", "<->"])
         // Hearts / smileys are NOT arrows even though they're punctuation-led.
         #expect(!AmbientEmoticonTable.arrowKeys.contains("<3"))
         #expect(!AmbientEmoticonTable.arrowKeys.contains("</3"))
         #expect(!AmbientEmoticonTable.arrowKeys.contains(">:)"))
+        #expect(AmbientEmoticonTable.isArrow("->"))
+        #expect(!AmbientEmoticonTable.isArrow("<3"))
     }
 
     @Test func arrowSuffixPullsTrailingArrowOutOfABuffer() {
         // The whole point of the fix: find the arrow at the end of `Foo->`.
         #expect(AmbientEmoticonTable.arrowSuffix(of: "Foo->") == "->")
         #expect(AmbientEmoticonTable.arrowSuffix(of: "Foo<->") == "<->")  // longest wins
-        #expect(AmbientEmoticonTable.arrowSuffix(of: "Foo<=") == "<=")
-        // No trailing arrow → nil (incomplete `<`, or plain prose).
+        // No trailing arrow → nil (incomplete `<`, dropped `=`-arrow, prose).
         #expect(AmbientEmoticonTable.arrowSuffix(of: "Foo<") == nil)
+        #expect(AmbientEmoticonTable.arrowSuffix(of: "Foo<=") == nil)
         #expect(AmbientEmoticonTable.arrowSuffix(of: "hello") == nil)
         // A non-arrow punctuation emoticon is not pulled as a suffix.
         #expect(AmbientEmoticonTable.arrowSuffix(of: "Hi<3") == nil)
@@ -48,11 +52,8 @@ struct AmbientEmoticonTableTests {
 
     @Test func hasLongerArrowDefersOnlyTheExtendableArrows() {
         #expect(AmbientEmoticonTable.hasLongerArrow(extending: "<-"))   // → <->
-        #expect(AmbientEmoticonTable.hasLongerArrow(extending: "<="))   // → <=>
         #expect(!AmbientEmoticonTable.hasLongerArrow(extending: "->"))
-        #expect(!AmbientEmoticonTable.hasLongerArrow(extending: "=>"))
         #expect(!AmbientEmoticonTable.hasLongerArrow(extending: "<->"))
-        #expect(!AmbientEmoticonTable.hasLongerArrow(extending: "<=>"))
     }
 
     @Test func caseVariantsAreSeparateKeys() {
@@ -73,8 +74,6 @@ struct AmbientEmoticonTableTests {
         #expect(AmbientEmoticonTable.shouldFireImmediately("->"))
         #expect(AmbientEmoticonTable.shouldFireImmediately("<-"))
         #expect(AmbientEmoticonTable.shouldFireImmediately("<->"))
-        #expect(AmbientEmoticonTable.shouldFireImmediately("=>"))
-        #expect(AmbientEmoticonTable.shouldFireImmediately("<=>"))
     }
 
     @Test func hasLongerMatchFindsTableExtensions() {
@@ -83,16 +82,12 @@ struct AmbientEmoticonTableTests {
         #expect(AmbientEmoticonTable.hasLongerMatch(for: "<-"))
         // `>` has both `>:)` and `>:(` as longer entries.
         #expect(AmbientEmoticonTable.hasLongerMatch(for: ">"))
-        // `<=` isn't itself in the table but extends to `<=>`.
-        #expect(AmbientEmoticonTable.hasLongerMatch(for: "<="))
     }
 
     @Test func hasLongerMatchReturnsFalseForTerminalEntries() {
         // No table key strictly extends these.
         #expect(!AmbientEmoticonTable.hasLongerMatch(for: "<->"))
-        #expect(!AmbientEmoticonTable.hasLongerMatch(for: "<=>"))
         #expect(!AmbientEmoticonTable.hasLongerMatch(for: "->"))
-        #expect(!AmbientEmoticonTable.hasLongerMatch(for: "=>"))
         #expect(!AmbientEmoticonTable.hasLongerMatch(for: ""))
     }
 

--- a/Tests/MojitoTests/AmbientEmoticonTableTests.swift
+++ b/Tests/MojitoTests/AmbientEmoticonTableTests.swift
@@ -21,7 +21,38 @@ struct AmbientEmoticonTableTests {
         #expect(AmbientEmoticonTable.emoji(for: "<-") == "←")
         #expect(AmbientEmoticonTable.emoji(for: "<->") == "↔")
         #expect(AmbientEmoticonTable.emoji(for: "=>") == "⇒")
+        #expect(AmbientEmoticonTable.emoji(for: "<=") == "⇐")
         #expect(AmbientEmoticonTable.emoji(for: "<=>") == "⇔")
+    }
+
+    @Test func arrowKeysAreJustThePunctuationArrows() {
+        // Derived from the map — only keys built solely from arrow punctuation.
+        #expect(AmbientEmoticonTable.arrowKeys == ["->", "<-", "<->", "=>", "<=", "<=>"])
+        // Hearts / smileys are NOT arrows even though they're punctuation-led.
+        #expect(!AmbientEmoticonTable.arrowKeys.contains("<3"))
+        #expect(!AmbientEmoticonTable.arrowKeys.contains("</3"))
+        #expect(!AmbientEmoticonTable.arrowKeys.contains(">:)"))
+    }
+
+    @Test func arrowSuffixPullsTrailingArrowOutOfABuffer() {
+        // The whole point of the fix: find the arrow at the end of `Foo->`.
+        #expect(AmbientEmoticonTable.arrowSuffix(of: "Foo->") == "->")
+        #expect(AmbientEmoticonTable.arrowSuffix(of: "Foo<->") == "<->")  // longest wins
+        #expect(AmbientEmoticonTable.arrowSuffix(of: "Foo<=") == "<=")
+        // No trailing arrow → nil (incomplete `<`, or plain prose).
+        #expect(AmbientEmoticonTable.arrowSuffix(of: "Foo<") == nil)
+        #expect(AmbientEmoticonTable.arrowSuffix(of: "hello") == nil)
+        // A non-arrow punctuation emoticon is not pulled as a suffix.
+        #expect(AmbientEmoticonTable.arrowSuffix(of: "Hi<3") == nil)
+    }
+
+    @Test func hasLongerArrowDefersOnlyTheExtendableArrows() {
+        #expect(AmbientEmoticonTable.hasLongerArrow(extending: "<-"))   // → <->
+        #expect(AmbientEmoticonTable.hasLongerArrow(extending: "<="))   // → <=>
+        #expect(!AmbientEmoticonTable.hasLongerArrow(extending: "->"))
+        #expect(!AmbientEmoticonTable.hasLongerArrow(extending: "=>"))
+        #expect(!AmbientEmoticonTable.hasLongerArrow(extending: "<->"))
+        #expect(!AmbientEmoticonTable.hasLongerArrow(extending: "<=>"))
     }
 
     @Test func caseVariantsAreSeparateKeys() {

--- a/Tests/MojitoTests/TriggerStateMachineTests.swift
+++ b/Tests/MojitoTests/TriggerStateMachineTests.swift
@@ -452,15 +452,16 @@ struct TriggerStateMachineTests {
     }
 
     @Test func ambientLeftArrowFiresOnTerminator() {
-        // Space after `<-` resolves the pending fire through the normal
-        // terminator path — the Engine's `checkAmbientEmoticon` finds
-        // `<-` in the table and replaces with `← `.
+        // A space can't extend `<-` to `<->`, so the deferred fire resolves
+        // immediately: the arrow is emitted and the terminator rides along as
+        // `trailing` (→ `← `). The space is consumed and re-emitted by the
+        // Engine, hence consumesKey == true.
         var sm = TriggerStateMachine()
         _ = sm.handle(.cancelChar("<"))
         _ = sm.handle(.nameChar("-"))
         let out = sm.handle(.cancelChar(" "))
-        #expect(out.action == .checkAmbientEmoticon(word: "<-", terminator: " "))
-        #expect(out.consumesKey == false)
+        #expect(out.action == .insertAmbientEmoticon(word: "<-", trailing: " "))
+        #expect(out.consumesKey == true)
     }
 
     @Test func ambientDoubleArrowFiresOnEqualsGreaterThan() {
@@ -472,14 +473,74 @@ struct TriggerStateMachineTests {
     }
 
     @Test func ambientLeftRightDoubleArrowAccumulatesFreely() {
-        // `<=` isn't in the table, so the buffer accumulates without a
-        // deferral and `<=>` fires once it completes.
+        // `<=` is itself an arrow (`⇐`) but defers because `<=>` (`⇔`) extends
+        // it — so the `=` holds the fire pending, and the trailing `>` resolves
+        // to the longer `<=>`.
         var sm = TriggerStateMachine()
         _ = sm.handle(.cancelChar("<"))
         let mid = sm.handle(.cancelChar("="))
         #expect(mid.action == .none)
         let out = sm.handle(.cancelChar(">"))
         #expect(out.action == .insertAmbientEmoticon(word: "<=>", trailing: ""))
+    }
+
+    @Test func ambientLeftDoubleArrowFiresWithTrailingOnNonExtendingChar() {
+        // `<=` deferred for `<=>`; a non-extending char collapses it to `⇐`
+        // and carries the char as trailing (parallels `<-` → `←x`).
+        var sm = TriggerStateMachine()
+        _ = sm.handle(.cancelChar("<"))
+        _ = sm.handle(.cancelChar("="))
+        let out = sm.handle(.nameChar("x"))
+        #expect(out.action == .insertAmbientEmoticon(word: "<=", trailing: "x"))
+        #expect(out.consumesKey == true)
+    }
+
+    // MARK: ambient arrows flush against text (no surrounding spaces)
+
+    /// Type a string char-by-char from idle, classifying each char the way the
+    /// KeyMonitor would (name chars vs. cancel chars), and return the last
+    /// non-passthrough action seen. Lets the adjacency tests read as the
+    /// literal thing the user types.
+    private func lastAmbientAction(typing text: String) -> TriggerAction {
+        var sm = TriggerStateMachine()
+        var last: TriggerAction = .none
+        let nameChars = Set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-+")
+        for ch in text {
+            let out = nameChars.contains(ch) ? sm.handle(.nameChar(ch)) : sm.handle(.cancelChar(ch))
+            if out.action != .none { last = out.action }
+        }
+        return last
+    }
+
+    @Test func ambientRightArrowFiresFlushAfterWord() {
+        // `Foo->` with no leading space: the `->` is pulled off the end and
+        // only those two chars are deleted, leaving `Foo`.
+        #expect(lastAmbientAction(typing: "Foo->") == .insertAmbientEmoticon(word: "->", trailing: ""))
+    }
+
+    @Test func ambientDoubleArrowFiresFlushAfterWord() {
+        #expect(lastAmbientAction(typing: "Foo=>") == .insertAmbientEmoticon(word: "=>", trailing: ""))
+    }
+
+    @Test func ambientLeftRightArrowFiresFlushAfterWord() {
+        // `Foo<->` → the deferred `<-` extends to `<->` and fires `↔`.
+        #expect(lastAmbientAction(typing: "Foo<->") == .insertAmbientEmoticon(word: "<->", trailing: ""))
+    }
+
+    @Test func ambientLeftArrowFiresFlushBetweenWords() {
+        // `Foo<-B`: `<-` defers, then the `B` (non-extending) collapses it to
+        // `←` carrying `B` as trailing — `Foo←B`.
+        #expect(lastAmbientAction(typing: "Foo<-B") == .insertAmbientEmoticon(word: "<-", trailing: "B"))
+    }
+
+    @Test func ambientLeftDoubleArrowFiresFlushBetweenWords() {
+        #expect(lastAmbientAction(typing: "Foo<=B") == .insertAmbientEmoticon(word: "<=", trailing: "B"))
+    }
+
+    @Test func nonArrowEmoticonStaysBoundaryGatedFlushAfterWord() {
+        // Per the chosen scope (arrows only), `<3` flush against a word does
+        // NOT fire — `Hi<3` stays literal.
+        #expect(lastAmbientAction(typing: "Hi<3") == .none)
     }
 
     @Test func ambientTerminatorChecksWordThenResetsBuffer() {

--- a/Tests/MojitoTests/TriggerStateMachineTests.swift
+++ b/Tests/MojitoTests/TriggerStateMachineTests.swift
@@ -464,35 +464,16 @@ struct TriggerStateMachineTests {
         #expect(out.consumesKey == true)
     }
 
-    @Test func ambientDoubleArrowFiresOnEqualsGreaterThan() {
+    @Test func ambientEqualsArrowsAreInert() {
+        // `=`-based arrows are deliberately unmapped (code-operator collisions),
+        // so `=>` / `<=` / `<=>` accumulate and never convert.
         var sm = TriggerStateMachine()
         _ = sm.handle(.cancelChar("="))
-        let out = sm.handle(.cancelChar(">"))
-        #expect(out.action == .insertAmbientEmoticon(word: "=>", trailing: ""))
-        #expect(out.consumesKey == false)
-    }
-
-    @Test func ambientLeftRightDoubleArrowAccumulatesFreely() {
-        // `<=` is itself an arrow (`⇐`) but defers because `<=>` (`⇔`) extends
-        // it — so the `=` holds the fire pending, and the trailing `>` resolves
-        // to the longer `<=>`.
-        var sm = TriggerStateMachine()
-        _ = sm.handle(.cancelChar("<"))
-        let mid = sm.handle(.cancelChar("="))
-        #expect(mid.action == .none)
-        let out = sm.handle(.cancelChar(">"))
-        #expect(out.action == .insertAmbientEmoticon(word: "<=>", trailing: ""))
-    }
-
-    @Test func ambientLeftDoubleArrowFiresWithTrailingOnNonExtendingChar() {
-        // `<=` deferred for `<=>`; a non-extending char collapses it to `⇐`
-        // and carries the char as trailing (parallels `<-` → `←x`).
-        var sm = TriggerStateMachine()
+        #expect(sm.handle(.cancelChar(">")).action == .none)        // =>
+        sm = TriggerStateMachine()
         _ = sm.handle(.cancelChar("<"))
         _ = sm.handle(.cancelChar("="))
-        let out = sm.handle(.nameChar("x"))
-        #expect(out.action == .insertAmbientEmoticon(word: "<=", trailing: "x"))
-        #expect(out.consumesKey == true)
+        #expect(sm.handle(.cancelChar(">")).action == .none)        // <=>
     }
 
     // MARK: ambient arrows flush against text (no surrounding spaces)
@@ -518,10 +499,6 @@ struct TriggerStateMachineTests {
         #expect(lastAmbientAction(typing: "Foo->") == .insertAmbientEmoticon(word: "->", trailing: ""))
     }
 
-    @Test func ambientDoubleArrowFiresFlushAfterWord() {
-        #expect(lastAmbientAction(typing: "Foo=>") == .insertAmbientEmoticon(word: "=>", trailing: ""))
-    }
-
     @Test func ambientLeftRightArrowFiresFlushAfterWord() {
         // `Foo<->` → the deferred `<-` extends to `<->` and fires `↔`.
         #expect(lastAmbientAction(typing: "Foo<->") == .insertAmbientEmoticon(word: "<->", trailing: ""))
@@ -533,14 +510,33 @@ struct TriggerStateMachineTests {
         #expect(lastAmbientAction(typing: "Foo<-B") == .insertAmbientEmoticon(word: "<-", trailing: "B"))
     }
 
-    @Test func ambientLeftDoubleArrowFiresFlushBetweenWords() {
-        #expect(lastAmbientAction(typing: "Foo<=B") == .insertAmbientEmoticon(word: "<=", trailing: "B"))
-    }
-
     @Test func nonArrowEmoticonStaysBoundaryGatedFlushAfterWord() {
         // Per the chosen scope (arrows only), `<3` flush against a word does
         // NOT fire — `Hi<3` stays literal.
         #expect(lastAmbientAction(typing: "Hi<3") == .none)
+    }
+
+    @Test func arrowConversionToggleMakesArrowsInert() {
+        // With the sub-toggle off, arrows neither fire nor defer/consume — but
+        // other ambient emoticons keep working.
+        var sm = TriggerStateMachine()
+        sm.arrowConversionEnabled = false
+        _ = sm.handle(.nameChar("-"))
+        #expect(sm.handle(.cancelChar(">")).action == .none)        // -> inert
+        sm = TriggerStateMachine()
+        sm.arrowConversionEnabled = false
+        _ = sm.handle(.cancelChar("<"))
+        let dash = sm.handle(.nameChar("-"))
+        #expect(dash.action == .none)                                // no defer
+        #expect(dash.consumesKey == false)                           // no consume
+        let x = sm.handle(.nameChar("x"))
+        #expect(x.action == .none)                                   // <-x stays literal
+        #expect(x.consumesKey == false)
+        // Heart still fires regardless of the arrow toggle.
+        sm = TriggerStateMachine()
+        sm.arrowConversionEnabled = false
+        _ = sm.handle(.cancelChar("<"))
+        #expect(sm.handle(.nameChar("3")).action == .insertAmbientEmoticon(word: "<3", trailing: ""))
     }
 
     @Test func ambientTerminatorChecksWordThenResetsBuffer() {


### PR DESCRIPTION
## What
Ambient arrow emoticons only converted when space-delimited (`Foo -> Bar`); typed flush against text (`Foo->Bar`) they didn't fire. The state machine matched the whole buffer since the last terminator and only fired when its first char was non-letter, so a leading space was required to isolate the arrow.

## Changes
- **Suffix matching** for the arrow family — arrows fire flush against text; only the arrow is deleted, the preceding text survives. `<-`→`<->` deferral carries over (and now resolves against a terminator too).
- **Scoped to hyphen arrows** `-> ← <->`. Dropped the `=`-based forms (`=>`, `<=`, `<=>`) — they collide with code operators / comparisons (`<=`, `=>`, spaceship, `<<=`).
- Non-arrow emoticons (`<3`, `>:)`, …) stay boundary-gated (unchanged).
- **"Convert text arrows" sub-toggle** under Convert emoticons (Settings ▸ General), default on. Gated in the state machine so a disabled arrow never defers/consumes a following char.
- **Default dev-tool exclusions** (Xcode, VS Code, Cursor, Zed, Sublime, JetBrains suite, Terminal, iTerm, Ghostty, kitty, Alacritty, WezTerm, Hyper, Android Studio, Nova). New installs seed them; existing installs get a one-time additive merge guarded by `devToolExclusionsSeeded`.
- **`<3` vs `<30` rescue**: `<3`→❤️ fires eagerly (so a heart at the end of a message lands), but a following digit means a number — fast path skips the conversion, slow path rebuilds `<3`+digit atomically.

## Test plan
- `xcodebuild test` — 181 pass (adjacency, hyphen-only mappings, `=`-arrow inertness, arrow toggle, `<3` rescue helper).
- Manual: `Foo->Bar`/`Foo<-Bar`/`Foo<->Bar` convert; `<30`/`<30 minutes`/`<3000` stay numbers; `<3` alone → ❤️; arrow toggle off leaves arrows literal; dev-tool apps excluded.

Known follow-up: W-323 (insertion races a fast-following keystroke — pre-existing, edge case).

Refs: W-320