### PR TITLE
W-432: drop component-group modifiers from the emoji corpus

### DIFF
--- a/Sources/Mojito/EmojiDB/EmojiDatabase.swift
+++ b/Sources/Mojito/EmojiDB/EmojiDatabase.swift
@@ -66,6 +66,10 @@ final class EmojiDatabase: ObservableObject {
     /// O(haystacks). 2 + English is a comfortable budget.
     static let maxAdditionalLocales = 2
 
+    /// emojibase group id for "component" (skin-tone + hair modifiers) — kept
+    /// out of the corpus entirely; see `load()`.
+    static let componentGroup = 2
+
     private func activeAdditionalLocales() -> [String] {
         var seen: Set<String> = []
         var out: [String] = []
@@ -99,7 +103,12 @@ final class EmojiDatabase: ObservableObject {
         }
         do {
             let data = try Data(contentsOf: url)
+            // emojibase group 2 is "component": bare skin-tone (🏻–🏿) and hair
+            // (🦰🦱🦳🦲) modifiers that only combine with another emoji, never
+            // stand alone. The browser already skips this group; drop it here so
+            // it can't surface as a standalone search hit either.
             let decoded = try JSONDecoder().decode([Emoji].self, from: data)
+                .filter { $0.group != Self.componentGroup }
             self.all = decoded
             let activeLocales = activeAdditionalLocales()
             var index: [String: Emoji] = [:]

--- a/Tests/MojitoTests/EmojiDatabaseTests.swift
+++ b/Tests/MojitoTests/EmojiDatabaseTests.swift
@@ -36,6 +36,20 @@ struct EmojiDatabaseTests {
         #expect(db.byHexcode[smile.hexcode]?.character == smile.character)
     }
 
+    @Test func componentModifiersAreExcluded() {
+        let db = EmojiDatabase.shared
+        // Group 2 (component): bare skin-tone + hair modifiers, never standalone.
+        #expect(db.all.allSatisfy { $0.group != EmojiDatabase.componentGroup })
+        // The reported case: the bare medium skin-tone swatch (🏽) is gone.
+        #expect(db.byHexcode["1F3FD"] == nil)
+        // And it doesn't surface in search.
+        let hits = FuzzyMatcher.search(
+            query: "medium", in: db, usage: [:],
+            corpus: .emojiOnly, useFrequencyBoost: false, limit: 50
+        )
+        #expect(!hits.contains { $0.emoji.character == "🏽" })
+    }
+
     @Test func indexedHaystacksIncludeEveryShortcode() throws {
         let db = EmojiDatabase.shared
         let smile = try #require(db.exact("smile"))


### PR DESCRIPTION
## What

Bare Fitzpatrick skin-tone swatches (🏻–🏿, e.g. `:medium_skin_tone:`) and hair modifiers (🦰🦱🦳🦲) surfaced as standalone search hits. They're emojibase group 2 ("component") — combining modifiers, useless inserted alone. The browser already skips this group, so they only leaked through live search.

## Fix

Filter the component group out of the loaded corpus in `EmojiDatabase.load`, so it's absent from search and exact-match — matching the browser. `SkinTone` applies modifiers via hardcoded scalars, not the DB, so skin-tone application is unaffected.

## Notes

- Removes the 4 hair components from search too (same rationale); easy to narrow to skin-tones-only if we want hair kept.
- Supersedes #147 (auto-closed when its stacked base branch was deleted on the W-431 merge).

## Test plan

- New `componentModifiersAreExcluded` test: no group-2 entries in the corpus; `🏽` gone from `byHexcode` and from a `:medium` search.
- Full suite green; verified in the dev app.

Refs W-432