### PR TITLE
W-357: frosted-glass blur on the nav language dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
 <link rel="alternate" hreflang="he" href="https://mojito.wells.ee/?lang=he">
 <link rel="preload" as="image" fetchpriority="high" href="wallpaper.webp" type="image/webp" media="(prefers-color-scheme: light)">
 <link rel="preload" as="image" fetchpriority="high" href="wallpaper-dark.webp" type="image/webp" media="(prefers-color-scheme: dark)">
-<link rel="stylesheet" href="style.css?v=68">
+<link rel="stylesheet" href="style.css?v=69">
 <script src="i18n.js?v=1"></script>
 </head>
 <body>

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <meta property="og:description" data-i18n-attr="content:stats.meta.ogDescription" content="Mojito in numbers. Anonymous, aggregate, fully public.">
 <link rel="icon" type="image/png" href="favicon.png">
 <link rel="apple-touch-icon" href="favicon.png">
-<link rel="stylesheet" href="style.css?v=68">
+<link rel="stylesheet" href="style.css?v=69">
 <link rel="stylesheet" href="stats.css?v=11">
 <script src="i18n.js?v=1"></script>
 </head>

--- a/style.css
+++ b/style.css
@@ -1653,9 +1653,14 @@ footer {
   min-width: 210px;
   max-height: 340px;
   overflow-y: auto;
-  background: var(--menu-bg);
-  backdrop-filter: saturate(180%) blur(20px);
-  -webkit-backdrop-filter: saturate(180%) blur(20px);
+  /* Frosted glass: a low-opacity tint over a strong backdrop blur so the page
+     reads through. The menu lives under .topbar (which also has a
+     backdrop-filter) — `isolation: isolate` gives it its own stacking context
+     so its backdrop samples the page content behind it, not the topbar's. */
+  isolation: isolate;
+  background: color-mix(in srgb, var(--bg) 60%, transparent);
+  backdrop-filter: saturate(180%) blur(24px);
+  -webkit-backdrop-filter: saturate(180%) blur(24px);
   border: 1px solid var(--menu-border);
   border-radius: 14px;
   box-shadow: var(--menu-shadow);


### PR DESCRIPTION
The nav language picker dropdown had a `backdrop-filter` but its background was nearly opaque (`--menu-bg` ≈ 0.92), so the blur was invisible.

- Tint dropped to `color-mix(in srgb, var(--bg) 60%, transparent)` over `blur(24px)` → visible frosted glass (adapts to light/dark via `--bg`).
- `isolation: isolate` so the menu's backdrop samples the page content behind it, not the backdrop-filtered `.topbar` ancestor (which otherwise swallows the effect).
- `style.css` cache-buster bumped `v=68 → v=69` on `index.html` + `stats.html`.

Verified by force-opening the menu over the hero and screenshotting: the heading + wallpaper now read through, blurred. `./scripts/check.sh` fully green (the menu is `display:none` until opened, so the Lighthouse a11y score is unaffected).

Refs W-357