### PR TITLE
W-373: add honest avgDailyActive to the stats API

### DIFF
--- a/stats-worker/src/index.js
+++ b/stats-worker/src/index.js
@@ -181,10 +181,7 @@ async function stats(env) {
                    pct: r.t ? Math.round((r.e / r.t) * 100) : 0 }))
     .sort((a, b) => b.pct - a.pct);
 
-  // `macsSharingStats` is the sum of daily-active pings (person-days) — kept for
-  // compatibility but misleading as a headcount. `avgDailyActive` is the honest
-  // headline: mean distinct installs on a day we saw any activity, so one
-  // returning user isn't multiplied across the days they showed up.
+  // macsSharingStats is person-days (kept for compat); avgDailyActive is the per-day mean.
   const activeTotal = active30.results[0]?.c || 0;
   const activeDays = active30.results[0]?.d || 0;
   const avgDailyActive = activeDays ? Math.round(activeTotal / activeDays) : 0;

--- a/stats-worker/src/index.js
+++ b/stats-worker/src/index.js
@@ -167,7 +167,8 @@ async function stats(env) {
       ).bind(win).all(),
       env.DB.prepare(`SELECT kind, SUM(count) c FROM totals_daily GROUP BY kind`).all(),
       env.DB.prepare(
-        `SELECT SUM(count) c FROM totals_daily WHERE kind = 'active' AND day >= ?`
+        `SELECT COALESCE(SUM(count), 0) c, COUNT(DISTINCT day) d
+         FROM totals_daily WHERE kind = 'active' AND day >= ?`
       ).bind(win).all(),
       env.DB.prepare(`SELECT value FROM meta WHERE key = 'community_eggs'`).all(),
     ]);
@@ -180,10 +181,19 @@ async function stats(env) {
                    pct: r.t ? Math.round((r.e / r.t) * 100) : 0 }))
     .sort((a, b) => b.pct - a.pct);
 
+  // `macsSharingStats` is the sum of daily-active pings (person-days) — kept for
+  // compatibility but misleading as a headcount. `avgDailyActive` is the honest
+  // headline: mean distinct installs on a day we saw any activity, so one
+  // returning user isn't multiplied across the days they showed up.
+  const activeTotal = active30.results[0]?.c || 0;
+  const activeDays = active30.results[0]?.d || 0;
+  const avgDailyActive = activeDays ? Math.round(activeTotal / activeDays) : 0;
+
   const payload = {
     generatedAt: new Date().toISOString(),
     window: { days: 30 },
-    macsSharingStats: active30.results[0]?.c || 0,
+    macsSharingStats: activeTotal,
+    avgDailyActive,
     totals: {
       emoji: totalsMap.emoji || 0,
       symbol: totalsMap.symbol || 0,


### PR DESCRIPTION
## What
The public stats headline reads "Active users" but is bound to `macsSharingStats` = the **sum of daily-active pings over 30 days** (person-days). Since the schema stores no identifiers, that multiplies one returning user across every day they show up — so it badly overstates headcount.

## Change
Add `avgDailyActive` to `GET /api/stats.json` = `round(active_total / distinct_active_days)` within the 30-day window — the mean number of installs active on a day we saw any activity. `macsSharingStats` is retained for compatibility.

The page (mojito-site) will bind the headline to `avgDailyActive` and relabel it "Avg. daily users."

## Test plan
- `node --check` passes.
- After deploy, `GET /api/stats.json` includes `avgDailyActive`.

Refs W-373