### PR TITLE
W-340: Apply URL exclusions across notable macOS browsers (fixes Helium, Orion)

### DIFF
--- a/Sources/Mojito/Context/BrowserURL.swift
+++ b/Sources/Mojito/Context/BrowserURL.swift
@@ -24,20 +24,56 @@ enum BrowserURL {
         knownBrowserBundleIDs.contains(bundleID)
     }
 
+    // Bundle IDs are opaque, so the obscure ones are named. detect() tries the
+    // Safari web-area path then an address-bar fallback, so WebKit/Gecko entries
+    // are best-effort; the Chromium path is the proven one.
     private static let knownBrowserBundleIDs: Set<String> = [
+        // WebKit
         "com.apple.Safari",
         "com.apple.SafariTechnologyPreview",
+        "com.kagi.kagimacOS",                       // Orion
+        "com.kagi.kagimacOS.RC",                    // Orion RC
+        "com.duckduckgo.macos.browser",             // DuckDuckGo
+        "com.sigmaos.sigmaos.macos",                // SigmaOS
+
+        // Chromium
         "com.google.Chrome",
-        "com.google.Chrome.canary",
         "com.google.Chrome.beta",
+        "com.google.Chrome.dev",
+        "com.google.Chrome.canary",
+        "org.chromium.Chromium",
         "com.brave.Browser",
+        "com.brave.Browser.beta",
+        "com.brave.Browser.nightly",
         "com.microsoft.edgemac",
-        "company.thebrowser.Browser",   // Arc
-        "company.thebrowser.dia",       // Dia
+        "com.microsoft.edgemac.Beta",
+        "com.microsoft.edgemac.Dev",
+        "com.microsoft.edgemac.Canary",
+        "com.vivaldi.Vivaldi",
+        "com.vivaldi.Vivaldi.snapshot",
+        "com.operasoftware.Opera",
+        "com.operasoftware.OperaGX",
+        "com.operasoftware.OperaAir",
+        "com.operasoftware.OperaNext",              // Opera beta
+        "com.operasoftware.OperaDeveloper",
+        "company.thebrowser.Browser",               // Arc
+        "company.thebrowser.dia",                   // Dia
+        "net.imput.helium",                         // Helium
+        "com.pushplaylabs.sidekick",                // Sidekick
+        "ru.yandex.desktop.yandex-browser",         // Yandex
+        "com.naver.Whale",                          // Naver Whale
+        "io.wavebox.wavebox",                       // Wavebox
+
+        // Gecko
         "org.mozilla.firefox",
         "org.mozilla.firefoxdeveloperedition",
-        "com.vivaldi.Vivaldi",
-        "com.operasoftware.Opera",
+        "org.mozilla.nightly",                      // Firefox Nightly
+        "app.zen-browser.zen",                      // Zen
+        "one.ablaze.floorp",                        // Floorp
+        "io.gitlab.librewolf-community.librewolf",  // LibreWolf
+        "org.waterfoxproject.waterfox",             // Waterfox
+        "net.mullvad.mullvadbrowser",               // Mullvad Browser
+        "org.torproject.torbrowser",                // Tor Browser
     ]
 
     private static func focusedWebAreaURL(in app: AXUIElement) -> URL? {


### PR DESCRIPTION
## Summary
`BrowserURL` only reads a browser tab's URL when the frontmost app's bundle ID is on a hardcoded whitelist. An unlisted browser yields a `nil` URL, so `ExclusionStore` skips URL-pattern matching and **fails open** — URL-based defaults like `*.slack.com` silently do nothing. **Helium** (`net.imput.helium`, reported in #101) and **Orion** (`com.kagi.kagimacOS`) were both unlisted.

This broadens the whitelist to the current crop of notable macOS browsers across all three engines. Bundle IDs were verified against Homebrew cask definitions + official sources (Maxthon omitted — its macOS ID couldn't be verified, and a wrong ID is worse than none).

- **Chromium:** Chrome (+beta/dev/canary), Chromium, Brave (+beta/nightly), Edge (+beta/dev/canary), Vivaldi (+snapshot), Opera (+GX/Air/Next/Developer), Arc, Dia, Helium, Sidekick, Yandex, Naver Whale, Wavebox
- **Gecko:** Firefox (+dev/nightly), Zen, Floorp, LibreWolf, Waterfox, Mullvad, Tor
- **WebKit:** Safari (+Tech Preview), Orion (+RC), DuckDuckGo, SigmaOS

Chromium is the proven URL-read path; Gecko forks reuse Firefox's existing path; WebKit third-party browsers are best-effort — if their AX tree doesn't expose the URL like Safari's does they fail open exactly as before, so listing them can only help.

## Test plan
- [x] Debug build compiles clean; unit suite passes (pre-push hook).
- [ ] Open Slack in Helium / Orion, type `:smile:` → picker no longer appears (browser must have Accessibility granted).
- [x] Existing browsers (Safari/Chrome) unaffected — only additions to the set.

Closes #101
Refs W-340