### PR TITLE
W-322: fix Sparkle release-notes element name (releaseNotesURL → releaseNotesLink)

### DIFF
--- a/scripts/update_appcast.py
+++ b/scripts/update_appcast.py
@@ -65,7 +65,11 @@ def main() -> int:
     ET.SubElement(item, "{%s}version" % NS["sparkle"]).text = args.build
     ET.SubElement(item, "{%s}minimumSystemVersion" % NS["sparkle"]).text = "14.0"
     if args.release_notes_url:
-        ET.SubElement(item, "{%s}releaseNotesURL" % NS["sparkle"]).text = args.release_notes_url
+        # The appcast element is `sparkle:releaseNotesLink` — NOT
+        # `releaseNotesURL` (that's the SUAppcastItem *property* name). Sparkle
+        # silently ignores the unknown element, so the wrong name leaves the
+        # update dialog with a blank release-notes pane.
+        ET.SubElement(item, "{%s}releaseNotesLink" % NS["sparkle"]).text = args.release_notes_url
     ET.SubElement(
         item,
         "enclosure",


### PR DESCRIPTION
## What
Sparkle's update dialog showed a blank release-notes pane. Root cause: the appcast generator emitted `<sparkle:releaseNotesURL>`, but Sparkle parses `<sparkle:releaseNotesLink>` — `releaseNotesURL` is the `SUAppcastItem` *property* name, not the XML element. Sparkle silently ignored the unknown element, so the item had no notes source.

Everything else was correct (URL referenced, HTML valid + reachable, standard driver, non-sandboxed). Diagnosed live; confirmed against Sparkle docs.

## Change
- `scripts/update_appcast.py`: emit `sparkle:releaseNotesLink` (+ comment so the property-vs-element gotcha doesn't recur). Fixes future releases.

The live `gh-pages` appcast (already-shipped 1.2.0 / 1.1.1 items) was corrected in place — verified `curl https://mojito.wells.ee/appcast.xml` now returns `<sparkle:releaseNotesLink>`.

## Test plan
- Ran the generator against a copy of the live appcast → emits `<sparkle:releaseNotesLink>`.
- Live feed confirmed via curl.
- Visual confirm needs a non-Debug build with build < 16 doing "Check for Updates" (Sparkle is disabled in Debug); also self-confirms on the next release.

Refs: W-322