### PR TITLE
W-380: show top emoji at low volume (drop the >=5 floor)

### DIFF
--- a/stats-worker/src/index.js
+++ b/stats-worker/src/index.js
@@ -198,8 +198,8 @@ async function stats(env) {
       emoticon: totalsMap.emoticon || 0,
     },
     communityDiscoveries: eggs.results[0]?.value || 0,
-    topEmoji: emoji.results.map((r) => ({ hexcode: r.hexcode, count: r.c }))
-      .filter((r) => r.count >= 5), // light long-tail trim (cosmetic, not privacy)
+    // Top inserted emoji, capped — no count floor, so it never blanks at low volume.
+    topEmoji: emoji.results.map((r) => ({ hexcode: r.hexcode, count: r.c })).slice(0, 12),
     os: os, arch: arch, lang: lang, appVersion: app, skinTone: skin,
     features: featureList,
   };


### PR DESCRIPTION
## What
The stats page's "Top emoji" section was blank — the worker trimmed `topEmoji` to `count >= 5`, and no emoji has been inserted that many times yet (max is 3).

## Change
`stats-worker/src/index.js`: drop the count floor; return the top 12 by count. The list now reflects real data and only blanks when zero emoji have ever been inserted. The SQL already orders by count desc, so this is a `.slice(0, 12)` in place of the `.filter(count >= 5)`.

No page or i18n changes; worker redeploy required.

Refs W-380