### PR TITLE
W-357: dial the lang dropdown glass back a touch

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
 <link rel="alternate" hreflang="he" href="https://mojito.wells.ee/?lang=he">
 <link rel="preload" as="image" fetchpriority="high" href="wallpaper.webp" type="image/webp" media="(prefers-color-scheme: light)">
 <link rel="preload" as="image" fetchpriority="high" href="wallpaper-dark.webp" type="image/webp" media="(prefers-color-scheme: dark)">
-<link rel="stylesheet" href="style.css?v=70">
+<link rel="stylesheet" href="style.css?v=71">
 <script src="i18n.js?v=2"></script>
 </head>
 <body>

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <meta property="og:description" data-i18n-attr="content:stats.meta.ogDescription" content="Mojito in numbers. Anonymous, aggregate, fully public.">
 <link rel="icon" type="image/png" href="favicon.png">
 <link rel="apple-touch-icon" href="favicon.png">
-<link rel="stylesheet" href="style.css?v=70">
+<link rel="stylesheet" href="style.css?v=71">
 <link rel="stylesheet" href="stats.css?v=11">
 <script src="i18n.js?v=2"></script>
 </head>

--- a/style.css
+++ b/style.css
@@ -1656,9 +1656,9 @@ footer {
   overflow-y: auto;
   /* Frosted glass: a translucent grey menu material over a strong backdrop
      blur, so the page reads through, frosted. */
-  background: color-mix(in srgb, var(--menu-bg) 72%, transparent);
-  backdrop-filter: saturate(180%) blur(24px);
-  -webkit-backdrop-filter: saturate(180%) blur(24px);
+  background: color-mix(in srgb, var(--menu-bg) 62%, transparent);
+  backdrop-filter: saturate(180%) blur(20px);
+  -webkit-backdrop-filter: saturate(180%) blur(20px);
   border: 1px solid var(--menu-border);
   border-radius: 14px;
   box-shadow: var(--menu-shadow);


### PR DESCRIPTION
Per review, the frosted dropdown read a bit heavy. Tint 72% → 62% and blur 24px → 20px so the page reads through a little more. CSS-only; cache-buster bumped to v=71.

Refs W-357