### PR TITLE
W-319: Click the discovery banner to reveal that egg in Settings

### DIFF
--- a/Mojito.xcodeproj/project.pbxproj
+++ b/Mojito.xcodeproj/project.pbxproj
@@ -123,6 +123,7 @@
 		C892E976ED36AA1810770521 /* CeleryMan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 947CA35F448BC012E3F73860 /* CeleryMan.swift */; };
 		C8F9762D99C984ABBB63A2BE /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = 1BA5A32889912268FF08AB30 /* AppIcon.icon */; };
 		CA1857DDE9F106C6CCB3FD2F /* v09.bin in Resources */ = {isa = PBXBuildFile; fileRef = 4F4CFB098FFC29AB8C8B9855 /* v09.bin */; };
+		CA31BF29EEEA9CC0D89637E4 /* SettingsNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9407B4350C7E77A3EABDEA /* SettingsNavigator.swift */; };
 		CA9FE651B042EFCC920407D5 /* ImageBlob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74DB9192DF20F83CAD8A820C /* ImageBlob.swift */; };
 		CEAF9DB89294B0652A8A16F7 /* PrivacyPermissionsSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CD240E9450366313F15198 /* PrivacyPermissionsSettings.swift */; };
 		D4E80136FD448E4ACC27EC58 /* QuickAccessSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F51678D17218A59CCE7DF9 /* QuickAccessSettings.swift */; };
@@ -323,6 +324,7 @@
 		FACE9E8BAF08240551D5237A /* v06.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; path = v06.bin; sourceTree = "<group>"; };
 		FDE7F8DEA98F385943A30B78 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		FE5EDBB8F234B21B8D4A3324 /* FzyScorer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FzyScorer.swift; sourceTree = "<group>"; };
+		FF9407B4350C7E77A3EABDEA /* SettingsNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNavigator.swift; sourceTree = "<group>"; };
 		FFC142D2205F1C089F7524D2 /* SettingsRoot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRoot.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -368,6 +370,7 @@
 				B3154DBEA72DA316E341C440 /* GeneralSettings.swift */,
 				C7CD240E9450366313F15198 /* PrivacyPermissionsSettings.swift */,
 				A5F51678D17218A59CCE7DF9 /* QuickAccessSettings.swift */,
+				FF9407B4350C7E77A3EABDEA /* SettingsNavigator.swift */,
 				FFC142D2205F1C089F7524D2 /* SettingsRoot.swift */,
 				ABF01308E9212227B8106776 /* SettingsWindowController.swift */,
 			);
@@ -920,6 +923,7 @@
 				1A80F47103BB59733D6292B7 /* QuickAccessStore.swift in Sources */,
 				FD15928FE17F78588821135E /* Rickroll.swift in Sources */,
 				41765C78ED90EB005C04E63B /* SeasonalGates.swift in Sources */,
+				CA31BF29EEEA9CC0D89637E4 /* SettingsNavigator.swift in Sources */,
 				DCE52DEE8C9CEC354443E7DB /* SettingsRoot.swift in Sources */,
 				155360187C1F8C68452934E7 /* SettingsWindowController.swift in Sources */,
 				6607717F2E4D11B5563F8184 /* Shortcuts.swift in Sources */,

--- a/Sources/Mojito/App/AchievementBanner.swift
+++ b/Sources/Mojito/App/AchievementBanner.swift
@@ -54,12 +54,18 @@ enum AchievementBanner {
         panel.backgroundColor = .clear
         panel.hasShadow = false  // SwiftUI draws its own shadow under the capsule
         panel.alphaValue = 1.0
-        panel.ignoresMouseEvents = true
+        // Clickable: only the pill takes hits (it sets its own content shape);
+        // the transparent margin reports no SwiftUI hit, so clicks there fall
+        // through to whatever is underneath.
+        panel.ignoresMouseEvents = false
         panel.level = NSWindow.Level(Int(CGWindowLevelForKey(.popUpMenuWindow)))
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle, .stationary]
 
         let controller = BannerController()
-        let host = NSHostingView(rootView: BannerView(egg: egg, controller: controller))
+        let host = NSHostingView(rootView: BannerView(egg: egg, controller: controller, onTap: {
+            NotificationCenter.default.post(name: .mojitoRevealEasterEgg, object: egg.rawValue)
+            beginExit(panel, controller)
+        }))
         host.translatesAutoresizingMaskIntoConstraints = false
         let container = NSView(frame: NSRect(origin: .zero, size: panelSize))
         container.addSubview(host)
@@ -74,21 +80,27 @@ enum AchievementBanner {
         currentPanel = panel
 
         // Entry + exit are both SwiftUI-driven scale springs in BannerView.
-        // After the hold, flip `visible` to false to play the shrink-down,
-        // then order the panel out once the spring has settled.
+        // After the hold, play the shrink-down and order the panel out. A
+        // click on the pill can call `beginExit` earlier; the guard inside
+        // makes the later hold-timer fire a no-op.
         DispatchQueue.main.asyncAfter(deadline: .now() + holdDuration) {
+            MainActor.assumeIsolated { beginExit(panel, controller) }
+        }
+    }
+
+    /// Plays the shrink-down, orders the panel out, and advances the queue.
+    /// Reentrancy-safe: claims `currentPanel` immediately so a second call
+    /// (click racing the hold timer, or a double-click) is a no-op.
+    private static func beginExit(_ panel: NSPanel, _ controller: BannerController) {
+        guard currentPanel === panel else { return }
+        currentPanel = nil
+        withAnimation(.easeIn(duration: 0.22)) {
+            controller.visible = false
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + exitDuration) {
             MainActor.assumeIsolated {
-                guard currentPanel === panel else { return }
-                withAnimation(.easeIn(duration: 0.22)) {
-                    controller.visible = false
-                }
-                DispatchQueue.main.asyncAfter(deadline: .now() + exitDuration) {
-                    MainActor.assumeIsolated {
-                        panel.orderOut(nil)
-                        if currentPanel === panel { currentPanel = nil }
-                        showNext()
-                    }
-                }
+                panel.orderOut(nil)
+                showNext()
             }
         }
     }
@@ -97,8 +109,9 @@ enum AchievementBanner {
 private struct BannerView: View {
     let egg: EasterEgg
     @ObservedObject var controller: BannerController
+    let onTap: () -> Void
 
-    var body: some View {
+    private var pill: some View {
         HStack(spacing: 8) {
             Text(egg.emojiGlyph ?? "🎉")
                 .font(.system(size: 20))
@@ -122,16 +135,25 @@ private struct BannerView: View {
                 .shadow(color: .black.opacity(0.25), radius: 8, y: 2)
         )
         .fixedSize()  // pill width hugs content
-        // Bouncy scale-pop in/out from center. Both axes scale together so
-        // the pill grows from a tiny dot into its resting size with an
-        // elastic overshoot, and shrinks back to a dot on dismiss.
-        .scaleEffect(controller.visible ? 1.0 : 0.0, anchor: .center)
-        .opacity(controller.visible ? 1.0 : 0.0)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)  // center pill within the oversized panel stage
-        .onAppear {
-            withAnimation(.spring(response: 0.42, dampingFraction: 0.55)) {
-                controller.visible = true
+        .contentShape(Capsule())  // hits confined to the pill, not the margin
+    }
+
+    var body: some View {
+        pill
+            .onTapGesture { onTap() }
+            .onHover { inside in
+                if inside { NSCursor.pointingHand.set() } else { NSCursor.arrow.set() }
             }
-        }
+            // Bouncy scale-pop in/out from center. Both axes scale together so
+            // the pill grows from a tiny dot into its resting size with an
+            // elastic overshoot, and shrinks back to a dot on dismiss.
+            .scaleEffect(controller.visible ? 1.0 : 0.0, anchor: .center)
+            .opacity(controller.visible ? 1.0 : 0.0)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)  // center pill within the oversized panel stage
+            .onAppear {
+                withAnimation(.spring(response: 0.42, dampingFraction: 0.55)) {
+                    controller.visible = true
+                }
+            }
     }
 }

--- a/Sources/Mojito/App/AppDelegate.swift
+++ b/Sources/Mojito/App/AppDelegate.swift
@@ -111,6 +111,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in self?.engine.showBrowser() }
             .store(in: &observers)
+
+        // Discovery banner click: open Settings, then ask the navigator to
+        // reveal the egg. Order matters — open first so a fresh window's
+        // views mount and pick up the (already-set) reveal request on appear.
+        NotificationCenter.default.publisher(for: .mojitoRevealEasterEgg)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] note in
+                self?.openSettings()
+                if let id = note.object as? String {
+                    SettingsNavigator.shared.revealEgg(id)
+                }
+            }
+            .store(in: &observers)
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/Sources/Mojito/Settings/EasterEggsSettings.swift
+++ b/Sources/Mojito/Settings/EasterEggsSettings.swift
@@ -6,6 +6,10 @@ struct EasterEggsSettingsView: View {
     @EnvironmentObject private var engine: Engine
     /// Bumped on `.easterEggDiscovered` so the section re-renders while open.
     @State private var easterEggsTick: Int = 0
+    @ObservedObject private var nav = SettingsNavigator.shared
+    /// Row currently flashing (banner-click reveal), and its animated tint.
+    @State private var flashEgg: String?
+    @State private var flashOpacity: Double = 0
 
     private let rowPadding: CGFloat = 2
 
@@ -24,24 +28,54 @@ struct EasterEggsSettingsView: View {
     }
 
     var body: some View {
-        Form {
-            Section("Stats") {
-                LabeledContent("User since", value: firstLaunchDate)
+        ScrollViewReader { proxy in
+            Form {
+                Section("Stats") {
+                    LabeledContent("User since", value: firstLaunchDate)
+                        .padding(.vertical, rowPadding)
+                    LabeledContent("Emoji autocompleted", value: "\(totalAutocompleted)")
+                        .padding(.vertical, rowPadding)
+                    HStack {
+                        Text("Danger zone")
+                        Spacer()
+                        ClearStatsButton(isDisabled: totalAutocompleted == 0)
+                    }
                     .padding(.vertical, rowPadding)
-                LabeledContent("Emoji autocompleted", value: "\(totalAutocompleted)")
-                    .padding(.vertical, rowPadding)
-                HStack {
-                    Text("Danger zone")
-                    Spacer()
-                    ClearStatsButton(isDisabled: totalAutocompleted == 0)
                 }
-                .padding(.vertical, rowPadding)
-            }
 
-            easterEggsSection
+                easterEggsSection
+            }
+            .formStyle(.grouped)
+            .scrollContentBackground(.hidden)
+            .onAppear { consumeReveal(proxy) }
+            .onChange(of: nav.reveal) { _, _ in consumeReveal(proxy) }
         }
-        .formStyle(.grouped)
-        .scrollContentBackground(.hidden)
+    }
+
+    /// Scroll the banner-clicked egg into view and flash its row. A no-op
+    /// unless `SettingsNavigator` has a pending reveal for a visible egg;
+    /// clears the request once handled so it doesn't re-fire.
+    private func consumeReveal(_ proxy: ScrollViewProxy) {
+        guard let request = nav.reveal else { return }
+        nav.reveal = nil
+        let id = request.eggID
+        guard EasterEggTracker.visibleCases.contains(where: { $0.id == id }) else { return }
+        // Defer a tick so a freshly-mounted list has laid out its rows.
+        DispatchQueue.main.async {
+            withAnimation(.easeInOut(duration: 0.35)) {
+                proxy.scrollTo(id, anchor: .center)
+            }
+            // Commit the lit tint first; animate it away on the next tick so
+            // the two state writes don't coalesce into a no-op render.
+            flashEgg = id
+            flashOpacity = 0.5
+            DispatchQueue.main.async {
+                // Ends dim: 0.5 → 0 → 0.5 → 0 (odd count settles on the target).
+                withAnimation(.easeInOut(duration: 0.5).repeatCount(3, autoreverses: true)) {
+                    flashOpacity = 0
+                }
+            }
+        }
     }
 
     // MARK: - Easter eggs
@@ -60,6 +94,8 @@ struct EasterEggsSettingsView: View {
                 easterEggRow(egg, discovered: EasterEggTracker.isDiscovered(egg))
                     .padding(.vertical, rowPadding)
                     .padding(.leading, EasterEggTracker.isChildKeyword(egg) ? 20 : 0)
+                    .background(flashBackground(for: egg))
+                    .id(egg.id)
             }
             HStack {
                 Text("Danger zone")
@@ -77,6 +113,17 @@ struct EasterEggsSettingsView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .easterEggDiscovered)) { _ in
             easterEggsTick &+= 1
+        }
+    }
+
+    /// Transient tint behind a row being revealed from a banner click.
+    @ViewBuilder
+    private func flashBackground(for egg: EasterEgg) -> some View {
+        if flashEgg == egg.id {
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(Color.accentColor.opacity(flashOpacity))
+                .padding(.horizontal, -8)
+                .allowsHitTesting(false)
         }
     }
 

--- a/Sources/Mojito/Settings/SettingsNavigator.swift
+++ b/Sources/Mojito/Settings/SettingsNavigator.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+/// Cross-cutting navigation requests into the Settings window. Right now the
+/// only request is "reveal this egg": select the Easter eggs tab, scroll the
+/// row into view, and flash it. Driven from the discovery banner (which posts
+/// `.mojitoRevealEasterEgg`, forwarded by `AppDelegate`) so a freshly found
+/// egg is one click from its Settings entry.
+///
+/// Requests are *consumed* (cleared back to nil) by the views that apply them,
+/// so opening Settings the normal way still lands on the default tab and never
+/// re-triggers a stale flash.
+@MainActor
+final class SettingsNavigator: ObservableObject {
+    static let shared = SettingsNavigator()
+
+    /// Egg to scroll-to-and-flash. The nonce lets the *same* egg re-trigger a
+    /// flash on a second click (the id alone wouldn't change).
+    struct Reveal: Equatable {
+        let eggID: String
+        let nonce: Int
+    }
+
+    @Published var requestedTab: SettingsRoot.Tab?
+    @Published var reveal: Reveal?
+
+    private var nonce = 0
+
+    func revealEgg(_ id: String) {
+        nonce += 1
+        requestedTab = .easterEggs
+        reveal = Reveal(eggID: id, nonce: nonce)
+    }
+}
+
+extension Notification.Name {
+    /// `object` is the egg's raw id (`String`). Posted by the discovery banner.
+    static let mojitoRevealEasterEgg = Notification.Name("mojitoRevealEasterEgg")
+}

--- a/Sources/Mojito/Settings/SettingsRoot.swift
+++ b/Sources/Mojito/Settings/SettingsRoot.swift
@@ -29,6 +29,7 @@ struct SettingsRoot: View {
 
     @State private var selection: Tab = .general
     @State private var hostWindow: NSWindow?
+    @ObservedObject private var nav = SettingsNavigator.shared
 
     var body: some View {
         NavigationSplitView {
@@ -61,6 +62,16 @@ struct SettingsRoot: View {
         .onChange(of: selection) { _, new in
             hostWindow?.title = new.title
         }
+        .onAppear { applyRequestedTab() }
+        .onChange(of: nav.requestedTab) { _, _ in applyRequestedTab() }
+    }
+
+    /// Honors a pending tab request from `SettingsNavigator`, then clears it so
+    /// a plain Settings open still defaults to General.
+    private func applyRequestedTab() {
+        guard let tab = nav.requestedTab else { return }
+        selection = tab
+        nav.requestedTab = nil
     }
 }
 


### PR DESCRIPTION
## What
The in-app achievement banner was informational only. Make it clickable: a click opens (or focuses) Settings, switches to the Easter eggs tab, scrolls the just-discovered row into view, and briefly flashes it.

## Changes
- `AchievementBanner`: enable mouse events; only the pill is the hit target (margins stay click-through); a tap posts a notification and dismisses the banner. Dismissal refactored to be reentrancy-safe (click racing the hold timer, double-click).
- New `SettingsNavigator` (shared `ObservableObject`): carries a requested-tab + a reveal request the Settings views observe; requests are consumed so a normal Settings open still lands on the default tab.
- `AppDelegate`: on the notification, open Settings then drive the navigator.
- `SettingsRoot`: applies the requested tab.
- `EasterEggsSettingsView`: `ScrollViewReader` scrolls to the row id; transient highlight animation.

## Test plan
- `xcodebuild test` green; build runs.
- Manual: trigger a discovery, click the banner → Settings opens to the Easter eggs tab, scrolls to and flashes the row. Clicking the transparent margin doesn't block clicks. Opening Settings normally still defaults to General.

Refs: W-319