### PR TITLE
W-426: curate stats feature-usage + add Quick Access card

### DIFF
--- a/stats-live.js
+++ b/stats-live.js
@@ -16,10 +16,14 @@
     es: "Spanish", zh: "Chinese", ko: "Korean", pt: "Portuguese", it: "Italian",
     ru: "Russian", nl: "Dutch", pl: "Polish", hi: "Hindi", ar: "Arabic",
     fa: "Persian", he: "Hebrew", und: "Other" };
-  var FEATURE = { symbols: "Symbols", symbolsDoubleColon: "Require ::",
-    emoticons: "Emoticons", arrows: "Arrow conversion", gifSearch: "GIF search",
-    frequencyBoost: "Frequency boost", launchAtLogin: "Launch at login",
-    quickAccess: "Quick Access", menuBarIcon: "Menu-bar icon" };
+  // Curated labels for the published feature set. The worker only sends the
+  // keys in PUBLIC_FEATURE_KEYS (stats-worker/src/index.js), so minutiae and
+  // the raw per-mode trigger flags never reach this map.
+  var FEATURE = { emoji: "Emoji", emoticons: "Emoticons", symbols: "Symbols",
+    gifSearch: "GIF search", quickAccess: "Quick Access",
+    triggersCustom: "Custom triggers", frequencyBoost: "Frequency boost",
+    easterEggs: "Easter eggs", launchAtLogin: "Launch at login",
+    menuBarIcon: "Menu-bar icon" };
   var TONE_ORDER = ["default", "light", "mediumLight", "medium", "mediumDark", "dark"];
   var TONE_COLOR = { default: "#ffce4a", light: "#f3d3b0", mediumLight: "#e7b78c",
     medium: "#c68a52", mediumDark: "#9c6438", dark: "#5e4129" };
@@ -74,7 +78,8 @@
     num("bn-emoticon", d.totals.emoticon);
     num("egg-num", d.communityDiscoveries);
 
-    renderEmoji(d.topEmoji || []);
+    renderRanked("emoji-rows", d.topEmoji || [], "stats.empty.emoji", "No emoji inserted yet.");
+    renderQuickAccess(d);
     renderMix(d.totals);
     renderDist("bars-os", d.os, function (v) { return "macOS " + v; });
     renderDist("bars-arch", d.arch, function (v) {
@@ -86,10 +91,11 @@
     renderFeatures("bars-features", d.features || []);
   }
 
-  function renderEmoji(top) {
-    var el = byId("emoji-rows");
+  // Shared ranked emoji list — drives both Top emoji and Top favorites.
+  function renderRanked(id, top, emptyKey, emptyText) {
+    var el = byId(id);
     if (!el) return;
-    if (!top.length) { el.innerHTML = note(t("stats.empty.emoji", "No emoji inserted yet.")); return; }
+    if (!top.length) { el.innerHTML = note(t(emptyKey, emptyText)); return; }
     var max = top[0].count || 1;
     el.innerHTML = top.map(function (e, i) {
       var pct = Math.round((e.count / max) * 100);
@@ -100,6 +106,13 @@
         '%"></span></span><span class="ecount">' + e.count.toLocaleString(loc()) +
         "</span></div>";
     }).join("");
+  }
+
+  function renderQuickAccess(d) {
+    num("qa-dau", d.avgQuickAccessActive || 0);
+    setText("qa-fav-pct", (d.favoritesPinnedPct || 0) + "%");
+    renderRanked("fav-rows", d.topFavorites || [],
+      "stats.empty.favorites", "No favorites pinned yet.");
   }
 
   function renderMix(tot) {

--- a/stats.css
+++ b/stats.css
@@ -319,6 +319,47 @@
   font-variant-numeric: tabular-nums;
 }
 
+/* ---- quick access ------------------------------------------------------- */
+.qa-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.qa-stat {
+  background: var(--track);
+  border-radius: 14px;
+  padding: 16px 14px;
+  text-align: center;
+}
+
+.qa-stat-value {
+  font-size: clamp(24px, 3.5vw, 30px);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+}
+
+.qa-stat-label {
+  margin-top: 7px;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text-soft);
+  letter-spacing: -0.005em;
+}
+
+.qa-sub {
+  margin: 24px 0 0;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-soft);
+}
+
 /* ---- emoji ranking ------------------------------------------------------ */
 .erows {
   display: flex;

--- a/stats.html
+++ b/stats.html
@@ -14,7 +14,7 @@
 <link rel="icon" type="image/png" href="favicon.png">
 <link rel="apple-touch-icon" href="favicon.png">
 <link rel="stylesheet" href="style.css?v=72">
-<link rel="stylesheet" href="stats.css?v=12">
+<link rel="stylesheet" href="stats.css?v=13">
 <script src="i18n.js?v=2"></script>
 </head>
 <body>
@@ -158,12 +158,41 @@
       <h2 class="card-title" data-i18n="stats.card.features">Feature usage</h2>
     </div>
     <div class="feat-grid" id="bars-features">
+      <div class="feat-tile"><div class="feat-gauge" style="--p:97"></div><span class="feat-pct">97%</span><span class="feat-name">Emoji</span></div>
       <div class="feat-tile"><div class="feat-gauge" style="--p:91"></div><span class="feat-pct">91%</span><span class="feat-name">Frequency boost</span></div>
       <div class="feat-tile"><div class="feat-gauge" style="--p:79"></div><span class="feat-pct">79%</span><span class="feat-name">Launch at login</span></div>
       <div class="feat-tile"><div class="feat-gauge" style="--p:73"></div><span class="feat-pct">73%</span><span class="feat-name">GIF search</span></div>
       <div class="feat-tile"><div class="feat-gauge" style="--p:64"></div><span class="feat-pct">64%</span><span class="feat-name">Emoticons</span></div>
-      <div class="feat-tile"><div class="feat-gauge" style="--p:52"></div><span class="feat-pct">52%</span><span class="feat-name">Arrow conversion</span></div>
+      <div class="feat-tile"><div class="feat-gauge" style="--p:55"></div><span class="feat-pct">55%</span><span class="feat-name">Easter eggs</span></div>
+      <div class="feat-tile"><div class="feat-gauge" style="--p:41"></div><span class="feat-pct">41%</span><span class="feat-name">Quick Access</span></div>
       <div class="feat-tile"><div class="feat-gauge" style="--p:38"></div><span class="feat-pct">38%</span><span class="feat-name">Symbols</span></div>
+      <div class="feat-tile"><div class="feat-gauge" style="--p:22"></div><span class="feat-pct">22%</span><span class="feat-name">Custom triggers</span></div>
+    </div>
+  </section>
+
+  <!-- quick access -->
+  <section class="card reveal" aria-label="Quick Access" data-i18n-attr="aria-label:stats.aria.quickAccess">
+    <div class="card-head">
+      <h2 class="card-title" data-i18n="stats.card.quickAccess">Quick Access</h2>
+    </div>
+    <div class="qa-stats">
+      <div class="qa-stat">
+        <div class="qa-stat-value" id="qa-dau" data-count="1840" data-format="int">1,840</div>
+        <div class="qa-stat-label" data-i18n="stats.qa.dau">Avg. daily users</div>
+      </div>
+      <div class="qa-stat">
+        <div class="qa-stat-value" id="qa-fav-pct">34%</div>
+        <div class="qa-stat-label" data-i18n="stats.qa.favorites">Pin a favorite</div>
+      </div>
+    </div>
+    <h3 class="qa-sub" data-i18n="stats.qa.topFavorites">Top favorites</h3>
+    <div class="erows" id="fav-rows">
+      <div class="erow"><span class="erank">1</span><span class="eglyph" aria-hidden="true">🔥</span><span class="ecode">:fire:</span><span class="bar-track"><span class="bar-fill" data-w="100%"></span></span><span class="ecount">14,920</span></div>
+      <div class="erow"><span class="erank">2</span><span class="eglyph" aria-hidden="true">✅</span><span class="ecode">:white_check_mark:</span><span class="bar-track"><span class="bar-fill" data-w="82%"></span></span><span class="ecount">12,233</span></div>
+      <div class="erow"><span class="erank">3</span><span class="eglyph" aria-hidden="true">👍</span><span class="ecode">:thumbsup:</span><span class="bar-track"><span class="bar-fill" data-w="71%"></span></span><span class="ecount">10,604</span></div>
+      <div class="erow"><span class="erank">4</span><span class="eglyph" aria-hidden="true">🎉</span><span class="ecode">:tada:</span><span class="bar-track"><span class="bar-fill" data-w="58%"></span></span><span class="ecount">8,651</span></div>
+      <div class="erow"><span class="erank">5</span><span class="eglyph" aria-hidden="true">❤️</span><span class="ecode">:heart:</span><span class="bar-track"><span class="bar-fill" data-w="49%"></span></span><span class="ecount">7,302</span></div>
+      <div class="erow"><span class="erank">6</span><span class="eglyph" aria-hidden="true">😂</span><span class="ecode">:joy:</span><span class="bar-track"><span class="bar-fill" data-w="44%"></span></span><span class="ecount">6,489</span></div>
     </div>
   </section>
 
@@ -275,6 +304,6 @@
 })();
 </script>
 <script src="emoji-codes.js?v=1"></script>
-<script src="stats-live.js?v=9"></script>
+<script src="stats-live.js?v=10"></script>
 </body>
 </html>


### PR DESCRIPTION
Stats page changes to match the deployed worker (PR #140).

- Feature tiles curated: drop Require :: / Arrow conversion, collapse the four raw per-mode trigger flags into one **Custom triggers**, add **Emoji** and **Easter eggs**. The worker now publishes only the curated keys, so no raw camelCase leaks.
- New **Quick Access** card: avg. daily users, % who pin a favorite, top favorites (shares the emoji-row renderer).
- Bumped `stats.css` / `stats-live.js` cache-bust versions.

Worker side is already live (`stats.mojito.wells.ee`), so this won't render against a stale API.

Verified: htmlhint + stylelint clean, `node --check stats-live.js`, local preview against a mock of the new payload.

Refs W-426