### PR TITLE
W-373: show avg. daily users on the stats headline

### DIFF
--- a/i18n/ar.json
+++ b/i18n/ar.json
@@ -85,7 +85,7 @@
   "stats.hero.sub": "نظرة حيّة على ما يلجأ إليه الناس — أكثر الرموز التعبيرية حبًّا، والميزات الأكثر استخدامًا، وأين يعمل Mojito.",
   "stats.hero.updatesDaily": "يُحدَّث يوميًا",
   "stats.lastUpdate": "آخر تحديث {date}",
-  "stats.bignum.users": "المستخدمون النشطون",
+  "stats.bignum.users": "متوسط المستخدمين يوميًا",
   "stats.bignum.emoji": "رموز تعبيرية",
   "stats.bignum.gif": "GIFs",
   "stats.bignum.emoticon": "وجوه تعبيرية",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -85,7 +85,7 @@
   "stats.hero.sub": "Ein Live-Blick darauf, wozu die Leute greifen — die beliebtesten Emojis, die meistgenutzten Funktionen und wo Mojito läuft.",
   "stats.hero.updatesDaily": "Täglich aktualisiert",
   "stats.lastUpdate": "zuletzt aktualisiert {date}",
-  "stats.bignum.users": "Aktive Nutzer",
+  "stats.bignum.users": "Ø tägliche Nutzer",
   "stats.bignum.emoji": "Emojis",
   "stats.bignum.gif": "GIFs",
   "stats.bignum.emoticon": "Emoticons",

--- a/i18n/en-GB.json
+++ b/i18n/en-GB.json
@@ -85,7 +85,7 @@
   "stats.hero.sub": "A live look at what people reach for — the most-loved emoji, the features that get used, and where Mojito runs.",
   "stats.hero.updatesDaily": "Updates daily",
   "stats.lastUpdate": "last update {date}",
-  "stats.bignum.users": "Active users",
+  "stats.bignum.users": "Avg. daily users",
   "stats.bignum.emoji": "Emoji",
   "stats.bignum.gif": "GIFs",
   "stats.bignum.emoticon": "Emoticons",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -100,7 +100,7 @@
   "stats.hero.sub": "A live look at what people reach for — the most-loved emoji, the features that get used, and where Mojito runs.",
   "stats.hero.updatesDaily": "Updates daily",
   "stats.lastUpdate": "last update {date}",
-  "stats.bignum.users": "Active users",
+  "stats.bignum.users": "Avg. daily users",
   "stats.bignum.emoji": "Emoji",
   "stats.bignum.gif": "GIFs",
   "stats.bignum.emoticon": "Emoticons",

--- a/i18n/es-419.json
+++ b/i18n/es-419.json
@@ -85,7 +85,7 @@
   "stats.hero.sub": "Un vistazo en vivo a lo que la gente usa: los emoji más queridos, las funciones que se usan y dónde corre Mojito.",
   "stats.hero.updatesDaily": "Se actualiza a diario",
   "stats.lastUpdate": "última actualización {date}",
-  "stats.bignum.users": "Usuarios activos",
+  "stats.bignum.users": "Usuarios diarios (prom.)",
   "stats.bignum.emoji": "Emoji",
   "stats.bignum.gif": "GIFs",
   "stats.bignum.emoticon": "Emoticones",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -85,7 +85,7 @@
   "stats.hero.sub": "Una mirada en vivo a lo que la gente usa — los emojis más queridos, las funciones que más se utilizan y dónde corre Mojito.",
   "stats.hero.updatesDaily": "Se actualiza a diario",
   "stats.lastUpdate": "última actualización {date}",
-  "stats.bignum.users": "Usuarios activos",
+  "stats.bignum.users": "Usuarios diarios (prom.)",
   "stats.bignum.emoji": "Emojis",
   "stats.bignum.gif": "GIFs",
   "stats.bignum.emoticon": "Emoticonos",

--- a/i18n/fa.json
+++ b/i18n/fa.json
@@ -85,7 +85,7 @@
   "stats.hero.sub": "نگاهی زنده به آنچه مردم بیشتر سراغش می‌روند — محبوب‌ترین ایموجی‌ها، پرکاربردترین قابلیت‌ها، و اینکه Mojito کجا اجرا می‌شود.",
   "stats.hero.updatesDaily": "هر روز به‌روزرسانی می‌شود",
   "stats.lastUpdate": "آخرین به‌روزرسانی {date}",
-  "stats.bignum.users": "کاربران فعال",
+  "stats.bignum.users": "میانگین کاربران روزانه",
   "stats.bignum.emoji": "ایموجی",
   "stats.bignum.gif": "GIFs",
   "stats.bignum.emoticon": "شکلک",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -85,7 +85,7 @@
   "stats.hero.sub": "Un aperçu en direct de ce que les gens utilisent — les emoji les plus appréciés, les fonctionnalités les plus sollicitées et là où Mojito tourne.",
   "stats.hero.updatesDaily": "Mis à jour chaque jour",
   "stats.lastUpdate": "dernière mise à jour {date}",
-  "stats.bignum.users": "Utilisateurs actifs",
+  "stats.bignum.users": "Utilisateurs/jour (moy.)",
   "stats.bignum.emoji": "Emoji",
   "stats.bignum.gif": "GIFs",
   "stats.bignum.emoticon": "Émoticônes",

--- a/i18n/he.json
+++ b/i18n/he.json
@@ -85,7 +85,7 @@
   "stats.hero.sub": "מבט חי על מה שאנשים בוחרים — האימוג'ים האהובים ביותר, הפיצ'רים שנמצאים בשימוש, והיכן Mojito פועל.",
   "stats.hero.updatesDaily": "מתעדכן מדי יום",
   "stats.lastUpdate": "עדכון אחרון {date}",
-  "stats.bignum.users": "משתמשים פעילים",
+  "stats.bignum.users": "ממוצע משתמשים יומי",
   "stats.bignum.emoji": "אימוג'ים",
   "stats.bignum.gif": "GIFs",
   "stats.bignum.emoticon": "סמיילים",

--- a/i18n/hi.json
+++ b/i18n/hi.json
@@ -85,7 +85,7 @@
   "stats.hero.sub": "लोग किस ओर सबसे ज़्यादा जाते हैं—इसकी एक लाइव झलक: सबसे पसंदीदा इमोजी, सबसे ज़्यादा इस्तेमाल होने वाली सुविधाएँ, और Mojito कहाँ चलता है।",
   "stats.hero.updatesDaily": "रोज़ अपडेट होता है",
   "stats.lastUpdate": "अंतिम अपडेट {date}",
-  "stats.bignum.users": "सक्रिय उपयोगकर्ता",
+  "stats.bignum.users": "औसत दैनिक उपयोगकर्ता",
   "stats.bignum.emoji": "इमोजी",
   "stats.bignum.gif": "GIFs",
   "stats.bignum.emoticon": "इमोटिकॉन",

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -85,7 +85,7 @@
   "stats.hero.sub": "Uno sguardo in tempo reale a ciò che le persone usano — le emoji più amate, le funzioni più utilizzate e dove gira Mojito.",
   "stats.hero.updatesDaily": "Aggiornato ogni giorno",
   "stats.lastUpdate": "ultimo aggiornamento {date}",
-  "stats.bignum.users": "Utenti attivi",
+  "stats.bignum.users": "Utenti/giorno (media)",
   "stats.bignum.emoji": "Emoji",
   "stats.bignum.gif": "GIFs",
   "stats.bignum.emoticon": "Emoticon",

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -85,7 +85,7 @@
   "stats.hero.sub": "みんながよく使うものをライブでチェック。人気の絵文字、よく使われる機能、そして Mojito が動いている場所がわかります。",
   "stats.hero.updatesDaily": "毎日更新",
   "stats.lastUpdate": "最終更新 {date}",
-  "stats.bignum.users": "アクティブユーザー",
+  "stats.bignum.users": "1日の平均ユーザー数",
   "stats.bignum.emoji": "絵文字",
   "stats.bignum.gif": "GIF",
   "stats.bignum.emoticon": "顔文字",

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -85,7 +85,7 @@
   "stats.hero.sub": "사람들이 즐겨 찾는 것을 실시간으로 살펴봐요. 가장 사랑받는 이모지, 많이 쓰는 기능, 그리고 Mojito가 실행되는 곳까지요.",
   "stats.hero.updatesDaily": "매일 업데이트",
   "stats.lastUpdate": "마지막 업데이트 {date}",
-  "stats.bignum.users": "활성 사용자",
+  "stats.bignum.users": "일일 평균 사용자",
   "stats.bignum.emoji": "이모지",
   "stats.bignum.gif": "GIF",
   "stats.bignum.emoticon": "이모티콘",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -85,7 +85,7 @@
   "stats.hero.sub": "Een live blik op waar mensen naar grijpen — de populairste emoji, de meest gebruikte functies en waar Mojito draait.",
   "stats.hero.updatesDaily": "Dagelijks bijgewerkt",
   "stats.lastUpdate": "laatst bijgewerkt {date}",
-  "stats.bignum.users": "Actieve gebruikers",
+  "stats.bignum.users": "Gem. dagelijkse gebruikers",
   "stats.bignum.emoji": "Emoji",
   "stats.bignum.gif": "GIFs",
   "stats.bignum.emoticon": "Emoticons",

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -85,7 +85,7 @@
   "stats.hero.sub": "Podgląd na żywo tego, po co ludzie sięgają — najbardziej lubiane emoji, najczęściej używane funkcje i to, gdzie działa Mojito.",
   "stats.hero.updatesDaily": "Aktualizacja codziennie",
   "stats.lastUpdate": "ostatnia aktualizacja {date}",
-  "stats.bignum.users": "Aktywni użytkownicy",
+  "stats.bignum.users": "Śr. dzienni użytkownicy",
   "stats.bignum.emoji": "Emoji",
   "stats.bignum.gif": "GIF-y",
   "stats.bignum.emoticon": "Emotikony",

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -85,7 +85,7 @@
   "stats.hero.sub": "Uma olhada ao vivo no que as pessoas mais usam: os emoji mais queridos, os recursos que são usados e onde o Mojito roda.",
   "stats.hero.updatesDaily": "Atualiza diariamente",
   "stats.lastUpdate": "última atualização {date}",
-  "stats.bignum.users": "Usuários ativos",
+  "stats.bignum.users": "Usuários/dia (méd.)",
   "stats.bignum.emoji": "Emoji",
   "stats.bignum.gif": "GIFs",
   "stats.bignum.emoticon": "Emoticons",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -85,7 +85,7 @@
   "stats.hero.sub": "Живой взгляд на то, чем пользуются люди: самые любимые эмодзи, востребованные функции и то, где работает Mojito.",
   "stats.hero.updatesDaily": "Обновляется ежедневно",
   "stats.lastUpdate": "последнее обновление {date}",
-  "stats.bignum.users": "Активные пользователи",
+  "stats.bignum.users": "Польз. в день (сред.)",
   "stats.bignum.emoji": "Эмодзи",
   "stats.bignum.gif": "GIF",
   "stats.bignum.emoticon": "Смайлики",

--- a/i18n/zh-Hans.json
+++ b/i18n/zh-Hans.json
@@ -85,7 +85,7 @@
   "stats.hero.sub": "实时了解大家都在用什么——最受喜爱的表情、最常用的功能，以及 Mojito 的运行环境。",
   "stats.hero.updatesDaily": "每日更新",
   "stats.lastUpdate": "最后更新 {date}",
-  "stats.bignum.users": "活跃用户",
+  "stats.bignum.users": "日均用户",
   "stats.bignum.emoji": "表情",
   "stats.bignum.gif": "GIF",
   "stats.bignum.emoticon": "颜文字",

--- a/i18n/zh-Hant.json
+++ b/i18n/zh-Hant.json
@@ -85,7 +85,7 @@
   "stats.hero.sub": "即時了解大家都在用什麼——最受喜愛的表情符號、最常用的功能，以及 Mojito 的執行環境。",
   "stats.hero.updatesDaily": "每日更新",
   "stats.lastUpdate": "最後更新 {date}",
-  "stats.bignum.users": "活躍使用者",
+  "stats.bignum.users": "日均使用者",
   "stats.bignum.emoji": "表情符號",
   "stats.bignum.gif": "GIF",
   "stats.bignum.emoticon": "顏文字",

--- a/stats-live.js
+++ b/stats-live.js
@@ -66,7 +66,9 @@
   function applyLive(d) {
     setText("updated", t("stats.lastUpdate", "last update {date}").replace("{date}", fmtDate(d.generatedAt)));
 
-    num("bn-macs", d.macsSharingStats);
+    num("bn-macs", d.avgDailyActive != null
+      ? d.avgDailyActive
+      : Math.round((d.macsSharingStats || 0) / ((d.window && d.window.days) || 30)));
     num("bn-emoji", d.totals.emoji);
     num("bn-gif", d.totals.gif);
     num("bn-emoticon", d.totals.emoticon);

--- a/stats.html
+++ b/stats.html
@@ -50,7 +50,7 @@
   <section class="bignums reveal" aria-label="Headline totals" data-i18n-attr="aria-label:stats.aria.totals">
     <div class="bignum">
       <div class="bignum-value" id="bn-macs" data-count="9184" data-format="int">9,184</div>
-      <div class="bignum-label" data-i18n="stats.bignum.users">Active users</div>
+      <div class="bignum-label" data-i18n="stats.bignum.users">Avg. daily users</div>
     </div>
     <div class="bignum">
       <div class="bignum-value" id="bn-emoji" data-count="12600000" data-format="m1">12.6M</div>
@@ -275,6 +275,6 @@
   document.querySelectorAll('.reveal').forEach(function (s) { io.observe(s); });
 })();
 </script>
-<script src="stats-live.js?v=7"></script>
+<script src="stats-live.js?v=8"></script>
 </body>
 </html>


### PR DESCRIPTION
## What
The stats headline showed `macsSharingStats` (sum of daily-active pings = person-days) under the label "Active users", overstating headcount by multiplying each returning user across the days they appeared.

## Change
- `stats-live.js`: bind the headline to the worker's new `avgDailyActive` (fallback: `macsSharingStats / window.days` for older cached API responses).
- `stats.html`: relabel "Active users" → "Avg. daily users"; bump `stats-live.js` cache-buster to `v=8`.
- `i18n/*.json`: translate the new label across all 19 locales.

Pairs with the worker change in #121 (`avgDailyActive` in `/api/stats.json`).

Refs W-373