### PR TITLE
W-426: scope stats feature-usage to real features + add Quick Access metrics + telemetry lint

### DIFF
--- a/.github/workflows/telemetry.yml
+++ b/.github/workflows/telemetry.yml
@@ -1,0 +1,29 @@
+name: telemetry
+
+# Fail a PR (or push to main) that lets the anonymous-stats pipeline drift:
+# the Swift client, the worker ingest allow-list, and the published feature set
+# must stay in sync. Pure-Python check — no Xcode/Wrangler needed, runs in
+# seconds.
+on:
+  pull_request:
+    paths:
+      - "Sources/Mojito/Telemetry/TelemetryUploader.swift"
+      - "stats-worker/src/index.js"
+      - "scripts/check_telemetry.py"
+      - ".github/workflows/telemetry.yml"
+  push:
+    branches: [main]
+    paths:
+      - "Sources/Mojito/Telemetry/TelemetryUploader.swift"
+      - "stats-worker/src/index.js"
+      - "scripts/check_telemetry.py"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python3 scripts/check_telemetry.py

--- a/Sources/Mojito/App/Engine.swift
+++ b/Sources/Mojito/App/Engine.swift
@@ -960,6 +960,9 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
             }
             TextInserter.replace(charactersToDelete: charsToDelete, with: scored.emoji.tonedGlyph)
             recordUsage(emoji: scored.emoji)
+            // An empty query in the picker path means the pick came from the
+            // bare-`:` favorites pill — the Quick Access feature in action.
+            if query.isEmpty { TelemetryStore.recordQuickAccess() }
             SeasonalGates.fire(for: scored.emoji)
 
         case .exactMatch:

--- a/Sources/Mojito/Telemetry/TelemetryStore.swift
+++ b/Sources/Mojito/Telemetry/TelemetryStore.swift
@@ -36,6 +36,9 @@ enum TelemetryStore {
     static func recordGif()      { guard isEnabled else { return }; bump(PrefsKey.telemetryPendingGif) }
     static func recordEmoticon() { guard isEnabled else { return }; bump(PrefsKey.telemetryPendingEmoticon) }
     static func recordEggDiscovery() { guard isEnabled else { return }; bump(PrefsKey.telemetryPendingEggs) }
+    /// A pick from the bare-`:` favorites pill. A non-zero daily count is what
+    /// the server reads as a Quick Access daily-active install.
+    static func recordQuickAccess() { guard isEnabled else { return }; bump(PrefsKey.telemetryPendingQuickAccess) }
 
     private static func bump(_ key: String) {
         defaults.set(defaults.integer(forKey: key) + 1, forKey: key)
@@ -50,6 +53,7 @@ enum TelemetryStore {
         var gif: Int
         var emoticon: Int
         var eggs: Int
+        var quickAccess: Int
     }
 
     static func snapshotPending() -> Pending {
@@ -59,7 +63,8 @@ enum TelemetryStore {
             symbol: defaults.integer(forKey: PrefsKey.telemetryPendingSymbol),
             gif: defaults.integer(forKey: PrefsKey.telemetryPendingGif),
             emoticon: defaults.integer(forKey: PrefsKey.telemetryPendingEmoticon),
-            eggs: defaults.integer(forKey: PrefsKey.telemetryPendingEggs)
+            eggs: defaults.integer(forKey: PrefsKey.telemetryPendingEggs),
+            quickAccess: defaults.integer(forKey: PrefsKey.telemetryPendingQuickAccess)
         )
     }
 
@@ -73,5 +78,6 @@ enum TelemetryStore {
         defaults.set(0, forKey: PrefsKey.telemetryPendingGif)
         defaults.set(0, forKey: PrefsKey.telemetryPendingEmoticon)
         defaults.set(0, forKey: PrefsKey.telemetryPendingEggs)
+        defaults.set(0, forKey: PrefsKey.telemetryPendingQuickAccess)
     }
 }

--- a/Sources/Mojito/Telemetry/TelemetryUploader.swift
+++ b/Sources/Mojito/Telemetry/TelemetryUploader.swift
@@ -77,10 +77,18 @@ final class TelemetryUploader {
                 "symbol": pending.symbol,
                 "gif": pending.gif,
                 "emoticon": pending.emoticon,
+                "quickAccess": pending.quickAccess,
             ],
             "eggs": pending.eggs,
         ]
         if let app = appVersion() { payload["app"] = app }
+        // Quick Access favorites: how many of the 8 slots are pinned, plus the
+        // pinned hexcodes for the public "top favorites" rollup. Hexcodes are
+        // the same already-public emoji codepoints we send in `emoji`; symbol
+        // pins (`SYM_…`) are dropped so only real emoji reach the histogram.
+        let favorites = pinnedFavoriteHexcodes()
+        payload["favoritesCount"] = favorites.count
+        if !favorites.isEmpty { payload["favorites"] = favorites }
         if !pending.emoji.isEmpty {
             // Mirrors MAX_EMOJI_PER_PING in stats-worker/src/index.js — the
             // server drops everything past it, so trim client-side keeping
@@ -99,7 +107,14 @@ final class TelemetryUploader {
     private func features() -> [String: Bool] {
         let triggers = TriggerConfigStore.load()
         let def = TriggerConfig.default
+        let triggersCustom = triggers.emoji != def.emoji
+            || triggers.symbols != def.symbols
+            || triggers.gif != def.gif
+            || triggers.quickAccess != def.quickAccess
         return [
+            // The emoji trigger can now be disabled, so its on/off state is a
+            // real adoption signal rather than an always-true constant.
+            "emoji": triggers.emoji.enabled,
             "symbols": triggers.symbols.enabled,
             // Kept for back-compat: now reflects the symbols *trigger* being on.
             "symbolsDoubleColon": triggers.symbols.enabled,
@@ -110,13 +125,23 @@ final class TelemetryUploader {
             "launchAtLogin": bool(PrefsKey.launchAtLogin, false),
             "quickAccess": triggers.quickAccess.enabled,
             "menuBarIcon": bool(PrefsKey.showMenuBarIcon, true),
-            // Whether each mode's trigger strings differ from the shipped
-            // defaults — measures adoption of customization, no strings sent.
+            "easterEggs": bool(PrefsKey.eggsEnabled, true),
+            // Whether *any* trigger string differs from the shipped defaults —
+            // one combined customization-adoption signal, no strings sent.
+            "triggersCustom": triggersCustom,
+            // Per-mode customization, kept for the debug/internal view.
             "emojiTriggerCustom": triggers.emoji != def.emoji,
             "symbolsTriggerCustom": triggers.symbols != def.symbols,
             "gifTriggerCustom": triggers.gif != def.gif,
             "quickAccessTriggerCustom": triggers.quickAccess != def.quickAccess,
         ]
+    }
+
+    /// Pinned Quick Access slots, as real emoji hexcodes. Empty (`""`) auto
+    /// slots and symbol pins (`SYM_…`, which aren't emoji) are dropped.
+    private func pinnedFavoriteHexcodes() -> [String] {
+        let raw = (UserDefaults.standard.array(forKey: PrefsKey.quickAccessSlots) as? [String]) ?? []
+        return raw.filter { !$0.isEmpty && !$0.hasPrefix("SYM_") }
     }
 
     // MARK: - Environment (all coarse, marginal)

--- a/Sources/Mojito/Util/PrefsKey.swift
+++ b/Sources/Mojito/Util/PrefsKey.swift
@@ -107,4 +107,5 @@ enum PrefsKey {
     static let telemetryPendingGif          = "mojito.telemetry.pending.gif"          // Int
     static let telemetryPendingEmoticon     = "mojito.telemetry.pending.emoticon"     // Int
     static let telemetryPendingEggs         = "mojito.telemetry.pending.eggs"         // Int
+    static let telemetryPendingQuickAccess  = "mojito.telemetry.pending.quickAccess"  // Int
 }

--- a/scripts/check_telemetry.py
+++ b/scripts/check_telemetry.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Fail if the anonymous-stats pipeline has drifted across its layers.
+
+Run in CI (.github/workflows/telemetry.yml) and locally:
+
+    python3 scripts/check_telemetry.py
+
+Telemetry flows through three places that must agree, in two files:
+
+  1. Swift client  — features() + the totals payload in
+     Sources/Mojito/Telemetry/TelemetryUploader.swift (what an install sends).
+  2. Worker ingest — FEATURE_KEYS + TOTAL_KINDS in stats-worker/src/index.js
+     (the allow-list; anything not here is silently dropped on receipt).
+  3. Worker publish — PUBLIC_FEATURE_KEYS in the same file (the curated subset
+     shown on mojito.wells.ee/stats).
+
+When someone adds a feature flag or insertion counter and wires only one or
+two of these, data goes missing with no error anywhere. This check is the
+backstop — the telemetry analogue of check_localizations.py: every reported
+feature must be allow-listed, and the published set must be a real subset.
+
+To fix a reported gap:
+  - feature drift  → add/remove the key in BOTH features() and FEATURE_KEYS.
+  - publish gap    → every PUBLIC_FEATURE_KEYS entry must also be in FEATURE_KEYS.
+  - totals drift   → keep the Swift `totals` payload keys and TOTAL_KINDS in sync.
+A key can be ingested but not published (kept for the debug/internal view);
+those are listed as a note, not a failure.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+UPLOADER = ROOT / "Sources" / "Mojito" / "Telemetry" / "TelemetryUploader.swift"
+WORKER = ROOT / "stats-worker" / "src" / "index.js"
+
+
+def fail(msg: str) -> None:
+    print(f"❌ {msg}")
+
+
+def swift_block_keys(text: str, start: int) -> list[str]:
+    """Keys of the bracketed dict literal beginning at the first `[` after
+    `start`, matched to its closing `]` so nested dicts/arrays are handled."""
+    i = text.index("[", start) + 1
+    depth, j = 1, i
+    while j < len(text) and depth:
+        if text[j] == "[":
+            depth += 1
+        elif text[j] == "]":
+            depth -= 1
+        j += 1
+    block = re.sub(r"//[^\n]*", "", text[i : j - 1])  # drop line comments
+    return re.findall(r'"([A-Za-z][A-Za-z0-9_]*)"\s*:', block)
+
+
+def js_array(text: str, name: str) -> list[str]:
+    m = re.search(rf"const\s+{name}\s*=\s*\[(.*?)\]", text, re.DOTALL)
+    if not m:
+        return []
+    return re.findall(r'"([A-Za-z][A-Za-z0-9_]*)"', m.group(1))
+
+
+def dups(items: list[str]) -> list[str]:
+    seen, out = set(), []
+    for it in items:
+        if it in seen and it not in out:
+            out.append(it)
+        seen.add(it)
+    return out
+
+
+def main() -> int:
+    for p in (UPLOADER, WORKER):
+        if not p.exists():
+            sys.exit(f"missing file: {p}")
+
+    swift = UPLOADER.read_text()
+    worker = WORKER.read_text()
+
+    feat_fn = swift.index("func features()")
+    swift_features = swift_block_keys(swift, swift.index("return [", feat_fn))
+    swift_totals = swift_block_keys(swift, swift.index('"totals":'))
+
+    ingest = js_array(worker, "FEATURE_KEYS")
+    public = js_array(worker, "PUBLIC_FEATURE_KEYS")
+    total_kinds = js_array(worker, "TOTAL_KINDS")
+
+    ok = True
+
+    # No list may repeat a key.
+    for label, items in [
+        ("features()", swift_features), ("FEATURE_KEYS", ingest),
+        ("PUBLIC_FEATURE_KEYS", public), ("TOTAL_KINDS", total_kinds),
+        ('"totals" payload', swift_totals),
+    ]:
+        if not items:
+            fail(f"could not parse any keys from {label} — has it moved or been renamed?")
+            ok = False
+        d = dups(items)
+        if d:
+            fail(f"{label} has duplicate keys: {', '.join(d)}")
+            ok = False
+
+    # 1. Client features() and the worker ingest allow-list must match exactly.
+    sf, ik = set(swift_features), set(ingest)
+    if sf - ik:
+        fail("features() sends keys the worker drops (add to FEATURE_KEYS): "
+             + ", ".join(sorted(sf - ik)))
+        ok = False
+    if ik - sf:
+        fail("FEATURE_KEYS allow-lists keys the client never sends "
+             "(remove, or add to features()): " + ", ".join(sorted(ik - sf)))
+        ok = False
+
+    # 2. Everything published must be ingestible.
+    pk = set(public)
+    if pk - ik:
+        fail("PUBLIC_FEATURE_KEYS publishes keys not in FEATURE_KEYS: "
+             + ", ".join(sorted(pk - ik)))
+        ok = False
+
+    # 3. Insertion totals: Swift payload keys vs worker TOTAL_KINDS.
+    st, tk = set(swift_totals), set(total_kinds)
+    if st != tk:
+        if st - tk:
+            fail("`totals` payload sends kinds the worker drops "
+                 "(add to TOTAL_KINDS): " + ", ".join(sorted(st - tk)))
+        if tk - st:
+            fail("TOTAL_KINDS expects kinds the client never sends: "
+                 + ", ".join(sorted(tk - st)))
+        ok = False
+
+    if not ok:
+        return 1
+
+    not_published = [k for k in ingest if k not in pk]
+    print(f"✓ telemetry in sync — {len(ingest)} feature keys "
+          f"({len(public)} published), {len(total_kinds)} insertion totals")
+    if not_published:
+        print(f"  note: ingested but not on the public page: {', '.join(not_published)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/stats-worker/schema.sql
+++ b/stats-worker/schema.sql
@@ -33,12 +33,24 @@ CREATE TABLE IF NOT EXISTS feature_daily (
 );
 
 -- Insertion volume + daily-active pings. kind ∈
--- emoji | symbol | gif | emoticon | active | eggs
+-- emoji | symbol | gif | emoticon | quickAccess | active | quickAccessActive | eggs
+-- (quickAccess = pill picks; quickAccessActive = installs that used the pill,
+-- one per ping — the Quick Access daily-active signal.)
 CREATE TABLE IF NOT EXISTS totals_daily (
   day   INTEGER NOT NULL,
   kind  TEXT    NOT NULL,
   count INTEGER NOT NULL DEFAULT 0,
   PRIMARY KEY (day, kind)
+);
+
+-- Top Quick Access favorites: how many reporting installs had each emoji
+-- pinned that day (one increment per pinned slot per ping). Hexcodes only —
+-- the same already-public codepoints as emoji_daily, never an identifier.
+CREATE TABLE IF NOT EXISTS favorite_daily (
+  day     INTEGER NOT NULL,
+  hexcode TEXT    NOT NULL,
+  count   INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (day, hexcode)
 );
 
 -- Running scalars (e.g. lifetime community easter-egg discoveries — a bare

--- a/stats-worker/src/index.js
+++ b/stats-worker/src/index.js
@@ -18,17 +18,31 @@ const MAX_BODY = 16 * 1024;
 const MAX_EMOJI_PER_PING = 300;
 
 // Allow-list of dimensions/features so a malformed or hostile payload can't
-// invent arbitrary rows.
+// invent arbitrary rows. This is the *ingest* set — everything the client may
+// report. Keep it in sync with features() in
+// Sources/Mojito/Telemetry/TelemetryUploader.swift (scripts/check_telemetry.py
+// fails the build if they drift).
 const FEATURE_KEYS = [
-  "symbols", "symbolsDoubleColon", "emoticons", "arrows", "gifSearch",
-  "frequencyBoost", "launchAtLogin", "quickAccess", "menuBarIcon",
-  "emojiTriggerCustom", "symbolsTriggerCustom", "gifTriggerCustom",
-  "quickAccessTriggerCustom",
+  "emoji", "symbols", "symbolsDoubleColon", "emoticons", "arrows", "gifSearch",
+  "frequencyBoost", "launchAtLogin", "quickAccess", "menuBarIcon", "easterEggs",
+  "triggersCustom", "emojiTriggerCustom", "symbolsTriggerCustom",
+  "gifTriggerCustom", "quickAccessTriggerCustom",
+];
+// The curated subset published on the public page, in display order. Minutiae
+// (arrows, symbolsDoubleColon) and the per-mode customization flags (collapsed
+// into triggersCustom) are ingested but never published. Must be a subset of
+// FEATURE_KEYS.
+const PUBLIC_FEATURE_KEYS = [
+  "emoji", "emoticons", "symbols", "gifSearch", "quickAccess",
+  "triggersCustom", "frequencyBoost", "easterEggs", "launchAtLogin",
+  "menuBarIcon",
 ];
 const SKIN_TONES = new Set([
   "default", "light", "mediumLight", "medium", "mediumDark", "dark",
 ]);
-const TOTAL_KINDS = ["emoji", "symbol", "gif", "emoticon"];
+const TOTAL_KINDS = ["emoji", "symbol", "gif", "emoticon", "quickAccess"];
+// Quick Access favorites: 8 slots, so cap the per-ping favorite histogram.
+const MAX_FAVORITES_PER_PING = 8;
 
 const today = () => Math.floor(Date.now() / 86_400_000);
 
@@ -97,6 +111,31 @@ async function ingest(request, env) {
     if (n > 0) stmts.push(totalStmt(env, day, kind, n));
   }
 
+  // Quick Access daily-active: one tick per ping that used the pill at all
+  // (the QA analogue of the `active` signal).
+  if (clampCount(totals.quickAccess, 100_000) > 0) {
+    stmts.push(totalStmt(env, day, "quickAccessActive", 1));
+  }
+
+  // Favorites pinned (0–8) as a marginal distribution. Recorded even at 0 so
+  // the adoption rate has the full reporting population as its denominator.
+  pushDim(stmts, env, day, "favorites", cleanFavCount(body.favoritesCount));
+
+  // Top-favorites histogram — charset-validated, capped at the slot count.
+  const favorites = Array.isArray(body.favorites) ? body.favorites : [];
+  let favKept = 0;
+  for (const hexcode of favorites) {
+    if (favKept >= MAX_FAVORITES_PER_PING) break;
+    if (typeof hexcode !== "string" || !/^[0-9A-Fa-f-]{1,48}$/.test(hexcode)) continue;
+    favKept++;
+    stmts.push(
+      env.DB.prepare(
+        `INSERT INTO favorite_daily (day, hexcode, count) VALUES (?, ?, 1)
+         ON CONFLICT(day, hexcode) DO UPDATE SET count = count + 1`
+      ).bind(day, hexcode.toUpperCase())
+    );
+  }
+
   // Easter-egg discoveries — a bare integer that feeds the community counter.
   const eggs = clampCount(body.eggs, 100);
   if (eggs > 0) {
@@ -161,7 +200,8 @@ async function stats(env) {
   const win = day - 29; // trailing 30 days for "current population" views
   const activeLo = day - 7; // headline avg over the last 7 *complete* UTC days
 
-  const [emoji, os, arch, lang, app, skin, features, totals, active30, active7, eggs] =
+  const [emoji, os, arch, lang, app, skin, features, totals, active30, active7,
+         eggs, qaActive7, favorites, topFav] =
     await Promise.all([
       env.DB.prepare(
         `SELECT hexcode, SUM(count) c FROM emoji_daily WHERE day >= ?
@@ -188,15 +228,30 @@ async function stats(env) {
          FROM totals_daily WHERE kind = 'active' AND day >= ? AND day < ?`
       ).bind(activeLo, day).all(),
       env.DB.prepare(`SELECT value FROM meta WHERE key = 'community_eggs'`).all(),
+      // Quick Access daily-active, same 7-complete-day window as avgDailyActive.
+      env.DB.prepare(
+        `SELECT COALESCE(SUM(count), 0) c, COUNT(DISTINCT day) d
+         FROM totals_daily WHERE kind = 'quickAccessActive' AND day >= ? AND day < ?`
+      ).bind(activeLo, day).all(),
+      dim(env, "favorites", win),
+      env.DB.prepare(
+        `SELECT hexcode, SUM(count) c FROM favorite_daily WHERE day >= ?
+         GROUP BY hexcode ORDER BY c DESC LIMIT 20`
+      ).bind(win).all(),
     ]);
 
   const totalsMap = {};
   for (const r of totals.results) totalsMap[r.kind] = r.c;
 
-  const featureList = features.results
-    .map((r) => ({ feature: r.feature, enabled: r.e, total: r.t,
-                   pct: r.t ? Math.round((r.e / r.t) * 100) : 0 }))
-    .sort((a, b) => b.pct - a.pct);
+  // Curated, fixed-order feature list — only keys in PUBLIC_FEATURE_KEYS that
+  // have actually been reported. Drops minutiae + the raw per-mode flags, and
+  // keeps the order stable day to day (no pct re-sorting).
+  const featMap = {};
+  for (const r of features.results) featMap[r.feature] = { e: r.e, t: r.t };
+  const featureList = PUBLIC_FEATURE_KEYS
+    .filter((k) => featMap[k] && featMap[k].t > 0)
+    .map((k) => ({ feature: k, enabled: featMap[k].e, total: featMap[k].t,
+                   pct: Math.round((featMap[k].e / featMap[k].t) * 100) }));
 
   // macsSharingStats is 30-day person-days (kept for compat); avgDailyActive is
   // the headline per-day mean over the last 7 complete UTC days.
@@ -205,21 +260,39 @@ async function stats(env) {
   const a7Days = active7.results[0]?.d || 0;
   const avgDailyActive = a7Days ? Math.round(a7Total / a7Days) : 0;
 
+  // Quick Access: per-day mean of installs that used the pill, same window.
+  const qaTotal = qaActive7.results[0]?.c || 0;
+  const qaDays = qaActive7.results[0]?.d || 0;
+  const avgQuickAccessActive = qaDays ? Math.round(qaTotal / qaDays) : 0;
+
+  // Favorites adoption: share of reporting installs that pinned ≥1 favorite.
+  let favWith = 0, favAll = 0;
+  for (const r of favorites) {
+    favAll += r.count;
+    if (Number(r.value) > 0) favWith += r.count;
+  }
+  const favoritesPinnedPct = favAll ? Math.round((favWith / favAll) * 100) : 0;
+
   const payload = {
     generatedAt: new Date().toISOString(),
     window: { days: 30 },
     activeWindow: { days: 7 },
     macsSharingStats: activeTotal,
     avgDailyActive,
+    avgQuickAccessActive,
+    favoritesPinnedPct,
     totals: {
       emoji: totalsMap.emoji || 0,
       symbol: totalsMap.symbol || 0,
       gif: totalsMap.gif || 0,
       emoticon: totalsMap.emoticon || 0,
+      quickAccess: totalsMap.quickAccess || 0,
     },
     communityDiscoveries: eggs.results[0]?.value || 0,
     // Top inserted emoji, capped — no count floor, so it never blanks at low volume.
     topEmoji: emoji.results.map((r) => ({ hexcode: r.hexcode, count: r.c })).slice(0, 12),
+    // Top pinned Quick Access favorites — same hexcode-only shape as topEmoji.
+    topFavorites: topFav.results.map((r) => ({ hexcode: r.hexcode, count: r.c })).slice(0, 12),
     os: os, arch: arch, lang: lang, appVersion: app, skinTone: skin,
     features: featureList,
   };
@@ -258,6 +331,14 @@ function clampCount(v, max) {
 function cleanInt(v) {
   const s = String(v ?? "");
   return /^[0-9]{1,3}$/.test(s) ? s : null;
+}
+
+// Favorites-pinned count: an integer 0–8 (the Quick Access slot count). Stored
+// as a string dimension value; out-of-range or non-integer → dropped.
+function cleanFavCount(v) {
+  const n = Number(v);
+  if (!Number.isInteger(n) || n < 0 || n > MAX_FAVORITES_PER_PING) return null;
+  return String(n);
 }
 
 function cleanLang(v) {


### PR DESCRIPTION
## What

Brings the anonymous-stats pipeline back in sync and scopes the public Feature Usage to features that matter.

### Feature coverage
- The worker ingested 13 feature keys but the page labelled 9, so the per-mode trigger flags rendered as raw camelCase and minutiae (Require ::, Arrow conversion) showed as full tiles.
- Split **ingest** from **publish**: `FEATURE_KEYS` keeps everything (debug view), a curated/ordered `PUBLIC_FEATURE_KEYS` is what the page shows.
- Added missing coverage: the **emoji** trigger (disableable now), a combined **triggersCustom**, and the **easter-egg** master switch.

### Quick Access metrics
- `quickAccess` insertion total + a `quickAccessActive` daily-active tick (a pick from the favorites pill).
- `favoritesCount` distribution → favorites-pinned adoption.
- `favorite_daily` top-favorites histogram (hexcodes only, same privacy posture as top emoji).

### Telemetry lint
- `scripts/check_telemetry.py` + `.github/workflows/telemetry.yml` fail the build when the Swift client / worker ingest / published set drift. Parallel to the i18n check.

## Test plan
- Debug build ✓, `scripts/run-tests.sh` ✓
- Worker `node --check` + mock-D1 smoke test ✓ (QA DAU & favorites math, curated ordering, bad-hex rejection)
- `python3 scripts/check_telemetry.py` ✓ (incl. in-memory drift detection)

## Deploy notes
- Worker needs `npm run deploy` + `npm run db:init:remote` (adds `favorite_daily`; idempotent `CREATE IF NOT EXISTS`).
- App telemetry rides the next release; stats page changes land separately on gh-pages.

Refs W-426