### PR TITLE
W-394: make "Convert text arrows" independent of "Convert emoticons"

### DIFF
--- a/Sources/Mojito/App/AppDelegate.swift
+++ b/Sources/Mojito/App/AppDelegate.swift
@@ -53,6 +53,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: PrefsKey.firstLaunchDate)
         }
 
+        // Arrows were a sub-toggle of emoticons before v1.4: emoticons off
+        // meant arrows implicitly off, and the hidden sub-toggle was never
+        // written. Pin that state now that the toggles are independent, so
+        // updating doesn't switch arrow conversion on behind anyone's back.
+        // Self-limiting: a no-op once the arrow key holds any value.
+        if UserDefaults.standard.object(forKey: PrefsKey.arrowConversionEnabled) == nil,
+           (UserDefaults.standard.object(forKey: PrefsKey.emoticonsEnabled) as? Bool) == false {
+            UserDefaults.standard.set(false, forKey: PrefsKey.arrowConversionEnabled)
+        }
+
         // Anonymous, consent-gated daily stats. Self-gates — a no-op until the
         // user has seen the notice and left it enabled.
         TelemetryUploader.shared.uploadIfDue()

--- a/Sources/Mojito/App/Engine.swift
+++ b/Sources/Mojito/App/Engine.swift
@@ -187,18 +187,16 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
         // The pill is summoned by `:?` when Quick Access is enabled.
         let qaEnabled = (defaults.object(forKey: PrefsKey.quickAccessEnabled) as? Bool) ?? true
         stateMachine.quickAccessTrigger = qaEnabled ? "?" : nil
-        // Arrows are inert unless both emoticons and the arrow sub-toggle are on
-        // — gating in the SM means a disabled arrow never defers or consumes a
-        // following char (which would otherwise be dropped when the insert is
-        // suppressed downstream).
+        // Gating arrows in the SM means a disabled arrow never defers or
+        // consumes a following char (which would otherwise be dropped when
+        // the insert is suppressed downstream).
         stateMachine.arrowConversionEnabled = arrowConversionActive
     }
 
-    /// Arrow conversion runs only when emoticons *and* the arrow sub-toggle are
-    /// both on. The sub-toggle is read fresh (cheap, off the keystroke path).
+    /// Arrow conversion is independent of the emoticon toggle. Read fresh
+    /// (cheap, off the keystroke path).
     private var arrowConversionActive: Bool {
-        let arrowsOn = (UserDefaults.standard.object(forKey: PrefsKey.arrowConversionEnabled) as? Bool) ?? true
-        return emoticonsEnabled && arrowsOn
+        (UserDefaults.standard.object(forKey: PrefsKey.arrowConversionEnabled) as? Bool) ?? true
     }
 
     deinit {
@@ -1256,11 +1254,15 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
         )
     }
 
-    /// Ambient lookup, honoring the emoticon master toggle and the arrow
-    /// sub-toggle. `nil` means the word stays literal.
+    /// Ambient lookup. Arrows answer to the arrow toggle, every other
+    /// ambient emoticon to the emoticon toggle — the two are independent.
+    /// `nil` means the word stays literal.
     private func ambientEmoji(for word: String) -> String? {
-        guard emoticonsEnabled,
-              arrowConversionActive || !AmbientEmoticonTable.isArrow(word) else { return nil }
+        if AmbientEmoticonTable.isArrow(word) {
+            guard arrowConversionActive else { return nil }
+        } else {
+            guard emoticonsEnabled else { return nil }
+        }
         return AmbientEmoticonTable.emoji(for: word)
     }
 

--- a/Sources/Mojito/KeyMonitor/TriggerStateMachine.swift
+++ b/Sources/Mojito/KeyMonitor/TriggerStateMachine.swift
@@ -135,8 +135,13 @@ struct TriggerStateMachine {
     /// inert — never matched as a suffix, never deferred, never consume a
     /// following char — so they read as plain text. The Engine sets it from
     /// `PrefsKey.arrowConversionEnabled`. Other ambient emoticons (`<3`, …)
-    /// are unaffected.
-    var arrowConversionEnabled: Bool = true
+    /// are unaffected. Turning it off drops any deferred arrow match, so a
+    /// fire held back before the toggle flipped can't land after it.
+    var arrowConversionEnabled: Bool = true {
+        didSet {
+            if !arrowConversionEnabled { pendingImmediateFire = nil }
+        }
+    }
 
     /// The character that, typed right after a bare `:`, opens the Quick Access
     /// pill (e.g. `?` → `:?`). `nil` disables it. The Engine sets it from

--- a/Sources/Mojito/Settings/GeneralSettings.swift
+++ b/Sources/Mojito/Settings/GeneralSettings.swift
@@ -76,11 +76,8 @@ struct GeneralSettingsView: View {
                     .toggleStyle(.switch)
                 Toggle("Convert emoticons (`:D` → 😃)", isOn: $emoticonsEnabled)
                     .toggleStyle(.switch)
-                if emoticonsEnabled {
-                    Toggle("Convert text arrows (`->` to →)", isOn: $arrowConversionEnabled)
-                        .toggleStyle(.switch)
-                        .padding(.leading, 20)
-                }
+                Toggle("Convert text arrows (`->` to →)", isOn: $arrowConversionEnabled)
+                    .toggleStyle(.switch)
             }
 
             QuickAccessSection()

--- a/Sources/Mojito/Util/PrefsKey.swift
+++ b/Sources/Mojito/Util/PrefsKey.swift
@@ -43,8 +43,8 @@ enum PrefsKey {
     static let skinTone              = "mojito.skinTone"
     /// `:D` → 😃 conversion.
     static let emoticonsEnabled      = "mojito.emoticonsEnabled"
-    /// Sub-toggle of `emoticonsEnabled`: text-arrow conversion (`->` → →,
-    /// `<-` → ←, `<->` → ↔). Default on; off leaves arrows as literal text.
+    /// Text-arrow conversion (`->` → →, `<-` → ←, `<->` → ↔), independent
+    /// of `emoticonsEnabled`. Default on; off leaves arrows as literal text.
     static let arrowConversionEnabled = "mojito.arrowConversionEnabled"
     /// Experimental Symbols (★ ⌘ ⌥ …) included in fuzzy search.
     static let symbolsEnabled        = "mojito.symbolsEnabled"

--- a/Tests/MojitoTests/TriggerStateMachineTests.swift
+++ b/Tests/MojitoTests/TriggerStateMachineTests.swift
@@ -539,6 +539,30 @@ struct TriggerStateMachineTests {
         #expect(sm.handle(.nameChar("3")).action == .insertAmbientEmoticon(word: "<3", trailing: ""))
     }
 
+    @Test func arrowToggleOffDropsDeferredArrowFire() {
+        // `<-` defers waiting for a possible `<->`. If the toggle flips off
+        // while the fire is pending, the pending match is dropped — the next
+        // char must not collapse it into an insert.
+        var sm = TriggerStateMachine()
+        _ = sm.handle(.cancelChar("<"))
+        _ = sm.handle(.nameChar("-"))                                // deferred
+        sm.arrowConversionEnabled = false
+        let x = sm.handle(.nameChar("x"))
+        #expect(x.action == .none)
+        #expect(x.consumesKey == false)
+    }
+
+    @Test func arrowToggleOffThenOnRestoresConversion() {
+        var sm = TriggerStateMachine()
+        sm.arrowConversionEnabled = false
+        _ = sm.handle(.nameChar("-"))
+        #expect(sm.handle(.cancelChar(">")).action == .none)
+        sm.arrowConversionEnabled = true
+        _ = sm.handle(.cancelChar(" "))                              // clear buffer
+        _ = sm.handle(.nameChar("-"))
+        #expect(sm.handle(.cancelChar(">")).action == .insertAmbientEmoticon(word: "->", trailing: ""))
+    }
+
     @Test func ambientTerminatorChecksWordThenResetsBuffer() {
         var sm = TriggerStateMachine()
         for ch in "hello" { _ = sm.handle(.nameChar(ch)) }


### PR DESCRIPTION
## Summary

"Convert text arrows" was a sub-toggle of "Convert emoticons" — hidden in Settings when emoticons were off and gated on both prefs at runtime. Requested in #130: arrow conversion without emoticon conversion.

- Settings: the two toggles are now siblings (arrow toggle always visible, no indent). Labels unchanged, so existing localizations carry over.
- Runtime: arrows gate only on `arrowConversionEnabled`; colon-emoticons and other ambient emoticons (`<3`, `XD`, …) gate only on `emoticonsEnabled`.
- Migration: one-time launch check pins arrows off for installs that had emoticons explicitly off with the (previously hidden) arrow key unset — updating doesn't silently enable arrow conversion.
- Fix: a deferred arrow match (`<-` held back waiting for a possible `<->`) is dropped when the toggle flips off, so a pending conversion can't land after arrows were disabled.

Closes #130.

## Test plan

- 2 new `TriggerStateMachine` tests: deferred fire dropped on toggle-off; off→on restores conversion. Full suite green (`scripts/run-tests.sh`, also enforced by the pre-push hook).
- Manual: emoticons OFF / arrows ON → `->` converts, `:D ` and `<3 ` stay literal; emoticons ON / arrows OFF → inverse; toggles take effect immediately without restart.

Refs W-394