### PR TITLE
W-431: make autocomplete picker rows mouse-clickable

### DIFF
--- a/Sources/Mojito/App/Engine.swift
+++ b/Sources/Mojito/App/Engine.swift
@@ -42,6 +42,10 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
     /// True if the current capture's app/URL is in the exclusion list.
     /// Emoji-related actions get suppressed; GIF picker still fires.
     private var captureIsExcluded: Bool = false
+    /// Scope of the live list search, cached so a mouse-pick can rebuild the
+    /// same insert the keyboard `.fromPicker` path uses (keyboard reads it off
+    /// the state-machine action; a click has no action to carry it).
+    private var captureScope: CaptureScope = .normal
     private var usage: [String: Int]
     private var workspaceObserver: NSObjectProtocol?
     private var spaceObserver: NSObjectProtocol?
@@ -95,6 +99,25 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
                 self.expandToBrowser(deleteCount: openLen)  // the typed open delimiter
             } else {
                 self.insert(query: "", mode: .fromPicker, scope: .normal, openLen: openLen, closeLen: 0)
+            }
+        }
+
+        // Mouse-pick on a vertical-list row — same resolution as Return on the
+        // selected row: insert it (`.fromPicker` reads `topResult`), or grow
+        // into the grid for the trailing Browse row. The typed `:query` (no
+        // closing colon) is what's in the focused app, so the delete span is
+        // query + open delimiter.
+        viewModel.onPickRow = { [weak self] index in
+            guard let self, !self.viewModel.compact, !self.viewModel.expanded else { return }
+            guard index >= 0, index < self.viewModel.results.count else { return }
+            if self.captureExcluded { return }
+            self.viewModel.selectedIndex = index
+            let q = self.viewModel.query
+            let openLen = max(1, self.stateMachine.captureOpenLen)
+            if self.viewModel.results[index].emoji.hexcode == EmojiBrowser.sentinelHexcode {
+                self.expandToBrowser(deleteCount: q.count + openLen)
+            } else {
+                self.insert(query: q, mode: .fromPicker, scope: self.captureScope, openLen: openLen, closeLen: 0)
             }
         }
 
@@ -886,6 +909,7 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
     }
 
     private func updateResults(query: String, scope: CaptureScope) {
+        captureScope = scope
         // Empty query → the compact favorites pill; anything typed → the
         // vertical shortcode list.
         viewModel.compact = query.isEmpty

--- a/Sources/Mojito/Picker/PickerView.swift
+++ b/Sources/Mojito/Picker/PickerView.swift
@@ -125,6 +125,11 @@ private struct PickerRow: View {
                 .fill(isSelected ? Color(nsColor: .unemphasizedSelectedContentBackgroundColor) : .clear)
                 .padding(.horizontal, 4)
         )
+        .contentShape(Rectangle())
+        .onTapGesture { viewModel.onPickRow?(index) }
+        .onHover { hovering in
+            if hovering { viewModel.selectedIndex = index }
+        }
     }
 
     /// Defaults to the Text glyph; eggs that need a custom asset

--- a/Sources/Mojito/Picker/PickerViewModel.swift
+++ b/Sources/Mojito/Picker/PickerViewModel.swift
@@ -19,6 +19,9 @@ final class PickerViewModel: ObservableObject {
     /// Mouse-pick from the picker (compact bar cells). The Engine sets this;
     /// the index is the cell tapped.
     var onActivate: ((Int) -> Void)?
+    /// Mouse-pick on a vertical-list row (the typed-query shortcode list). The
+    /// Engine sets this; the index is the row clicked.
+    var onPickRow: ((Int) -> Void)?
     /// Hover over a pill cell (nil = hover ended). PickerWindow shows the
     /// number-hotkey tooltip above that cell. The pill panel is too short to
     /// host the tooltip itself, so it lives in a separate panel.


### PR DESCRIPTION
## What

The vertical autocomplete list rows couldn't be clicked — only keyboard worked, and there was no hover highlight. Root cause: `PickerRow` (the typed-query list) had no `.onTapGesture` or `.onHover` at all. Only the compact `:?` pill and the expanded browser grid had them.

(Not a glass / non-key-panel hit-testing issue — the browser grid clicks fine through the same non-key panel. The list rows were simply never wired.)

## Fix

- Add `.contentShape(Rectangle())` + `.onTapGesture` + `.onHover` to `PickerRow`, wired to a new `viewModel.onPickRow`.
- `onPickRow` mirrors the keyboard Return path: set the selected index, then insert the selected row (`.fromPicker` reads `topResult`), or grow into the grid for the trailing Browse row. Hover sets the selection so the highlight tracks the mouse.
- Engine caches the live search scope (`captureScope`) so a click can rebuild the same insert the keyboard path gets from the state-machine action.

## Test plan

- Verified in the dev app: `:fire` → hover highlights, click inserts, Browse row expands; `:?` pill still works.
- Full unit suite green.

Refs W-431