### PR TITLE
W-325/W-326: full version-history link + consistent release-notes format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ single source of truth for that release: `scripts/release.sh` extracts it for
 both the GitHub Release body and the Sparkle update notes shown in the in-app
 updater.
 
+## v1.2.1
+
+## New
+- **Text arrows:** type `->`, `<-`, or `<->` and they turn into → ← ↔ — now even flush against a word like `Foo->Bar`. Don't want them? Turn off "Convert text arrows" in Settings → General. Mojito also stays out of code editors and terminals by default. ([#93](https://github.com/wr/mojito/pull/93))
+
+## Fixed
+- **Update window:** the "What's New" window now shows the release notes, and "Version history" opens the full changelog. ([#95](https://github.com/wr/mojito/pull/95), [#97](https://github.com/wr/mojito/pull/97))
+- Easter-egg polish.
+
 ## v1.2.0
 
 **New**

--- a/scripts/md_to_release_notes.py
+++ b/scripts/md_to_release_notes.py
@@ -47,6 +47,9 @@ a { color: #0a7aff; }
 
 def render_inline(text: str) -> str:
     text = html.escape(text, quote=False)
+    # Links first, before the emphasis passes — a URL's `_`/`*` shouldn't be
+    # mangled into <em>. `&` in hrefs stays escaped (valid in HTML attrs).
+    text = re.sub(r"\[([^\]]+)\]\(([^)\s]+)\)", r'<a href="\2">\1</a>', text)
     text = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", text)
     text = re.sub(r"`([^`]+)`", r"<code>\1</code>", text)
     text = re.sub(r"(?<!\*)\*(?!\*)([^*]+?)\*(?!\*)", r"<em>\1</em>", text)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -215,9 +215,11 @@ echo "→ Extracting release notes for v$VERSION from CHANGELOG.md"
 # This fragment is the single source of truth for both the GitHub Release body
 # and the Sparkle HTML notes, so the two can never drift apart.
 CHANGELOG_FRAGMENT=$(mktemp)
+# Stop at the next *version* heading, not any `## ` — the per-release body
+# now uses `## New` / `## Fixed` section headings that must be captured.
 awk -v header="## v$VERSION" '
     $0 == header { capture = 1; next }
-    capture && /^## / { exit }
+    capture && /^## v[0-9]/ { exit }
     capture { print }
 ' "$REPO_ROOT/CHANGELOG.md" > "$CHANGELOG_FRAGMENT"
 if [[ ! -s "$CHANGELOG_FRAGMENT" ]]; then
@@ -248,11 +250,20 @@ git clone --depth 1 --branch gh-pages "https://github.com/$GITHUB_REPO.git" "$GH
 
 echo "→ Rendering release-notes HTML"
 RELEASE_NOTES_URL="https://mojito.wells.ee/release-notes/$VERSION.html"
+FULL_NOTES_URL="https://mojito.wells.ee/release-notes/history.html"
 mkdir -p "$GH_PAGES_DIR/release-notes"
 python3 "$REPO_ROOT/scripts/md_to_release_notes.py" \
     --title "$APP_NAME $VERSION" \
     < "$CHANGELOG_FRAGMENT" \
     > "$GH_PAGES_DIR/release-notes/$VERSION.html"
+
+# Full version history → Sparkle's "Version history" link. Render every
+# `## vX.Y.Z` section (skip the `# Changelog` intro, which is repo-internal).
+echo "→ Rendering full version-history HTML"
+awk '/^## v[0-9]/ { p = 1 } p' "$REPO_ROOT/CHANGELOG.md" \
+    | python3 "$REPO_ROOT/scripts/md_to_release_notes.py" \
+        --title "$APP_NAME — Version History" \
+    > "$GH_PAGES_DIR/release-notes/history.html"
 
 APPCAST="$GH_PAGES_DIR/appcast.xml"
 python3 "$REPO_ROOT/scripts/update_appcast.py" \
@@ -262,7 +273,8 @@ python3 "$REPO_ROOT/scripts/update_appcast.py" \
     --url "$DOWNLOAD_URL" \
     --length "$LENGTH" \
     --signature "$EDDSA_SIGNATURE" \
-    --release-notes-url "$RELEASE_NOTES_URL"
+    --release-notes-url "$RELEASE_NOTES_URL" \
+    --full-release-notes-url "$FULL_NOTES_URL"
 
 cd "$GH_PAGES_DIR"
 git add appcast.xml release-notes

--- a/scripts/update_appcast.py
+++ b/scripts/update_appcast.py
@@ -34,7 +34,8 @@ def main() -> int:
     p.add_argument("--url", required=True)
     p.add_argument("--length", required=True)
     p.add_argument("--signature", required=True)
-    p.add_argument("--release-notes-url", default="", help="URL to hosted HTML release notes")
+    p.add_argument("--release-notes-url", default="", help="URL to hosted HTML release notes for this version")
+    p.add_argument("--full-release-notes-url", default="", help="URL to the full version-history page (Sparkle's 'Version history' link)")
     args = p.parse_args()
 
     if os.path.exists(args.appcast):
@@ -70,6 +71,9 @@ def main() -> int:
         # silently ignores the unknown element, so the wrong name leaves the
         # update dialog with a blank release-notes pane.
         ET.SubElement(item, "{%s}releaseNotesLink" % NS["sparkle"]).text = args.release_notes_url
+    if args.full_release_notes_url:
+        # Drives the update dialog's "Version history" link → full changelog.
+        ET.SubElement(item, "{%s}fullReleaseNotesLink" % NS["sparkle"]).text = args.full_release_notes_url
     ET.SubElement(
         item,
         "enclosure",


### PR DESCRIPTION
## What
Two release-notes improvements (prep for v1.2.1):

1. **Version history** (W-325) — the Sparkle update dialog's "Version history" link opened the *per-version* notes (`<version>.html`). Now it opens a full changelog: `release.sh` renders the whole `CHANGELOG.md` to `release-notes/history.html`, and `update_appcast.py` emits `<sparkle:fullReleaseNotesLink>` pointing at it.
2. **Consistent format** (W-326) — adopt `## New` / `## Fixed` section headings with linked issue/PR refs. Required:
   - `md_to_release_notes.py`: render markdown links (`[text](url)`).
   - `release.sh`: changelog extractor stops at the next `## v` (not any `## `), so `## New`/`## Fixed` are captured.
   - `CHANGELOG.md`: v1.2.1 entry in the new format.

## Test plan
- Extracted the v1.2.1 fragment via the updated awk → renders `<h2>New</h2>`/`<h2>Fixed</h2>` + `<a>` links.
- Full `CHANGELOG` → `history.html` renders all version sections.
- `update_appcast.py` emits both `releaseNotesLink` and `fullReleaseNotesLink`.

Refs: W-325, W-326