### PR TITLE
W-357: actually blur the lang dropdown (portal out of .topbar)

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -245,9 +245,25 @@
     });
   }
 
+  // The menu is portaled to <body> (out of the backdrop-filtered .topbar so its
+  // own backdrop-filter can actually blur the page), so position it under the
+  // button by hand — aligning its inline-end edge to the button's.
+  function positionMenu() {
+    var r = btn.getBoundingClientRect();
+    menu.style.top = (r.bottom + 8) + "px";
+    if (document.documentElement.dir === "rtl") {
+      menu.style.left = r.left + "px";
+      menu.style.right = "auto";
+    } else {
+      menu.style.right = (window.innerWidth - r.right) + "px";
+      menu.style.left = "auto";
+    }
+  }
+
   function openMenu() {
     if (menuOpen) return;
     menuOpen = true;
+    positionMenu();
     menu.hidden = false;
     btn.setAttribute("aria-expanded", "true");
     var opts = menu.querySelectorAll('[role="option"]');
@@ -334,12 +350,13 @@
       else if (e.key === "Tab") { closeMenu(false); }
     });
     document.addEventListener("click", function (e) {
-      if (menuOpen && !wrap.contains(e.target)) closeMenu(false);
+      if (menuOpen && !wrap.contains(e.target) && !menu.contains(e.target)) closeMenu(false);
     });
+    window.addEventListener("resize", function () { if (menuOpen) positionMenu(); });
 
     wrap.appendChild(btn);
-    wrap.appendChild(menu);
     nav.insertBefore(wrap, nav.firstChild);
+    document.body.appendChild(menu); // portal out of .topbar's backdrop-filter
   }
 
   /* ----- boot --------------------------------------------------------- */

--- a/index.html
+++ b/index.html
@@ -39,8 +39,8 @@
 <link rel="alternate" hreflang="he" href="https://mojito.wells.ee/?lang=he">
 <link rel="preload" as="image" fetchpriority="high" href="wallpaper.webp" type="image/webp" media="(prefers-color-scheme: light)">
 <link rel="preload" as="image" fetchpriority="high" href="wallpaper-dark.webp" type="image/webp" media="(prefers-color-scheme: dark)">
-<link rel="stylesheet" href="style.css?v=69">
-<script src="i18n.js?v=1"></script>
+<link rel="stylesheet" href="style.css?v=70">
+<script src="i18n.js?v=2"></script>
 </head>
 <body>
 

--- a/stats.html
+++ b/stats.html
@@ -13,9 +13,9 @@
 <meta property="og:description" data-i18n-attr="content:stats.meta.ogDescription" content="Mojito in numbers. Anonymous, aggregate, fully public.">
 <link rel="icon" type="image/png" href="favicon.png">
 <link rel="apple-touch-icon" href="favicon.png">
-<link rel="stylesheet" href="style.css?v=69">
+<link rel="stylesheet" href="style.css?v=70">
 <link rel="stylesheet" href="stats.css?v=11">
-<script src="i18n.js?v=1"></script>
+<script src="i18n.js?v=2"></script>
 </head>
 <body>
 

--- a/style.css
+++ b/style.css
@@ -1644,27 +1644,25 @@ footer {
 .lang-btn-caret { opacity: 0.55; }
 
 .lang-menu {
-  position: absolute;
-  top: calc(100% + 8px);
-  inset-inline-end: 0;
+  /* position:fixed + portaled to <body> (see i18n.js) so the menu sits OUTSIDE
+     .topbar's backdrop-filter — otherwise the ancestor filter swallows this
+     one and the blur never samples the page. i18n.js sets top/right/left. */
+  position: fixed;
   margin: 0;
   padding: 6px;
   list-style: none;
   min-width: 210px;
   max-height: 340px;
   overflow-y: auto;
-  /* Frosted glass: a low-opacity tint over a strong backdrop blur so the page
-     reads through. The menu lives under .topbar (which also has a
-     backdrop-filter) — `isolation: isolate` gives it its own stacking context
-     so its backdrop samples the page content behind it, not the topbar's. */
-  isolation: isolate;
-  background: color-mix(in srgb, var(--bg) 60%, transparent);
+  /* Frosted glass: a translucent grey menu material over a strong backdrop
+     blur, so the page reads through, frosted. */
+  background: color-mix(in srgb, var(--menu-bg) 72%, transparent);
   backdrop-filter: saturate(180%) blur(24px);
   -webkit-backdrop-filter: saturate(180%) blur(24px);
   border: 1px solid var(--menu-border);
   border-radius: 14px;
   box-shadow: var(--menu-shadow);
-  z-index: 60;
+  z-index: 70;
 }
 .lang-menu[hidden] { display: none; }
 .lang-menu:focus { outline: none; }


### PR DESCRIPTION
Follow-up to #111, which made the dropdown translucent but **not actually blurred** — a `backdrop-filter` on an ancestor (`.topbar`) swallows a descendant's `backdrop-filter`, so the menu's blur never sampled the page (`isolation: isolate` doesn't fix that).

- **Portal the menu to `<body>`** (`position: fixed`, positioned under the button by `i18n.js` via `getBoundingClientRect`, RTL-aware) so it sits outside `.topbar`'s filter context → the blur actually works.
- Tint now mixes the **grey menu material** (`--menu-bg`) instead of the page's near-black, for a cleaner frosted look in both light/dark.
- Cache-busters bumped (`style.css?v=70`, `i18n.js?v=2`).

Verified with a blur-on vs blur-off screenshot over sharp text: with the fix, the text behind the menu is frosted away; without `backdrop-filter` it's sharp. `./scripts/check.sh` fully green.

Refs W-357