### PR TITLE
W-345: disable telemetry uploads in Debug/dev builds

### DIFF
--- a/Sources/Mojito/Telemetry/TelemetryUploader.swift
+++ b/Sources/Mojito/Telemetry/TelemetryUploader.swift
@@ -23,9 +23,22 @@ final class TelemetryUploader {
 
     static func utcDay(_ now: Date = Date()) -> Int { Int(now.timeIntervalSince1970 / 86_400) }
 
+    /// Debug/dev builds never upload — this keeps dev pings out of the public
+    /// production stats (Sparkle is disabled in Debug for the same reason). The
+    /// consent alert and Settings toggle stay visible in dev so the UX is
+    /// testable; only the network send is suppressed.
+    private static let uploadsEnabled: Bool = {
+        #if DEBUG
+        return false
+        #else
+        return true
+        #endif
+    }()
+
     func uploadIfDue() {
         let defaults = UserDefaults.standard
-        guard TelemetryStore.isEnabled,
+        guard Self.uploadsEnabled,
+              TelemetryStore.isEnabled,
               defaults.bool(forKey: PrefsKey.telemetryConsentSeen),
               defaults.integer(forKey: PrefsKey.telemetryLastUploadDay) != Self.utcDay()
         else { return }

--- a/Sources/Mojito/Telemetry/TelemetryUploader.swift
+++ b/Sources/Mojito/Telemetry/TelemetryUploader.swift
@@ -23,10 +23,7 @@ final class TelemetryUploader {
 
     static func utcDay(_ now: Date = Date()) -> Int { Int(now.timeIntervalSince1970 / 86_400) }
 
-    /// Debug/dev builds never upload — this keeps dev pings out of the public
-    /// production stats (Sparkle is disabled in Debug for the same reason). The
-    /// consent alert and Settings toggle stay visible in dev so the UX is
-    /// testable; only the network send is suppressed.
+    // Debug builds never upload — keeps dev pings out of production stats.
     private static let uploadsEnabled: Bool = {
         #if DEBUG
         return false


### PR DESCRIPTION
Debug/dev builds (`ee.wells.Mojito.dev`) ran the telemetry uploader, so dev testing polluted the public production stats — during W-342 testing one dev Mac registered as several "Macs".

`TelemetryUploader.uploadIfDue()` now guards on a Release-only flag (`#if DEBUG` → no upload), mirroring how Sparkle is already disabled in Debug. The consent alert and Settings toggle stay visible in dev so the UX is testable; only the network send is suppressed. Release behavior is unchanged.

## Test plan
- Debug build: `uploadIfDue()` returns early; no `/ingest` traffic.
- Release behavior unchanged (gate is `true` outside `#if DEBUG`).
- Pre-push test suite green.

Refs: W-345