### PR TITLE
W-405: float Sparkle's update window above other apps

### DIFF
--- a/Sources/Mojito/App/UpdaterCoordinator.swift
+++ b/Sources/Mojito/App/UpdaterCoordinator.swift
@@ -123,24 +123,15 @@ final class UpdaterCoordinator: NSObject, ObservableObject, SPUUpdaterDelegate, 
 
     // MARK: - SPUStandardUserDriverDelegate
 
-    /// Getting Sparkle's window in front is harder than it looks for a menu-bar
-    /// (`.accessory`) app. Once the appcast round-trip finishes, the app no
-    /// longer owns the active event, so macOS denies activation — `NSApp
-    /// .activate` is a no-op (Sparkle calls it too, with the same result), and
-    /// the window lands behind whatever's frontmost. So instead of fighting
-    /// activation, we float the window above other apps by raising its window
-    /// *level* (the same trick the picker panel uses); that doesn't depend on
-    /// activation at all. Promotion to `.regular` is kept as well so the app
-    /// gets a dock icon / ⌘-Tab entry while the update UI is up, ref-counted
-    /// through `DockIconManager` so it composes with an open settings window.
-    private var didPromoteForUpdateUI = false
-
-    private func promoteForUpdateUI() {
-        if !didPromoteForUpdateUI {
-            didPromoteForUpdateUI = true
-            DockIconManager.windowDidOpen()
-        }
-        NSApp.activate(ignoringOtherApps: true)
+    /// Getting Sparkle's window in front is hard for a menu-bar (`.accessory`)
+    /// app: once the appcast round-trip finishes the app no longer owns the
+    /// active event, so macOS denies activation (`NSApp.activate` is a no-op —
+    /// Sparkle calls it too, same result) and the window lands behind whatever's
+    /// frontmost. Fighting activation also makes the Dock bounce the icon for
+    /// attention. So don't fight it: float the window above other apps by
+    /// raising its window *level* (the activation-independent trick the picker
+    /// panel uses) and leave the app a quiet menu-bar app — no dock bounce.
+    private func raiseUpdaterWindowSoon() {
         // The window doesn't exist yet when these hooks fire, and the no-update
         // / error path then blocks the main thread in `runModal` — so schedule
         // the raise across default + modal run-loop modes, on a short retry
@@ -151,12 +142,9 @@ final class UpdaterCoordinator: NSObject, ObservableObject, SPUUpdaterDelegate, 
         }
     }
 
-    private func demoteAfterUpdateUI() {
+    private func cancelPendingRaise() {
         NSObject.cancelPreviousPerformRequests(
             withTarget: self, selector: #selector(raiseUpdaterWindow), object: nil)
-        guard didPromoteForUpdateUI else { return }
-        didPromoteForUpdateUI = false
-        DockIconManager.windowDidClose()
     }
 
     /// Float whichever window Sparkle just presented above other applications.
@@ -174,18 +162,18 @@ final class UpdaterCoordinator: NSObject, ObservableObject, SPUUpdaterDelegate, 
 
     // These fire on the main thread (they bracket AppKit presentation).
     nonisolated func standardUserDriverWillHandleShowingUpdate(_ handleShowingUpdate: Bool, forUpdate update: SUAppcastItem, state: SPUUserUpdateState) {
-        MainActor.assumeIsolated { promoteForUpdateUI() }
+        MainActor.assumeIsolated { raiseUpdaterWindowSoon() }
     }
 
     nonisolated func standardUserDriverWillShowModalAlert() {
-        MainActor.assumeIsolated { promoteForUpdateUI() }
+        MainActor.assumeIsolated { raiseUpdaterWindowSoon() }
     }
 
     nonisolated func standardUserDriverDidShowModalAlert() {
-        MainActor.assumeIsolated { demoteAfterUpdateUI() }
+        MainActor.assumeIsolated { cancelPendingRaise() }
     }
 
     nonisolated func standardUserDriverWillFinishUpdateSession() {
-        MainActor.assumeIsolated { demoteAfterUpdateUI() }
+        MainActor.assumeIsolated { cancelPendingRaise() }
     }
 }

--- a/Sources/Mojito/App/UpdaterCoordinator.swift
+++ b/Sources/Mojito/App/UpdaterCoordinator.swift
@@ -123,15 +123,69 @@ final class UpdaterCoordinator: NSObject, ObservableObject, SPUUpdaterDelegate, 
 
     // MARK: - SPUStandardUserDriverDelegate
 
-    /// Mojito is an `.accessory` app, so Sparkle orders its windows front but
-    /// never activates us — leaving the update window beneath the frontmost
-    /// app. Pull the app forward right before Sparkle presents any UI. These
-    /// fire on the main thread (they bracket AppKit window/alert presentation).
+    /// Getting Sparkle's window in front is harder than it looks for a menu-bar
+    /// (`.accessory`) app. Once the appcast round-trip finishes, the app no
+    /// longer owns the active event, so macOS denies activation — `NSApp
+    /// .activate` is a no-op (Sparkle calls it too, with the same result), and
+    /// the window lands behind whatever's frontmost. So instead of fighting
+    /// activation, we float the window above other apps by raising its window
+    /// *level* (the same trick the picker panel uses); that doesn't depend on
+    /// activation at all. Promotion to `.regular` is kept as well so the app
+    /// gets a dock icon / ⌘-Tab entry while the update UI is up, ref-counted
+    /// through `DockIconManager` so it composes with an open settings window.
+    private var didPromoteForUpdateUI = false
+
+    private func promoteForUpdateUI() {
+        if !didPromoteForUpdateUI {
+            didPromoteForUpdateUI = true
+            DockIconManager.windowDidOpen()
+        }
+        NSApp.activate(ignoringOtherApps: true)
+        // The window doesn't exist yet when these hooks fire, and the no-update
+        // / error path then blocks the main thread in `runModal` — so schedule
+        // the raise across default + modal run-loop modes, on a short retry
+        // ladder to beat the show / runModal race.
+        for delay in [0.0, 0.1, 0.25] {
+            perform(#selector(raiseUpdaterWindow), with: nil, afterDelay: delay,
+                    inModes: [.default, .modalPanel, .common])
+        }
+    }
+
+    private func demoteAfterUpdateUI() {
+        NSObject.cancelPreviousPerformRequests(
+            withTarget: self, selector: #selector(raiseUpdaterWindow), object: nil)
+        guard didPromoteForUpdateUI else { return }
+        didPromoteForUpdateUI = false
+        DockIconManager.windowDidClose()
+    }
+
+    /// Float whichever window Sparkle just presented above other applications.
+    /// `modalWindow` covers the no-update / error `NSAlert`; the update-found
+    /// window is matched by the `SUUpdateAlert` identifier set in Sparkle's nib.
+    @objc private func raiseUpdaterWindow() {
+        let window = NSApp.modalWindow
+            ?? NSApp.windows.first { $0.isVisible && $0.identifier?.rawValue == "SUUpdateAlert" }
+        guard let window else { return }
+        if window.level.rawValue < NSWindow.Level.floating.rawValue {
+            window.level = .floating
+        }
+        window.orderFrontRegardless()
+    }
+
+    // These fire on the main thread (they bracket AppKit presentation).
     nonisolated func standardUserDriverWillHandleShowingUpdate(_ handleShowingUpdate: Bool, forUpdate update: SUAppcastItem, state: SPUUserUpdateState) {
-        MainActor.assumeIsolated { NSApp.activate(ignoringOtherApps: true) }
+        MainActor.assumeIsolated { promoteForUpdateUI() }
     }
 
     nonisolated func standardUserDriverWillShowModalAlert() {
-        MainActor.assumeIsolated { NSApp.activate(ignoringOtherApps: true) }
+        MainActor.assumeIsolated { promoteForUpdateUI() }
+    }
+
+    nonisolated func standardUserDriverDidShowModalAlert() {
+        MainActor.assumeIsolated { demoteAfterUpdateUI() }
+    }
+
+    nonisolated func standardUserDriverWillFinishUpdateSession() {
+        MainActor.assumeIsolated { demoteAfterUpdateUI() }
     }
 }


### PR DESCRIPTION
## What

The "Check for Updates…" window (and the *"you're up to date"* / error alerts) kept opening **behind** whatever app was frontmost. The v1.5.0 fix and a follow-up that promoted the app to `.regular` both relied on `NSApp.activate` — but once the appcast network round-trip finishes, the `.accessory` menu-bar app no longer owns the active event and macOS **denies activation**. Sparkle itself calls `NSApp.activate` on the same path with the same result, so the window kept landing behind.

## Fix

Stop fighting activation. Grab the window Sparkle just presented and raise its **window level to `.floating`** so it sits above other apps' normal windows — the same activation-independent trick the emoji picker panel uses.

- No-update / error `NSAlert` → reached via `NSApp.modalWindow`.
- Update-available window → matched by the `SUUpdateAlert` identifier from Sparkle's nib.
- Raise is scheduled across `default` + `modalPanel` run-loop modes (the error path blocks in `runModal`) on a short retry ladder to beat the show/`runModal` race.
- `.regular` promotion is kept (ref-counted via `DockIconManager`) so the app still gets a dock icon / ⌘-Tab entry while the update UI is up.

## Test plan

Verified by hand against a dev build with the updater temporarily enabled (it's `#if DEBUG`-disabled normally): with another app frontmost, clicking **Check for Updates…** now brings the *"you're up to date"* window **in front** of the active app. Update-available and modal-alert paths share the same raise logic.

Refs: W-405