### PR TITLE
W-369: correct misleading "bare :" comments on the favorites pill

### DIFF
--- a/Sources/Mojito/App/Engine.swift
+++ b/Sources/Mojito/App/Engine.swift
@@ -506,8 +506,8 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
             if captureExcluded { break }
             updateResults(query: q, scope: scope)
             if q.isEmpty {
-                // Bare `:` → favorites + most-used. Debounced so a follow-up
-                // keystroke (`:)`, `:smile`) cancels it before it flashes.
+                // `:?` (empty query) → favorites + most-used. Debounced so a
+                // follow-up keystroke (`:)`, `:smile`) cancels it before it flashes.
                 scheduleEmptyPickerShow()
             } else {
                 // Defer one tick: the keystroke moves the caret in the focused
@@ -922,7 +922,7 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
             "results": "\(results.count)",
             "scope": "\(scope)",
         ])
-        // Trailing Browse row mirrors the bare-`:` pill — a no-match query
+        // Trailing Browse row mirrors the `:?` favorites pill — a no-match query
         // still hides the picker (results stay empty), but any hit list lets
         // the user fall through to the full grid.
         if !results.isEmpty {

--- a/Sources/Mojito/Picker/PickerView.swift
+++ b/Sources/Mojito/Picker/PickerView.swift
@@ -28,7 +28,7 @@ struct PickerView: View {
         }
     }
 
-    /// Bare-`:` favorites pill: a single horizontal row of emoji cells with
+    /// `:?` favorites pill: a single horizontal row of emoji cells with
     /// a trailing chevron (the Browse row) that expands to the full grid.
     private var compactBar: some View {
         HStack(spacing: PickerLayout.compactSpacing) {

--- a/Sources/Mojito/Picker/PickerViewModel.swift
+++ b/Sources/Mojito/Picker/PickerViewModel.swift
@@ -7,8 +7,8 @@ final class PickerViewModel: ObservableObject {
     @Published var results: [ScoredEmoji] = []
     @Published var selectedIndex: Int = 0
     @Published var isVisible: Bool = false
-    /// True for the bare-`:` favorites surface, which renders as a compact
-    /// horizontal pill instead of the vertical shortcode list.
+    /// True for the `:?` (empty-query) favorites surface, which renders as a
+    /// compact horizontal pill instead of the vertical shortcode list.
     @Published var compact: Bool = false
     /// True once the pill has grown into the full-library grid (same panel).
     @Published var expanded: Bool = false


### PR DESCRIPTION
## Summary

Follow-up to #116. Four code comments called the empty-query favorites pill the "bare-`:`" surface — that's the wording that led the README astray. The pill is actually summoned by `:?` (the quick-access trigger); a bare `:` just starts capturing with nothing on screen (`TriggerStateMachine.swift:374-377`, and `.openPicker(query: "")` is only emitted from the `:?` branch at `:588-592`).

Reworded the four pill comments to `:?` / empty-query:
- `Engine.swift` (the debounced empty-picker show + the Browse-row mirror comment)
- `PickerViewModel.swift` (`compact` doc comment)
- `PickerView.swift` (`compactBar` doc comment)

Left alone the comments that use "bare `:`" to mean *colon typed, nothing after, no pill yet* (state-machine arrow-key handling) — those are accurate.

## Test plan

Comment-only change; no behavior touched.

Refs W-369