### PR TITLE
W-366: fix stats bars collapsing to a sliver at the 620–760px breakpoint

### DIFF
--- a/stats.css
+++ b/stats.css
@@ -166,6 +166,9 @@
 
 /* ---- card --------------------------------------------------------------- */
 .card {
+  /* Query container so .bar can adapt to the CARD's width, not the viewport —
+     in a 2-up .grid-2 the cards get narrow well before any viewport breakpoint. */
+  container-type: inline-size;
   background: var(--card-bg);
   border: 0.5px solid var(--card-border);
   border-radius: 18px;
@@ -216,6 +219,15 @@
   grid-template-columns: minmax(96px, 150px) 1fr 52px;
   align-items: center;
   gap: 14px;
+}
+
+/* Narrow card (the 2-up .grid-2 cards at most widths): shrink the label + value
+   columns so the track keeps real width instead of collapsing to a sliver. */
+@container (max-width: 400px) {
+  .bars .bar {
+    grid-template-columns: minmax(56px, 90px) 1fr 40px;
+    gap: 10px;
+  }
 }
 
 .bar-label {

--- a/stats.html
+++ b/stats.html
@@ -14,7 +14,7 @@
 <link rel="icon" type="image/png" href="favicon.png">
 <link rel="apple-touch-icon" href="favicon.png">
 <link rel="stylesheet" href="style.css?v=72">
-<link rel="stylesheet" href="stats.css?v=11">
+<link rel="stylesheet" href="stats.css?v=12">
 <script src="i18n.js?v=2"></script>
 </head>
 <body>


### PR DESCRIPTION
On the stats page, `.stats-main` caps content at 760px but `.grid-2` only collapses to 1 column below 620px. In the **620–760px** range the two cards stay side-by-side and get narrow (~278px), so the bar grid (`minmax(96,150)` label + `1fr` track + 52px value + gaps) starved the `1fr` track down to a sliver.

Fix: make `.card` a **query container** (`container-type: inline-size`) and give `.bar` a compact column template (`minmax(56,90) 1fr 40px`, tighter gap) via `@container (max-width: 400px)` — so a bar adapts to its **card's** width, not the viewport, and the track keeps real width in any grid/viewport state. (`.card`'s only abs-positioned child is `.feat-gauge::before`, anchored to `.feat-gauge`, so the containment is safe.)

Verified with headless screenshots at 640px and 700px: bars now render full-length fills tracking the percentages instead of slivers. `node`/stylelint clean; index gate unaffected.

Refs W-366