### PR TITLE
W-386: fix URL exclusions in Chrome (and all Chromium browsers)

### DIFF
--- a/Sources/Mojito/Context/BrowserURL.swift
+++ b/Sources/Mojito/Context/BrowserURL.swift
@@ -11,8 +11,12 @@ enum BrowserURL {
 
         let app = AXUIElementCreateApplication(pid)
 
-        // Safari exposes AXURL on the web area.
-        if let url = focusedWebAreaURL(in: app) { return url }
+        // Most browsers expose the page URL as an `AXURL` attribute somewhere
+        // under the focused window — Safari/WebKit on the `AXWebArea`, Chrome
+        // and other Chromium browsers on a top-level `AXGroup`. Walking the
+        // tree DFS for the first element that carries `AXURL` finds the
+        // outermost page URL before any nested iframe.
+        if let url = focusedURL(in: app) { return url }
 
         if let raw = focusedAddressBarValue(in: app), let url = normalizedURL(from: raw) {
             return url
@@ -76,10 +80,12 @@ enum BrowserURL {
         "org.torproject.torbrowser",                // Tor Browser
     ]
 
-    private static func focusedWebAreaURL(in app: AXUIElement) -> URL? {
+    private static func focusedURL(in app: AXUIElement) -> URL? {
         guard let window = focusedWindow(in: app) else { return nil }
-        guard let webArea = findElement(role: "AXWebArea", under: window, depth: 6) else { return nil }
-        guard let value = copyAttribute(webArea, attribute: "AXURL") else { return nil }
+        guard let element = findElement(under: window, depth: 10, match: { el in
+            copyAttribute(el, attribute: "AXURL") != nil
+        }) else { return nil }
+        guard let value = copyAttribute(element, attribute: "AXURL") else { return nil }
         if let url = value as? URL { return url }
         if let str = value as? String { return URL(string: str) }
         return nil
@@ -87,7 +93,7 @@ enum BrowserURL {
 
     private static func focusedAddressBarValue(in app: AXUIElement) -> String? {
         guard let window = focusedWindow(in: app) else { return nil }
-        guard let toolbar = findElement(role: "AXToolbar", under: window, depth: 4) else { return nil }
+        guard let toolbar = findElement(role: "AXToolbar", under: window, depth: 10) else { return nil }
         guard let field = findAddressField(under: toolbar) else { return nil }
         return copyAttribute(field, attribute: kAXValueAttribute as String) as? String
     }


### PR DESCRIPTION
## Summary

The URL-pattern exclusion list silently no-op'd in every Chromium browser — `github.com` and `*.github.com` are in the default denylist, but the autocomplete picker still appeared on github.com in Chrome.

Root cause: `BrowserURL.focusedWebAreaURL` looked up the AX element by role `AXWebArea`. That role only exists in Safari/WebKit. Chrome (and other Chromium browsers) expose the page URL as `AXURL` on a top-level `AXGroup` instead, so detection returned `nil` and `ExclusionStore.isExcluded` saw no URL to match. The toolbar fallback didn't catch it either — Chrome's `AXToolbar` is at depth 6, past the depth-4 cap.

Fix: walk the AX tree for any descendant carrying an `AXURL` attribute (depth 10) instead of filtering by role. Works the same for Safari (finds it on `AXWebArea`) and for Chrome/Brave/Edge/etc. (finds it on the top-level `AXGroup`). Toolbar-search depth bumped 4→10 for the same reason.

Verified by AX-dumping both Chrome 149 and Safari on github.com — both now resolve `host=github.com`, which matches the default `github.com` and `*.github.com` patterns and suppresses the picker.

## Test plan

- [x] `scripts/run-tests.sh` — 181 tests pass
- [x] Re-ran the AX walk live against Chrome 149 + Safari on github.com → both return `host=github.com`
- [ ] Manual: type `:smile:` in a github.com comment box in Chrome → picker does NOT appear
- [ ] Manual: type `:smile:` in a github.com comment box in Safari → picker does NOT appear (no regression)
- [ ] Manual: type `:smile:` in a non-excluded site (e.g. example.com) in Chrome → picker DOES appear

Refs: W-386