### PR TITLE
W-405: "Check for Updates…" window opens behind other windows

### DIFF
--- a/Sources/Mojito/App/UpdaterCoordinator.swift
+++ b/Sources/Mojito/App/UpdaterCoordinator.swift
@@ -4,7 +4,7 @@ import os.log
 import Sparkle
 
 @MainActor
-final class UpdaterCoordinator: NSObject, ObservableObject, SPUUpdaterDelegate {
+final class UpdaterCoordinator: NSObject, ObservableObject, SPUUpdaterDelegate, SPUStandardUserDriverDelegate {
     static let shared = UpdaterCoordinator()
 
     /// Sparkle's standard driver only shows errors for user-initiated checks.
@@ -19,7 +19,7 @@ final class UpdaterCoordinator: NSObject, ObservableObject, SPUUpdaterDelegate {
     @Published private(set) var hasUpdateAvailable = false
 
     private let log = OSLog(subsystem: "ee.wells.Mojito", category: "Updater")
-    private let driver = SPUStandardUserDriver(hostBundle: .main, delegate: nil)
+    private lazy var driver = SPUStandardUserDriver(hostBundle: .main, delegate: self)
     private lazy var updater: SPUUpdater = SPUUpdater(
         hostBundle: .main,
         applicationBundle: .main,
@@ -119,5 +119,19 @@ final class UpdaterCoordinator: NSObject, ObservableObject, SPUUpdaterDelegate {
             self.hasUpdateError = false
             self.hasUpdateAvailable = false
         }
+    }
+
+    // MARK: - SPUStandardUserDriverDelegate
+
+    /// Mojito is an `.accessory` app, so Sparkle orders its windows front but
+    /// never activates us — leaving the update window beneath the frontmost
+    /// app. Pull the app forward right before Sparkle presents any UI. These
+    /// fire on the main thread (they bracket AppKit window/alert presentation).
+    nonisolated func standardUserDriverWillHandleShowingUpdate(_ handleShowingUpdate: Bool, forUpdate update: SUAppcastItem, state: SPUUserUpdateState) {
+        MainActor.assumeIsolated { NSApp.activate(ignoringOtherApps: true) }
+    }
+
+    nonisolated func standardUserDriverWillShowModalAlert() {
+        MainActor.assumeIsolated { NSApp.activate(ignoringOtherApps: true) }
     }
 }


### PR DESCRIPTION
## Summary

Clicking "Check for Updates…" in the menu bar showed Sparkle's update window (and the "you're up to date" / error alerts) *behind* whatever else was on screen.

**Cause:** Mojito runs as an `.accessory` (menu-bar) app and `SPUStandardUserDriver` was created with `delegate: nil`. Sparkle orders its windows front but never *activates* the app, so for a background app the window lands beneath the frontmost one.

**Fix:** `UpdaterCoordinator` now conforms to `SPUStandardUserDriverDelegate` and is wired in as the driver delegate. It calls `NSApp.activate(ignoringOtherApps: true)` — the activation convention used throughout this codebase — right before Sparkle presents any UI:
- `standardUserDriverWillHandleShowingUpdate(…)` → the "update available" window
- `standardUserDriverWillShowModalAlert` → the "up to date" / error alerts

Both fire on the main thread (they bracket AppKit presentation), so they dispatch synchronously via `MainActor.assumeIsolated`.

## Test plan

⚠️ Sparkle is **disabled in Debug builds** (`start()` early-returns under `#if DEBUG`), so this path can't be exercised by the dev build. Verification requires a notarized release:

- [ ] In a release build, click **Check for Updates…** while another app is frontmost → the update / "up to date" window appears **in front**.
- [ ] Same for the error alert (e.g. with the network down).
- [ ] Deferred-update badge → clicking **Update available…** re-surfaces the window in front.

Compiles clean (`xcodebuild … Debug build` → BUILD SUCCEEDED).

Refs W-405