### PR TITLE
W-388: stop the emoji browser from snapping mid-scroll on macOS 27 beta 1

### DIFF
--- a/Sources/Mojito/Browser/EmojiBrowserViewModel.swift
+++ b/Sources/Mojito/Browser/EmojiBrowserViewModel.swift
@@ -32,13 +32,28 @@ final class EmojiBrowserViewModel: ObservableObject {
         let cells: [Cell]
         var id: EmojiCategory { category }
         var startIndex: Int { cells.first?.id ?? 0 }
+        var indices: Range<Int> { startIndex..<(startIndex + cells.count) }
     }
 
     @Published private(set) var query: String = ""
     /// Section currently at the top of the scroll view — drives the tab
-    /// highlight. Derived from scroll position, not set by tab taps directly.
-    @Published var activeCategory: EmojiCategory
+    /// highlight. Backed by a Combine subject (not `@Published`) so the
+    /// scroll-driven updates from `onPreferenceChange` don't invalidate the
+    /// `InlineBrowserView` body and re-evaluate the `ScrollView`/`LazyVGrid`
+    /// mid-scroll — on macOS 27 beta 1 that re-eval visibly snapped the scroll
+    /// position back to the top when crossing a section boundary. The tab bar
+    /// subscribes to `activeCategoryPublisher` via `.onReceive` and holds its
+    /// own local highlight state instead.
+    private let activeCategorySubject: CurrentValueSubject<EmojiCategory, Never>
+    let activeCategoryPublisher: AnyPublisher<EmojiCategory, Never>
+    var activeCategory: EmojiCategory { activeCategorySubject.value }
     @Published var selectedIndex: Int = 0
+    /// Cell the mouse is currently hovering over. Plain (non-`@Published`)
+    /// storage so cells passing under a stationary cursor during a slow scroll
+    /// don't invalidate the `InlineBrowserView` body and reset the scroll
+    /// position. `selectedEmoji` prefers this over `selectedIndex` so
+    /// hover-then-Enter still inserts the hovered cell.
+    var hoverIndex: Int?
     /// Flat cell index to scroll into view (keyboard nav / reset to top). The
     /// view clears it to nil after handling so the same index can repeat.
     @Published var scrollTarget: Int?
@@ -66,7 +81,9 @@ final class EmojiBrowserViewModel: ObservableObject {
         let flat = built.flatMap { $0.cells.map(\.emoji) }
         self.flat = flat
         self.current = flat  // query starts empty → whole library
-        self.activeCategory = built.first?.category ?? .smileysPeople
+        let subject = CurrentValueSubject<EmojiCategory, Never>(built.first?.category ?? .smileysPeople)
+        self.activeCategorySubject = subject
+        self.activeCategoryPublisher = subject.eraseToAnyPublisher()
     }
 
     /// The addressable list for selection + keyboard nav: search results when
@@ -93,6 +110,7 @@ final class EmojiBrowserViewModel: ObservableObject {
 
     var selectedEmoji: Emoji? {
         let items = current
+        if let h = hoverIndex, items.indices.contains(h) { return items[h] }
         guard items.indices.contains(selectedIndex) else { return items.first }
         return items[selectedIndex]
     }
@@ -102,6 +120,7 @@ final class EmojiBrowserViewModel: ObservableObject {
         current = computeCurrent()
         selectedIndex = 0
         scrollTarget = 0  // back to top on every query change
+        selectionStale = false
     }
 
     /// Tab tap: jump the scroll view to that category's section. Clears any
@@ -115,14 +134,49 @@ final class EmojiBrowserViewModel: ObservableObject {
         }
         // If we were searching the list was a flat result grid; rebuilding the
         // sectioned list first, then jumping, keeps the target laid out.
-        activeCategory = category
+        setActiveCategory(category)
         categoryTarget = category
+        selectionStale = false  // tab tap is an explicit selection action
         if wasSearching { scrollTarget = nil }
     }
+
+    private func setActiveCategory(_ value: EmojiCategory) {
+        guard activeCategorySubject.value != value else { return }
+        activeCategorySubject.send(value)
+    }
+
+    /// True iff the viewport has scrolled to a different section since the
+    /// last `move`/`selectCategory`/`setQuery`. Drives the one-shot resync in
+    /// `move(_:)` so an arrow press after a mouse scroll lands where the user
+    /// is looking instead of snapping back to where the selection happens to be.
+    private var selectionStale: Bool = false
+    /// Timestamp of the last `move(_:)` — used by `updateActiveCategory` to
+    /// suppress `selectionStale` during the scroll animation triggered by that
+    /// move. Otherwise a section transition mid-animation, with `activeCategory`
+    /// lagging one section behind `selectedIndex`, flags stale and a quick
+    /// second arrow press resyncs back — observed as an intermittent wrap.
+    private var lastMoveAt: Date = .distantPast
 
     func move(_ direction: GifMoveDirection) {
         let count = current.count
         guard count > 0 else { return }
+        lastMoveAt = Date()
+        // Only resync the selection if the user has mouse-scrolled the viewport
+        // away from where the selection lives since the last selection action.
+        // `selectionStale` is flipped by scroll-driven `setActiveCategory`; a
+        // resync here just from `move()` would race the scroll-driven category
+        // update and snap the selection back to the previous section.
+        if !isSearching, selectionStale,
+           let active = sections.first(where: { $0.category == activeCategory }),
+           !active.indices.contains(selectedIndex)
+        {
+            selectedIndex = active.startIndex
+            scrollTarget = selectedIndex
+            selectionStale = false
+            return
+        }
+        selectionStale = false
+        let prev = selectedIndex
         // Search results are one flat grid (no headers), so simple column
         // stepping lands directly above/below.
         if isSearching {
@@ -140,7 +194,12 @@ final class EmojiBrowserViewModel: ObservableObject {
             // not by a flat ±8, so the selection tracks straight up/down.
             selectedIndex = sectionedTarget(from: selectedIndex, direction: direction)
         }
-        scrollTarget = selectedIndex
+        // Only fire the scroll target when the selection actually changed —
+        // otherwise a held arrow key at the top/bottom edge re-fires
+        // `scrollTo(0, .top)` every tick and the viewport visibly jitters.
+        if selectedIndex != prev {
+            scrollTarget = selectedIndex
+        }
     }
 
     /// Column-preserving ↑/↓ (and clamped flat ←/→) across the sectioned grid.
@@ -193,7 +252,22 @@ final class EmojiBrowserViewModel: ObservableObject {
         let threshold: CGFloat = 1
         let atOrAboveTop = offsets.filter { $0.value <= threshold }
         guard let active = atOrAboveTop.max(by: { $0.value < $1.value })?.key else { return }
-        if active != activeCategory { activeCategory = active }
+        let changed = active != activeCategorySubject.value
+        setActiveCategory(active)
+        // Mark the selection stale only when the user has scrolled into a
+        // section that does NOT already contain `selectedIndex`, AND the scroll
+        // isn't the tail of an arrow-key animation. Arrow-induced scrolls
+        // animate over ~hundreds of ms; if `activeCategory` lags `selectedIndex`
+        // by one section during that window, we'd flag stale and a quick second
+        // arrow press would resync — observed as an intermittent wrap-to-top.
+        // The `Date()` read is deferred behind `changed` because most scroll
+        // frames don't transition section.
+        guard changed,
+              let section = sections.first(where: { $0.category == active }),
+              !section.indices.contains(selectedIndex),
+              Date().timeIntervalSince(lastMoveAt) >= 0.75
+        else { return }
+        selectionStale = true
     }
 
     private static func build(

--- a/Sources/Mojito/Browser/InlineBrowserView.swift
+++ b/Sources/Mojito/Browser/InlineBrowserView.swift
@@ -1,3 +1,4 @@
+import Combine
 import SwiftUI
 
 /// The full-library grid, shown by *growing the picker panel* (not a separate
@@ -23,9 +24,6 @@ struct InlineBrowserView: View {
     /// editable `TextField`.
     var editableSearch: Bool = false
 
-    @State private var hoverIndex: Int?
-    @State private var tooltipIndex: Int?
-    @State private var hoverWork: DispatchWorkItem?
     @State private var tooltipSize: CGSize = .zero
     @State private var typedQuery = ""
     @FocusState private var searchFieldFocused: Bool
@@ -205,36 +203,14 @@ struct InlineBrowserView: View {
     }
 
     private func cell(_ emoji: Emoji, index: Int) -> some View {
-        let isSelected = index == browser.selectedIndex
-        let glyph = emoji.tonedGlyph
-        return Text(glyph)
-            .font(.system(size: 25))  // match the pill's glyph size
-            .frame(maxWidth: .infinity)
-            .frame(height: Self.cellHeight)
-            .background(
-                RoundedRectangle(cornerRadius: 9, style: .continuous)
-                    .fill(isSelected ? Color(nsColor: .unemphasizedSelectedContentBackgroundColor) : Color.clear)
-            )
-            .contentShape(Rectangle())
-            .anchorPreference(key: TooltipAnchorKey.self, value: .bounds) { anchor in
-                tooltipIndex == index ? TooltipData(text: ":\(emoji.primaryShortcode):", anchor: anchor) : nil
-            }
-            .onTapGesture { onPick(emoji) }
-            .onHover { hovering in
-                hoverWork?.cancel()
-                if hovering {
-                    browser.selectedIndex = index
-                    hoverIndex = index
-                    let work = DispatchWorkItem {
-                        if hoverIndex == index { tooltipIndex = index }
-                    }
-                    hoverWork = work
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: work)
-                } else {
-                    if hoverIndex == index { hoverIndex = nil }
-                    if tooltipIndex == index { tooltipIndex = nil }
-                }
-            }
+        BrowserCell(
+            emoji: emoji,
+            index: index,
+            isKeyboardSelected: index == browser.selectedIndex,
+            cellHeight: Self.cellHeight,
+            onPick: onPick,
+            onHoverChanged: { browser.hoverIndex = $0 }
+        )
     }
 
     private var emptyResults: some View {
@@ -255,36 +231,16 @@ struct InlineBrowserView: View {
     private var categoryBar: some View {
         ZStack(alignment: .bottom) {
             tabBarBackdrop
-            tabBarIcons
+            CategoryTabBar(
+                categories: browser.visibleCategories,
+                isSearching: browser.isSearching,
+                activeCategoryPublisher: browser.activeCategoryPublisher,
+                initialActiveCategory: browser.activeCategory,
+                tabBarHeight: Self.tabBarHeight,
+                onCategory: onCategory
+            )
         }
         .frame(height: Self.tabBarHeight + Self.tabBarFade)
-    }
-
-    private var tabBarIcons: some View {
-        HStack(spacing: 1) {
-            ForEach(browser.visibleCategories) { category in
-                // Active = the section scrolled to the top (cleared while searching).
-                let isActive = !browser.isSearching && browser.activeCategory == category
-                Button {
-                    onCategory(category)
-                } label: {
-                    Image(systemName: category.tabSymbol)
-                        .font(.system(size: 13))
-                        .foregroundStyle(isActive ? Color.primary : Color.secondary)
-                        .frame(width: 30, height: 26)
-                        .background(
-                            RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                .fill(isActive ? Color(nsColor: .unemphasizedSelectedContentBackgroundColor) : .clear)
-                        )
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .help(category.title)
-            }
-            Spacer(minLength: 0)
-        }
-        .padding(.horizontal, 8)
-        .frame(height: Self.tabBarHeight)
     }
 
     /// Glass/material masked by a vertical gradient so it fades *in* toward the
@@ -304,6 +260,111 @@ struct InlineBrowserView: View {
                     endPoint: .bottom
                 )
             )
+    }
+}
+
+/// One emoji cell, broken out so hover state is per-cell `@State` and a cell
+/// scrolling under the cursor only invalidates itself — not the parent
+/// `InlineBrowserView`, which would re-evaluate the `ScrollView` and reset the
+/// scroll position on macOS 27 beta 1.
+private struct BrowserCell: View {
+    let emoji: Emoji
+    let index: Int
+    let isKeyboardSelected: Bool
+    let cellHeight: CGFloat
+    let onPick: (Emoji) -> Void
+    let onHoverChanged: (Int?) -> Void
+
+    @State private var hovered: Bool = false
+    @State private var showTooltip: Bool = false
+    @State private var tooltipWork: DispatchWorkItem?
+
+    var body: some View {
+        let glyph = emoji.tonedGlyph
+        let highlighted = isKeyboardSelected || hovered
+        Text(glyph)
+            .font(.system(size: 25))  // match the pill's glyph size
+            .frame(maxWidth: .infinity)
+            .frame(height: cellHeight)
+            .background(
+                RoundedRectangle(cornerRadius: 9, style: .continuous)
+                    .fill(highlighted ? Color(nsColor: .unemphasizedSelectedContentBackgroundColor) : Color.clear)
+            )
+            .contentShape(Rectangle())
+            .anchorPreference(key: TooltipAnchorKey.self, value: .bounds) { anchor in
+                showTooltip ? TooltipData(text: ":\(emoji.primaryShortcode):", anchor: anchor) : nil
+            }
+            .onTapGesture { onPick(emoji) }
+            .onHover { hovering in
+                tooltipWork?.cancel()
+                hovered = hovering
+                onHoverChanged(hovering ? index : nil)
+                if hovering {
+                    let work = DispatchWorkItem { showTooltip = true }
+                    tooltipWork = work
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: work)
+                } else {
+                    showTooltip = false
+                }
+            }
+    }
+}
+
+/// Tab bar pulled into its own view so the active-section highlight tracks the
+/// scroll position through a local `@State` driven by a Combine publisher,
+/// instead of through a `@Published` on `EmojiBrowserViewModel`. The point: a
+/// scroll-driven activeCategory change must not invalidate the parent
+/// `InlineBrowserView` body (and re-evaluate the `ScrollView`/`LazyVGrid`
+/// mid-scroll, which on macOS 27 beta 1 snapped the scroll position back).
+private struct CategoryTabBar: View {
+    let categories: [EmojiCategory]
+    let isSearching: Bool
+    let activeCategoryPublisher: AnyPublisher<EmojiCategory, Never>
+    let tabBarHeight: CGFloat
+    let onCategory: (EmojiCategory) -> Void
+    @State private var activeCategory: EmojiCategory
+
+    init(
+        categories: [EmojiCategory],
+        isSearching: Bool,
+        activeCategoryPublisher: AnyPublisher<EmojiCategory, Never>,
+        initialActiveCategory: EmojiCategory,
+        tabBarHeight: CGFloat,
+        onCategory: @escaping (EmojiCategory) -> Void
+    ) {
+        self.categories = categories
+        self.isSearching = isSearching
+        self.activeCategoryPublisher = activeCategoryPublisher
+        self.tabBarHeight = tabBarHeight
+        self.onCategory = onCategory
+        self._activeCategory = State(initialValue: initialActiveCategory)
+    }
+
+    var body: some View {
+        HStack(spacing: 1) {
+            ForEach(categories) { category in
+                let isActive = !isSearching && activeCategory == category
+                Button {
+                    onCategory(category)
+                } label: {
+                    Image(systemName: category.tabSymbol)
+                        .font(.system(size: 13))
+                        .foregroundStyle(isActive ? Color.primary : Color.secondary)
+                        .frame(width: 30, height: 26)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                .fill(isActive ? Color(nsColor: .unemphasizedSelectedContentBackgroundColor) : .clear)
+                        )
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help(category.title)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 8)
+        .frame(height: tabBarHeight)
+        .onReceive(activeCategoryPublisher) { activeCategory = $0 }
     }
 }
 

--- a/Sources/Mojito/Picker/PickerWindow.swift
+++ b/Sources/Mojito/Picker/PickerWindow.swift
@@ -171,6 +171,9 @@ final class PickerWindow {
     /// Anchors near the caret rect, or the mouse if nil.
     func show(near caret: CGRect?) {
         hidePillTooltip()  // clear any stale tooltip; re-shows on hover
+        // Pill / list mode tracks the caret; if the user dragged a previous
+        // expanded session, snap back to caret-anchored on the next open.
+        panel.isMovableByWindowBackground = false
         let anchor = caret ?? mouseAnchor()
         // Follow the live system appearance. A borderless panel created once
         // and reused otherwise stays pinned to its launch-time appearance, so
@@ -197,6 +200,10 @@ final class PickerWindow {
     func showExpanded(near caret: CGRect?) {
         hidePillTooltip()
         panel.appearance = NSApp.effectiveAppearance
+        // Browser window can be dragged from any background area (search row,
+        // tab bar, gaps between cells) — buttons and cells still receive their
+        // own clicks via AppKit's hit-testing.
+        panel.isMovableByWindowBackground = true
         setCornerRadius(BrowserLayout.cornerRadius)
         let size = CGSize(width: BrowserLayout.width, height: BrowserLayout.height)
 


### PR DESCRIPTION
## Summary
- Lift every per-frame scroll mutation off the `@ObservedObject` invalidation path so the browser's `ScrollView`/`LazyVGrid` stops re-evaluating mid-scroll on macOS 27 beta 1 (was visibly snapping back to the top).
- `activeCategory` rides a Combine subject the new `CategoryTabBar` mirrors via `.onReceive`; `BrowserCell` is extracted with per-cell `@State` hover/tooltip; `hoverIndex` is non-published storage `selectedEmoji` falls back to so Enter-while-hovering still inserts the hovered cell.
- Arrow nav: `move(_:)` only fires `scrollTarget` on a real change, and resyncs the selection to the active section after a mouse scroll (gated by a 750 ms `lastMoveAt` window to avoid racing the arrow-induced scroll animation).
- Browser window is now draggable (`isMovableByWindowBackground` toggled per show mode).

## Test plan
- [x] Pure-logic test suite (`scripts/run-tests.sh`) passes.
- [ ] Slow-scroll past Quick Access — smooth, no snap-back.
- [ ] Mouse-scroll deep, then arrow up — first press resyncs to visible section, subsequent presses walk row-by-row.
- [ ] Arrow-down through Quick Access → Smileys → next sections — walks row-by-row, no intermittent wrap-to-top.
- [ ] Held arrow at top/bottom — no jitter.
- [ ] Drag the browser window by an empty background area — repositions.
- [ ] Click any cell — still inserts. Hover-then-Enter — still inserts the hovered cell.

Refs W-388