### PR TITLE
W-433: Replace the system emoji picker (⌃⌘Space + Globe key)

### DIFF
--- a/Mojito.xcodeproj/project.pbxproj
+++ b/Mojito.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		3FDBEFA3636F345D917BE553 /* AppContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = A891A50B1E32BC1A8B549268 /* AppContext.swift */; };
 		41765C78ED90EB005C04E63B /* SeasonalGates.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C5BC5F015CABDD85262258 /* SeasonalGates.swift */; };
 		42DC32C9130BAB5381534226 /* EggIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB126DDBD153A051CDEF105B /* EggIndex.swift */; };
+		492E99ABC57E92DE1DDE5A1E /* SystemEmojiPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66C166F241AD0718D2067AF1 /* SystemEmojiPicker.swift */; };
 		4949BE63FAD5A5FC2573CFE1 /* DefaultExclusions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877AFBCD3CD8EE7B154C73BD /* DefaultExclusions.swift */; };
 		4AE8FF96950E4AD801A5D632 /* AnimatedGifView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31E41F813A67872400E4942 /* AnimatedGifView.swift */; };
 		4C024B6EA9665C5DFDB80CE7 /* WarpDrive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9658C9CF3396443D22FF4E28 /* WarpDrive.swift */; };
@@ -72,6 +73,7 @@
 		6B48E883C3B324C8ABB16C93 /* AmbientEmoticonTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE7D78A4736AA53650D60DC /* AmbientEmoticonTable.swift */; };
 		6CFD48A60F308CA1FCBF059A /* TelemetryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CC88D13B457E17EBC5B68C5 /* TelemetryStore.swift */; };
 		6F9314FB48040BE582D87716 /* BlueScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD72EE1D10D399387F1DD1C8 /* BlueScreen.swift */; };
+		73BCEA1FC4A0115090ACB735 /* ShortcutRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96837E12D46B10FC4D77897A /* ShortcutRecorder.swift */; };
 		74CED6225633C087A96D7E9C /* DebugRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2928BC07BE26CF9B15F23D70 /* DebugRecorder.swift */; };
 		75008F5E9E8750E55512283C /* FzyScorer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5EDBB8F234B21B8D4A3324 /* FzyScorer.swift */; };
 		751B7D80FF9EA3BA8B30B8FC /* EasterEggsSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA756B434C9FED6B691D07B8 /* EasterEggsSettings.swift */; };
@@ -246,6 +248,7 @@
 		5FB7AB3DB0E63AF30880FE66 /* BrowserURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserURL.swift; sourceTree = "<group>"; };
 		625433055302CF9B9053F885 /* ExclusionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExclusionStoreTests.swift; sourceTree = "<group>"; };
 		6666150B793721D5095E72A8 /* SymbolsDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolsDatabase.swift; sourceTree = "<group>"; };
+		66C166F241AD0718D2067AF1 /* SystemEmojiPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemEmojiPicker.swift; sourceTree = "<group>"; };
 		682479ADBA3E221825BADC83 /* TriggersSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggersSettings.swift; sourceTree = "<group>"; };
 		69CD38087938C1E258718C69 /* FzyScorerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FzyScorerTests.swift; sourceTree = "<group>"; };
 		6C69999E4AC7F8B8C054B395 /* DebugReportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugReportTests.swift; sourceTree = "<group>"; };
@@ -276,6 +279,7 @@
 		9528726096C90D6A0523B86F /* Emoji.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Emoji.swift; sourceTree = "<group>"; };
 		964D290D66BB33D1F21333A0 /* QuickAccessStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickAccessStore.swift; sourceTree = "<group>"; };
 		9658C9CF3396443D22FF4E28 /* WarpDrive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarpDrive.swift; sourceTree = "<group>"; };
+		96837E12D46B10FC4D77897A /* ShortcutRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorder.swift; sourceTree = "<group>"; };
 		96C001583E27CC71D9959055 /* EmojiBrowserCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiBrowserCatalog.swift; sourceTree = "<group>"; };
 		9903710C7A46FB1BB47A47BA /* WarpSound.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarpSound.swift; sourceTree = "<group>"; };
 		9C81578D7A36FB7EA31D1985 /* Fireworks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fireworks.swift; sourceTree = "<group>"; };
@@ -409,6 +413,7 @@
 				FF9407B4350C7E77A3EABDEA /* SettingsNavigator.swift */,
 				FFC142D2205F1C089F7524D2 /* SettingsRoot.swift */,
 				ABF01308E9212227B8106776 /* SettingsWindowController.swift */,
+				96837E12D46B10FC4D77897A /* ShortcutRecorder.swift */,
 				682479ADBA3E221825BADC83 /* TriggersSettings.swift */,
 			);
 			path = Settings;
@@ -622,6 +627,7 @@
 				463478D4F770642DDCBA5C8F /* Snowfall.swift */,
 				7E63ABA27E65953D84162097 /* SolitaireWin.swift */,
 				300590ABBE9E070A97FCFF92 /* SosumiSound.swift */,
+				66C166F241AD0718D2067AF1 /* SystemEmojiPicker.swift */,
 				EC3E46F6B55025038F101A4A /* TadaSound.swift */,
 				B05F08FB28C8998B7F7075BB /* TicTacToeGame.swift */,
 				E7D1F9E45C5D2C8B6FB43111 /* TrainGame.swift */,
@@ -991,6 +997,7 @@
 				CA31BF29EEEA9CC0D89637E4 /* SettingsNavigator.swift in Sources */,
 				DCE52DEE8C9CEC354443E7DB /* SettingsRoot.swift in Sources */,
 				155360187C1F8C68452934E7 /* SettingsWindowController.swift in Sources */,
+				73BCEA1FC4A0115090ACB735 /* ShortcutRecorder.swift in Sources */,
 				6607717F2E4D11B5563F8184 /* Shortcuts.swift in Sources */,
 				29B4C683D96EE275A114B5FD /* SingleInstanceCoordinator.swift in Sources */,
 				DD75EE1DF9351238356F60E7 /* SkinTone.swift in Sources */,
@@ -1000,6 +1007,7 @@
 				368FCAE7AAA6BB9F89291A1D /* SosumiSound.swift in Sources */,
 				2B3FD6118D1C2D7AB0D24588 /* SymbolsDatabase.swift in Sources */,
 				62417E7F0AA71DEF9928E2B9 /* SynthRenderer.swift in Sources */,
+				492E99ABC57E92DE1DDE5A1E /* SystemEmojiPicker.swift in Sources */,
 				5EBE8D89D81DB7FF6AF09968 /* TadaSound.swift in Sources */,
 				EE298513CD9C097AD2AEA237 /* TelemetryConsent.swift in Sources */,
 				6CFD48A60F308CA1FCBF059A /* TelemetryStore.swift in Sources */,

--- a/Sources/Mojito/App/AppDelegate.swift
+++ b/Sources/Mojito/App/AppDelegate.swift
@@ -89,8 +89,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             self?.toggleOrPause(until: Self.tomorrowMorning())
         }
         KeyboardShortcuts.onKeyDown(for: .showEmojiBrowser) { [weak self] in
-            self?.engine.showBrowser()
+            self?.engine.toggleBrowser()
         }
+        // Re-assert the runtime-only system-panel suppression (the ⌃⌘Space
+        // binding and Fn pref persist on their own).
+        SystemEmojiPickerReplacer.shared.applyAtLaunch()
 
         // Force onboarding any time permissions aren't granted — revoked
         // perms / fresh accounts get the guided fix, not a silent break.

--- a/Sources/Mojito/App/Engine.swift
+++ b/Sources/Mojito/App/Engine.swift
@@ -9,6 +9,10 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
     @Published private(set) var isActive: Bool = false
     @Published var pausedUntil: Date?
 
+    /// True while Mojito's Settings window holds key focus — see
+    /// `setMonitorSuspended`. Keeps the tap from fighting recorders there.
+    private var uiSuspended = false
+
     /// State-machine label for diagnostic reports. Query contents are
     /// elided so the value is anonymous.
     var triggerStateLabel: String {
@@ -354,12 +358,26 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
         UserDefaults.standard.set(0, forKey: PrefsKey.totalEmoticonInserted)
     }
 
+    /// Suspends the event tap while Mojito's own Settings window is key — the
+    /// global tap would otherwise compete with `KeyboardShortcuts.Recorder` for
+    /// keystrokes (and the browser, if open, eats them), so recorders there go
+    /// flaky. Triggers in other apps resume the moment Settings isn't key.
+    func setMonitorSuspended(_ suspended: Bool) {
+        guard uiSuspended != suspended else { return }
+        uiSuspended = suspended
+        reconcile()
+    }
+
     private func reconcile() {
         guard let permissions, permissions.allGranted else {
             stop()
             return
         }
         if let until = pausedUntil, until > Date() {
+            stop()
+            return
+        }
+        if uiSuspended {
             stop()
             return
         }
@@ -383,6 +401,13 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
             // Tap may have died because the user revoked Input Monitoring —
             // let the coordinator resume polling and surface the UI state.
             self.permissions?.handleInputMonitoringLost()
+        }
+    }
+
+    nonisolated func keyMonitorDidTapGlobeKey(_ monitor: KeyMonitor) {
+        MainActor.assumeIsolated {
+            guard SystemEmojiPickerReplacer.shared.globeOpensBrowser else { return }
+            self.toggleBrowser()
         }
     }
 
@@ -825,6 +850,16 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
     }
 
     // MARK: - Full-library browser (the picker panel, grown)
+
+    /// Globe / ⌃⌘Space entry for the "replace system emoji picker" feature.
+    /// Mirrors the macOS panel: the key that opens the browser also closes it.
+    func toggleBrowser() {
+        if case .browsing = stateMachine.state {
+            collapseBrowser()
+            return
+        }
+        showBrowser()
+    }
 
     /// Menu-bar / global-hotkey entry. These fire independently of the event
     /// tap, so — unlike the `:` paths — they must explicitly honor pause +

--- a/Sources/Mojito/App/Shortcuts.swift
+++ b/Sources/Mojito/App/Shortcuts.swift
@@ -10,7 +10,9 @@ extension KeyboardShortcuts.Name {
     /// while paused resumes immediately.
     static let pauseUntilTomorrow = Self("pauseUntilTomorrow")
 
-    /// Global hotkey that opens the full emoji browser anywhere. No default —
-    /// the user assigns it in Settings ▸ General ▸ Quick Access.
-    static let showEmojiBrowser = Self("showEmojiBrowser")
+    /// Global hotkey that opens (and closes) the full emoji browser anywhere.
+    /// Defaults to ⌃⌥Space; "Replace System Picker" swaps it to ⌃⌘Space, and the
+    /// reset button restores the default. Set in Settings ▸ General ▸ Quick Access.
+    static let showEmojiBrowser = Self("showEmojiBrowser",
+                                       default: .init(.space, modifiers: [.control, .option]))
 }

--- a/Sources/Mojito/App/SystemEmojiPicker.swift
+++ b/Sources/Mojito/App/SystemEmojiPicker.swift
@@ -1,0 +1,194 @@
+import AppKit
+import CoreGraphics
+import KeyboardShortcuts
+
+// MARK: - Private symbolic-hotkey bridge
+
+// `CGSSetSymbolicHotKeyEnabled` / `CGSIsSymbolicHotKeyEnabled` are unsupported
+// WindowServer exports (SkyLight on modern macOS, CoreGraphics on older). They
+// need no entitlement in a Developer-ID, non-sandboxed build and notarization
+// doesn't scan for them — but a future macOS could renumber or drop them, so we
+// resolve them by name at runtime and treat absence as "feature unavailable"
+// rather than linking the framework and risking an undefined-symbol crash.
+private enum CGSHotkeyBridge {
+    private typealias SetEnabledFn = @convention(c) (Int32, Bool) -> CGError
+    private typealias IsEnabledFn = @convention(c) (Int32) -> Bool
+
+    private static let setEnabledFn: SetEnabledFn? = resolve("CGSSetSymbolicHotKeyEnabled")
+    private static let isEnabledFn: IsEnabledFn? = resolve("CGSIsSymbolicHotKeyEnabled")
+
+    /// RTLD_DEFAULT searches every image already loaded into this process.
+    /// SkyLight is loaded into every GUI app, so no explicit dlopen is needed.
+    private static func resolve<T>(_ symbol: String) -> T? {
+        let rtldDefault = UnsafeMutableRawPointer(bitPattern: -2)
+        guard let sym = dlsym(rtldDefault, symbol) else { return nil }
+        return unsafeBitCast(sym, to: T.self)
+    }
+
+    static func setEnabled(_ hotKey: Int32, _ enabled: Bool) -> Bool {
+        guard let fn = setEnabledFn else { return false }
+        return fn(hotKey, enabled) == .success
+    }
+
+    /// Defaults to `true` when the symbol is missing — matches the system
+    /// default so a later restore re-enables rather than silently leaving off.
+    static func isEnabled(_ hotKey: Int32) -> Bool {
+        guard let fn = isEnabledFn else { return true }
+        return fn(hotKey)
+    }
+}
+
+private enum SystemSymbolicHotkey {
+    /// `kCGSHotKeyToggleCharacterPallette` (sic) — the ⌃⌘Space Emoji & Symbols
+    /// panel. Documented in the reverse-engineered CGSHotKeys.h but unverified
+    /// on recent macOS, so a no-op disable is expected; our own ⌃⌘Space
+    /// registration is what actually wins the chord.
+    static let characterPalette: Int32 = 50
+
+    static var characterPaletteEnabled: Bool { CGSHotkeyBridge.isEnabled(characterPalette) }
+
+    @discardableResult
+    static func setCharacterPalette(enabled: Bool) -> Bool {
+        CGSHotkeyBridge.setEnabled(characterPalette, enabled)
+    }
+}
+
+// MARK: - Coordinator
+
+/// Owns the "Replace system emoji picker" feature, split into two independent
+/// concerns: claiming ⌃⌘Space + suppressing the macOS panel (`replacesPanel`),
+/// and taking over the Globe/Fn key (`globeEnabled`). The "Replace" button does
+/// both; each is also separately toggleable.
+@MainActor
+final class SystemEmojiPickerReplacer {
+    static let shared = SystemEmojiPickerReplacer()
+
+    private let defaults = UserDefaults.standard
+    private static let hiToolboxDomain = "com.apple.HIToolbox" as CFString
+    private static let fnUsageKey = "AppleFnUsageType" as CFString
+    /// `AppleFnUsageType` value for "Do Nothing" — set so the OS stops claiming
+    /// the Globe key while we detect a lone tap ourselves.
+    private static let fnUsageNone = 0
+
+    private init() {}
+
+    /// The system emoji shortcut Mojito claims — ⌃⌘Space, the real macOS
+    /// Emoji & Symbols chord.
+    static let systemShortcut = KeyboardShortcuts.Shortcut(.space, modifiers: [.command, .control])
+
+    /// The browser hotkey's default — what the reset button restores.
+    static let defaultShortcut = KeyboardShortcuts.Shortcut(.space, modifiers: [.control, .option])
+
+    /// Whether Mojito stands in for the ⌃⌘Space panel: the browser hotkey owns
+    /// ⌃⌘Space and the macOS Emoji & Symbols panel (CGS hotkey 50) is suppressed.
+    /// The persisted flag is the source of truth — NOT the hotkey value, which in
+    /// the dev build reflects the release app's inherited fallback. Drives the
+    /// "Replace" button's visibility: once on, there's nothing left to replace.
+    var replacesPanel: Bool { defaults.bool(forKey: PrefsKey.replaceSystemEmojiPickerEnabled) }
+
+    /// Whether a lone Globe/Fn tap opens the browser. Its own toggle in Settings,
+    /// independent of the ⌃⌘Space replacement.
+    var globeEnabled: Bool { defaults.bool(forKey: PrefsKey.globeKeyEnabled) }
+    var globeOpensBrowser: Bool { globeEnabled }
+
+    /// Set by `enableGlobe()` when the Fn pref had to change: the Globe takeover
+    /// only fully lands after the user logs out and back in.
+    private(set) var needsLogoutForGlobe = false
+
+    /// Re-assert the CGS disable at launch (it resets every login). The hotkey
+    /// binding and Fn pref persist on their own; only the CGS state is runtime.
+    func applyAtLaunch() {
+        guard replacesPanel else { return }
+        SystemSymbolicHotkey.setCharacterPalette(enabled: false)
+    }
+
+    // MARK: Combined actions (Replace button / onboarding)
+
+    /// "Replace System Picker": claim ⌃⌘Space, suppress the macOS panel, and
+    /// take over the Globe key — the whole feature in one tap.
+    func replaceSystemPicker() {
+        setBrowserShortcut(Self.systemShortcut)
+        enablePanelReplacement()
+        enableGlobe()
+    }
+
+    /// Reset: restore the default hotkey, the system panel, and the Globe key.
+    func restoreSystemPicker() {
+        setBrowserShortcut(Self.defaultShortcut)
+        disablePanelReplacement()
+        disableGlobe()
+    }
+
+    /// The bind is programmatic so it skips the recorder's "already a system
+    /// shortcut" alert that ⌃⌘Space would otherwise trip.
+    func setBrowserShortcut(_ shortcut: KeyboardShortcuts.Shortcut?) {
+        KeyboardShortcuts.setShortcut(shortcut, for: .showEmojiBrowser)
+    }
+
+    // MARK: ⌃⌘Space panel replacement
+
+    /// Best-effort suppress the macOS Emoji & Symbols panel (CGS hotkey 50).
+    /// Separate from the hotkey bind so the recorder can sync this to a ⌃⌘Space
+    /// the user typed directly.
+    func enablePanelReplacement() {
+        defaults.set(true, forKey: PrefsKey.replaceSystemEmojiPickerEnabled)
+        if defaults.object(forKey: PrefsKey.priorCharacterPaletteEnabled) == nil {
+            defaults.set(SystemSymbolicHotkey.characterPaletteEnabled,
+                         forKey: PrefsKey.priorCharacterPaletteEnabled)
+        }
+        SystemSymbolicHotkey.setCharacterPalette(enabled: false)
+    }
+
+    func disablePanelReplacement() {
+        defaults.set(false, forKey: PrefsKey.replaceSystemEmojiPickerEnabled)
+        let restore = defaults.object(forKey: PrefsKey.priorCharacterPaletteEnabled) as? Bool ?? true
+        SystemSymbolicHotkey.setCharacterPalette(enabled: restore)
+        defaults.removeObject(forKey: PrefsKey.priorCharacterPaletteEnabled)
+    }
+
+    // MARK: Globe / Fn key
+
+    func enableGlobe() {
+        defaults.set(true, forKey: PrefsKey.globeKeyEnabled)
+        takeOverGlobeKey()
+    }
+
+    func disableGlobe() {
+        defaults.set(false, forKey: PrefsKey.globeKeyEnabled)
+        restoreGlobeKey()
+    }
+
+    // MARK: Globe / Fn key
+
+    private func takeOverGlobeKey() {
+        let current = currentFnUsageType()
+        if defaults.object(forKey: PrefsKey.priorFnUsageType) == nil {
+            defaults.set(current, forKey: PrefsKey.priorFnUsageType)
+        }
+        // If Fn is already "Do Nothing", our event-tap detection works
+        // immediately and nothing competes — no logout needed.
+        if current != Self.fnUsageNone {
+            setFnUsageType(Self.fnUsageNone)
+            needsLogoutForGlobe = true
+        } else {
+            needsLogoutForGlobe = false
+        }
+    }
+
+    private func restoreGlobeKey() {
+        if let prior = defaults.object(forKey: PrefsKey.priorFnUsageType) as? Int {
+            setFnUsageType(prior)
+            defaults.removeObject(forKey: PrefsKey.priorFnUsageType)
+        }
+        needsLogoutForGlobe = false
+    }
+
+    private func currentFnUsageType() -> Int {
+        CFPreferencesCopyAppValue(Self.fnUsageKey, Self.hiToolboxDomain) as? Int ?? 0
+    }
+
+    private func setFnUsageType(_ value: Int) {
+        CFPreferencesSetAppValue(Self.fnUsageKey, value as CFNumber, Self.hiToolboxDomain)
+        _ = CFPreferencesAppSynchronize(Self.hiToolboxDomain)
+    }
+}

--- a/Sources/Mojito/KeyMonitor/KeyMonitor.swift
+++ b/Sources/Mojito/KeyMonitor/KeyMonitor.swift
@@ -8,6 +8,12 @@ protocol KeyMonitorDelegate: AnyObject {
     /// Returns true if the event should be consumed (not delivered to the focused app).
     func keyMonitor(_ monitor: KeyMonitor, didReceive input: TriggerInput) -> Bool
     func keyMonitorDidLoseTap(_ monitor: KeyMonitor)
+    /// A lone Globe/Fn key was tapped (pressed and released with no other key
+    /// in between). Not consumed — fn is just a modifier here, and consuming
+    /// the key-up doesn't suppress the system panel anyway (macOS resolves
+    /// Globe below the session tap), so suppression is handled by the
+    /// AppleFnUsageType takeover instead.
+    func keyMonitorDidTapGlobeKey(_ monitor: KeyMonitor)
 }
 
 @MainActor
@@ -17,6 +23,12 @@ final class KeyMonitor {
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
     private(set) var isRunning = false
+
+    /// Lone Globe/Fn-tap detection: fn-down then fn-up within the threshold
+    /// with no key pressed in between. `nil` timestamp = no press in flight.
+    private var fnDownTimestamp: CGEventTimestamp?
+    private var fnTapInterrupted = false
+    private static let globeTapMaxDuration: CGEventTimestamp = 300_000_000  // ns
 
     func start() -> Bool {
         // Engine's `MainActor.assumeIsolated` callback dispatch is only safe
@@ -82,13 +94,39 @@ final class KeyMonitor {
             delegate?.keyMonitorDidLoseTap(self)
             return Unmanaged.passUnretained(event)
         }
+        if type == .flagsChanged {
+            handleFlagsChanged(event)
+            return Unmanaged.passUnretained(event)
+        }
         guard type == .keyDown else { return Unmanaged.passUnretained(event) }
+
+        // A real keypress during an fn hold means it wasn't a lone Globe tap.
+        if fnDownTimestamp != nil { fnTapInterrupted = true }
 
         let input = translate(event: event)
         guard let input else { return Unmanaged.passUnretained(event) }
 
         let consumed = delegate?.keyMonitor(self, didReceive: input) ?? false
         return consumed ? nil : Unmanaged.passUnretained(event)
+    }
+
+    private func handleFlagsChanged(_ event: CGEvent) {
+        let keyCode = Int(event.getIntegerValueField(.keyboardEventKeycode))
+        guard keyCode == kVK_Function else {
+            // A different modifier toggled mid-press — not a lone Globe tap.
+            if fnDownTimestamp != nil { fnTapInterrupted = true }
+            return
+        }
+        if event.flags.contains(.maskSecondaryFn) {
+            fnDownTimestamp = event.timestamp
+            fnTapInterrupted = false
+        } else {
+            defer { fnDownTimestamp = nil }
+            guard let down = fnDownTimestamp, !fnTapInterrupted,
+                  event.timestamp >= down,
+                  event.timestamp - down < Self.globeTapMaxDuration else { return }
+            delegate?.keyMonitorDidTapGlobeKey(self)
+        }
     }
 
     private func translate(event: CGEvent) -> TriggerInput? {

--- a/Sources/Mojito/Onboarding/OnboardingRoot.swift
+++ b/Sources/Mojito/Onboarding/OnboardingRoot.swift
@@ -6,6 +6,7 @@ struct OnboardingRoot: View {
     private enum Step: Int, CaseIterable {
         case welcome
         case permissions
+        case replaceEmoji
         case done
 
         var isFirst: Bool { self == .welcome }
@@ -89,6 +90,7 @@ struct OnboardingRoot: View {
                 openAccessibilitySettings: permissions.openAccessibilitySettings,
                 openInputMonitoringSettings: permissions.openInputMonitoringSettings
             )
+        case .replaceEmoji:      ReplaceEmojiStep()
         case .done:              DoneStep()
         }
     }

--- a/Sources/Mojito/Onboarding/OnboardingScreens.swift
+++ b/Sources/Mojito/Onboarding/OnboardingScreens.swift
@@ -465,6 +465,65 @@ struct PermissionsStep: View {
     }
 }
 
+// MARK: - Replace system emoji picker
+
+struct ReplaceEmojiStep: View {
+    @AppStorage(PrefsKey.replaceSystemEmojiPickerEnabled) private var enabled: Bool = false
+    @State private var needsLogout = false
+
+    var body: some View {
+        VStack(spacing: 22) {
+            Image(systemName: "face.smiling")
+                .font(.system(size: 44))
+                .foregroundStyle(.tint)
+
+            VStack(spacing: 6) {
+                Text("Replace the system emoji picker")
+                    .font(.system(size: 22, weight: .semibold))
+                Text("Make ⌃⌘Space and the \(Image(systemName: "globe")) key open \(AppInfo.displayName) instead of the macOS Emoji & Symbols panel.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 480)
+            }
+
+            Button(action: toggle) {
+                Label(
+                    enabled ? "Using \(AppInfo.displayName)" : "Replace system emoji picker",
+                    systemImage: enabled ? "checkmark.circle.fill" : "wand.and.stars"
+                )
+                .frame(maxWidth: 300)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .tint(enabled ? .green : .accentColor)
+
+            VStack(spacing: 4) {
+                if enabled && needsLogout {
+                    Text("Log out and back in to finish handing over the \(Image(systemName: "globe")) key.")
+                        .font(.system(size: 13))
+                        .foregroundStyle(.secondary)
+                }
+                Text("Optional — you can change this any time in Settings.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.tertiary)
+            }
+
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func toggle() {
+        if enabled {
+            SystemEmojiPickerReplacer.shared.restoreSystemPicker()
+            needsLogout = false
+        } else {
+            SystemEmojiPickerReplacer.shared.replaceSystemPicker()
+            needsLogout = SystemEmojiPickerReplacer.shared.needsLogoutForGlobe
+        }
+    }
+}
+
 // MARK: - Done
 
 struct DoneStep: View {

--- a/Sources/Mojito/Settings/GeneralSettings.swift
+++ b/Sources/Mojito/Settings/GeneralSettings.swift
@@ -157,8 +157,16 @@ struct GeneralSettingsView: View {
             }
 
             Section {
-                KeyboardShortcuts.Recorder("Pause for 1 hour", name: .pauseHour)
-                KeyboardShortcuts.Recorder("Pause until tomorrow", name: .pauseUntilTomorrow)
+                HStack {
+                    Text("Pause for 1 hour")
+                    Spacer(minLength: 8)
+                    ShortcutRecorder(name: .pauseHour)
+                }
+                HStack {
+                    Text("Pause until tomorrow")
+                    Spacer(minLength: 8)
+                    ShortcutRecorder(name: .pauseUntilTomorrow)
+                }
             } header: {
                 Text("Pausing")
             } footer: {

--- a/Sources/Mojito/Settings/QuickAccessSettings.swift
+++ b/Sources/Mojito/Settings/QuickAccessSettings.swift
@@ -47,9 +47,7 @@ struct QuickAccessSection: View {
                 slotGrid
             }
 
-            LabeledContent("Emoji Browser shortcut") {
-                KeyboardShortcuts.Recorder("", name: .showEmojiBrowser)
-            }
+            EmojiBrowserHotkeyRow()
         }
         .sheet(item: $editing) { slot in
             QuickAccessBrowserSheet { emoji in store.pin(emoji.hexcode, at: slot.id) }
@@ -165,6 +163,101 @@ struct QuickAccessSection: View {
 
     private func displayGlyph(_ emoji: Emoji) -> String {
         emoji.tonedGlyph
+    }
+}
+
+/// The system-emoji-picker controls: a Raycast-style hotkey row (Replace
+/// button + recorder + reset-to-default) plus an independent Globe-key toggle.
+/// "Replace System Picker" claims ⌃⌘Space, suppresses the macOS panel, and turns
+/// on the Globe key; reset restores the ⌃⌥Space default and all three off. The
+/// Globe key is also toggleable on its own. State is driven by the persisted
+/// flags and the authoritative shortcut handed to each handler — never re-read
+/// from `getShortcut`, which (in dev) reflects the release-app fallback.
+private struct EmojiBrowserHotkeyRow: View {
+    @State private var replacesPanel = SystemEmojiPickerReplacer.shared.replacesPanel
+    @State private var atDefault = KeyboardShortcuts.getShortcut(for: .showEmojiBrowser)
+        == SystemEmojiPickerReplacer.defaultShortcut
+    @State private var globeOn = SystemEmojiPickerReplacer.shared.globeEnabled
+    @State private var needsLogout = SystemEmojiPickerReplacer.shared.needsLogoutForGlobe
+
+    var body: some View {
+        Group {
+            // A plain HStack (not LabeledContent) so the label center-aligns with
+            // the custom recorder, which has no text baseline to align against.
+            HStack(spacing: 8) {
+                Text("Emoji Browser")
+                Spacer(minLength: 8)
+                ShortcutRecorder(name: .showEmojiBrowser) { shortcut in
+                    syncPanel(to: shortcut)
+                }
+                if !atDefault {
+                    Button { reset() } label: {
+                        Image(systemName: "arrow.counterclockwise")
+                    }
+                    .help("Reset to default (⌃⌥Space) and restore the system picker")
+                }
+            }
+
+            if !replacesPanel {
+                HStack {
+                    Spacer()
+                    Button("Replace System Picker") { replace() }
+                        .help("Open Mojito on ⌃⌘Space instead of the macOS Emoji & Symbols panel, and turn on the Globe key")
+                }
+            }
+
+            Toggle(isOn: Binding(get: { globeOn }, set: setGlobe)) {
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Open with the \(Image(systemName: "globe")) key")
+                    if globeOn && needsLogout {
+                        Text("Log out and back in to finish handing the \(Image(systemName: "globe")) key to Mojito.")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+            .toggleStyle(.switch)
+        }
+    }
+
+    private func replace() {
+        SystemEmojiPickerReplacer.shared.replaceSystemPicker()
+        replacesPanel = true
+        atDefault = false
+        globeOn = true
+        needsLogout = SystemEmojiPickerReplacer.shared.needsLogoutForGlobe
+    }
+
+    private func reset() {
+        SystemEmojiPickerReplacer.shared.restoreSystemPicker()
+        replacesPanel = false
+        atDefault = true
+        globeOn = false
+        needsLogout = false
+    }
+
+    /// Recorder edits manage only the ⌃⌘Space panel replacement — the Globe key
+    /// is its own toggle.
+    private func syncPanel(to shortcut: KeyboardShortcuts.Shortcut?) {
+        if shortcut == SystemEmojiPickerReplacer.systemShortcut {
+            SystemEmojiPickerReplacer.shared.enablePanelReplacement()
+            replacesPanel = true
+        } else {
+            SystemEmojiPickerReplacer.shared.disablePanelReplacement()
+            replacesPanel = false
+        }
+        atDefault = shortcut == SystemEmojiPickerReplacer.defaultShortcut
+    }
+
+    private func setGlobe(_ on: Bool) {
+        if on {
+            SystemEmojiPickerReplacer.shared.enableGlobe()
+        } else {
+            SystemEmojiPickerReplacer.shared.disableGlobe()
+        }
+        globeOn = on
+        needsLogout = SystemEmojiPickerReplacer.shared.needsLogoutForGlobe
     }
 }
 

--- a/Sources/Mojito/Settings/SettingsWindowController.swift
+++ b/Sources/Mojito/Settings/SettingsWindowController.swift
@@ -7,12 +7,20 @@ import SwiftUI
 @MainActor
 final class SettingsWindowController {
     private var window: NSWindow?
+    private weak var engine: Engine?
+
+    /// While Settings is key, suspend the global event tap so it doesn't fight
+    /// `KeyboardShortcuts.Recorder` (and any open browser) for keystrokes.
+    func setKey(_ isKey: Bool) {
+        engine?.setMonitorSuspended(isKey)
+    }
 
     func show(
         permissions: PermissionsCoordinator,
         exclusions: ExclusionStore,
         engine: Engine
     ) {
+        self.engine = engine
         if let window {
             window.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
@@ -67,10 +75,19 @@ final class SettingsWindowDelegate: NSObject, NSWindowDelegate {
         self.controller = controller
     }
 
+    func windowDidBecomeKey(_ notification: Notification) {
+        controller?.setKey(true)
+    }
+
+    func windowDidResignKey(_ notification: Notification) {
+        controller?.setKey(false)
+    }
+
     func windowWillClose(_ notification: Notification) {
         // Detach so close() doesn't recurse into the closing window.
         let c = controller
         controller = nil
+        c?.setKey(false)
         c?.close()
         DockIconManager.windowDidClose()
     }

--- a/Sources/Mojito/Settings/ShortcutRecorder.swift
+++ b/Sources/Mojito/Settings/ShortcutRecorder.swift
@@ -1,0 +1,232 @@
+import AppKit
+import SwiftUI
+import KeyboardShortcuts
+
+/// A shortcut recorder that captures via the responder chain (`keyDown`) rather
+/// than a text field + `NSEvent` local monitor. The library's `Recorder`
+/// misbehaves in this app — keys leak into the search field's field editor and
+/// valid chords never register — so this purpose-built control sidesteps both.
+/// Reads/writes through `KeyboardShortcuts`, so the global hotkey still registers.
+///
+/// Click to record (the box clears to "Record Shortcut"); press a chord to set
+/// it; Escape or clicking away keeps the previous value; Delete clears it.
+struct ShortcutRecorder: NSViewRepresentable {
+    let name: KeyboardShortcuts.Name
+    var onChange: ((KeyboardShortcuts.Shortcut?) -> Void)? = nil
+
+    func makeNSView(context: Context) -> ShortcutRecorderView {
+        ShortcutRecorderView(name: name, onChange: onChange)
+    }
+
+    func updateNSView(_ view: ShortcutRecorderView, context: Context) {
+        view.onChange = onChange
+        view.refresh()
+    }
+
+    // Hand SwiftUI the exact size so it never stretches the view to fill the
+    // available width (which pushed it past the table edge).
+    func sizeThatFits(_ proposal: ProposedViewSize, nsView: ShortcutRecorderView, context: Context) -> CGSize? {
+        ShortcutRecorderView.size
+    }
+}
+
+@MainActor
+final class ShortcutRecorderView: NSView {
+    let name: KeyboardShortcuts.Name
+    var onChange: ((KeyboardShortcuts.Shortcut?) -> Void)?
+
+    private var recording = false { didSet { needsDisplay = true } }
+    private let label = NSTextField(labelWithString: "")
+    private let clearButton = NSButton()
+    /// Installed only while recording, to dismiss when the user clicks elsewhere.
+    private var clickMonitor: Any?
+
+    static let size = NSSize(width: 124, height: 24)
+
+    init(name: KeyboardShortcuts.Name, onChange: ((KeyboardShortcuts.Shortcut?) -> Void)?) {
+        self.name = name
+        self.onChange = onChange
+        super.init(frame: NSRect(origin: .zero, size: Self.size))
+        wantsLayer = true
+        focusRingType = .default
+        // Never let the content stretch or shrink this view away from its size.
+        setContentHuggingPriority(.required, for: .horizontal)
+        setContentHuggingPriority(.required, for: .vertical)
+        setContentCompressionResistancePriority(.required, for: .horizontal)
+
+        label.alignment = .center
+        label.font = .systemFont(ofSize: NSFont.systemFontSize)
+        label.lineBreakMode = .byTruncatingTail
+        // Truncate rather than forcing the box wider to fit the text.
+        label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(label)
+
+        clearButton.isBordered = false
+        clearButton.imagePosition = .imageOnly
+        clearButton.image = NSImage(systemSymbolName: "xmark.circle.fill",
+                                    accessibilityDescription: String(localized: "Clear shortcut"))?
+            .withSymbolConfiguration(.init(pointSize: 12, weight: .regular))
+        clearButton.contentTintColor = .tertiaryLabelColor
+        clearButton.target = self
+        clearButton.action = #selector(clearTapped)
+        clearButton.refusesFirstResponder = true
+        clearButton.isHidden = true
+        clearButton.translatesAutoresizingMaskIntoConstraints = false
+        clearButton.setContentHuggingPriority(.required, for: .horizontal)
+        addSubview(clearButton)
+
+        NSLayoutConstraint.activate([
+            clearButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -6),
+            clearButton.centerYAnchor.constraint(equalTo: centerYAnchor),
+            clearButton.widthAnchor.constraint(equalToConstant: 16),
+            clearButton.heightAnchor.constraint(equalToConstant: 16),
+            // Full width and centered; the clear button overlays the right edge
+            // (it's only shown alongside a short chord, never the placeholder).
+            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 6),
+            label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -6),
+            label.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+        refresh()
+    }
+
+    @available(*, unavailable) required init?(coder: NSCoder) { fatalError() }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        // Removed from the hierarchy (e.g. switched settings tabs) mid-record.
+        if window == nil {
+            recording = false
+            removeClickMonitor()
+        }
+    }
+
+    override var intrinsicContentSize: NSSize { Self.size }
+    override var acceptsFirstResponder: Bool { true }
+    override var canBecomeKeyView: Bool { true }
+
+    private var cornerRadius: CGFloat { 6 }
+
+    override func draw(_ dirtyRect: NSRect) {
+        // Native text-field look: white field background, hairline border. The
+        // active (recording) state is conveyed by AppKit's focus ring below.
+        let rect = bounds.insetBy(dx: 0.5, dy: 0.5)
+        let path = NSBezierPath(roundedRect: rect, xRadius: cornerRadius, yRadius: cornerRadius)
+        NSColor.textBackgroundColor.setFill()
+        path.fill()
+        path.lineWidth = 1
+        NSColor.separatorColor.setStroke()
+        path.stroke()
+    }
+
+    // Native focus ring while recording (the box is first responder).
+    override var focusRingMaskBounds: NSRect { bounds }
+
+    override func drawFocusRingMask() {
+        NSBezierPath(roundedRect: bounds, xRadius: cornerRadius, yRadius: cornerRadius).fill()
+    }
+
+    /// The whole box is a single click target (the label subview must not eat
+    /// clicks) — except the visible clear button. Reuse the default hit logic so
+    /// the coordinate math is correct, then redirect label hits to self.
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard let hit = super.hitTest(point) else { return nil }
+        if !clearButton.isHidden, hit == clearButton { return clearButton }
+        return self
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        // Only ever start recording on a click — never toggle off, or a click
+        // that AppKit already used to focus the box would immediately cancel it
+        // (the "needs a double-click" bug). Escape / click-away dismiss instead.
+        if !recording {
+            window?.makeFirstResponder(self)
+        }
+    }
+
+    override func becomeFirstResponder() -> Bool {
+        recording = true
+        label.stringValue = String(localized: "Record Shortcut")
+        label.textColor = .secondaryLabelColor
+        clearButton.isHidden = true
+        installClickMonitor()
+        return true
+    }
+
+    @objc private func clearTapped() {
+        KeyboardShortcuts.setShortcut(nil, for: name)
+        onChange?(nil)
+        refresh()
+    }
+
+    override func resignFirstResponder() -> Bool {
+        recording = false
+        removeClickMonitor()
+        refresh()
+        return true
+    }
+
+    /// A click anywhere outside the box ends recording (and still reaches its
+    /// target, so clicking a button both dismisses and activates it).
+    private func installClickMonitor() {
+        guard clickMonitor == nil else { return }
+        clickMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { [weak self] event in
+            guard let self, self.recording else { return event }
+            let point = self.convert(event.locationInWindow, from: nil)
+            if !self.bounds.contains(point) {
+                self.window?.makeFirstResponder(nil)
+            }
+            return event
+        }
+    }
+
+    private func removeClickMonitor() {
+        if let clickMonitor {
+            NSEvent.removeMonitor(clickMonitor)
+            self.clickMonitor = nil
+        }
+    }
+
+    override func keyDown(with event: NSEvent) {
+        guard recording else { super.keyDown(with: event); return }
+
+        switch event.keyCode {
+        case 53: // Escape — cancel, keep previous.
+            window?.makeFirstResponder(nil)
+            return
+        case 51, 117: // Backspace / forward-delete — clear.
+            KeyboardShortcuts.setShortcut(nil, for: name)
+            onChange?(nil)
+            window?.makeFirstResponder(nil)
+            return
+        default:
+            break
+        }
+
+        // Require a command/control/option modifier so a bare letter can't
+        // become a shortcut. (Shift alone doesn't count.)
+        let mods = event.modifierFlags.intersection([.command, .control, .option])
+        guard !mods.isEmpty, let shortcut = KeyboardShortcuts.Shortcut(event: event) else {
+            NSSound.beep()
+            return
+        }
+        KeyboardShortcuts.setShortcut(shortcut, for: name)
+        onChange?(shortcut)
+        window?.makeFirstResponder(nil)
+    }
+
+    /// Sync the displayed value to the stored shortcut (e.g. after the Replace /
+    /// reset buttons set it). No-op while recording so it keeps the prompt.
+    func refresh() {
+        guard !recording else { return }
+        if let shortcut = KeyboardShortcuts.getShortcut(for: name) {
+            label.textColor = .labelColor
+            label.stringValue = "\(shortcut)"
+            clearButton.isHidden = false
+        } else {
+            label.textColor = .secondaryLabelColor
+            label.stringValue = String(localized: "Record Shortcut")
+            clearButton.isHidden = true
+        }
+    }
+}

--- a/Sources/Mojito/Util/PrefsKey.swift
+++ b/Sources/Mojito/Util/PrefsKey.swift
@@ -88,6 +88,19 @@ enum PrefsKey {
     /// debug report can show whether conversions are landing at all.
     static let totalEmoticonInserted = "mojito.totals.emoticonInserted"
 
+    // MARK: Replace system emoji picker
+    /// When true, the browser hotkey owns ⌃⌘Space and the macOS Emoji & Symbols
+    /// panel is best-effort suppressed. Independent of the Globe toggle below.
+    static let replaceSystemEmojiPickerEnabled = "mojito.replaceSystemEmojiPicker.enabled"
+    /// When true, a lone Globe/Fn tap opens the browser (its own toggle).
+    static let globeKeyEnabled                 = "mojito.replaceSystemEmojiPicker.globeEnabled"
+    /// `AppleFnUsageType` value captured before we set it to 0, restored when the
+    /// Globe toggle goes off. Absent unless the Globe takeover is on.
+    static let priorFnUsageType                = "mojito.replaceSystemEmojiPicker.priorFnUsageType"
+    /// Whether symbolic hotkey 50 (Character Viewer) was enabled before we
+    /// disabled it, restored when panel replacement goes off.
+    static let priorCharacterPaletteEnabled    = "mojito.replaceSystemEmojiPicker.priorPaletteEnabled"
+
     // MARK: Anonymous usage statistics
     /// Opt-out master switch. Default true, but nothing is sent until
     /// `telemetryConsentSeen` is also true (Homebrew-style consent gate).


### PR DESCRIPTION
Points ⌃⌘Space and a lone Globe/Fn key tap at Mojito's emoji browser instead of the macOS Emoji & Symbols panel. Opt-in, surfaced as a Raycast-style row in Quick Access settings and an onboarding step.

## What's in it
- **Panel replacement** — the browser hotkey claims ⌃⌘Space (via KeyboardShortcuts), and the OS panel is best-effort suppressed through the private SkyLight `CGSSetSymbolicHotKeyEnabled` (hotkey 50), resolved by `dlsym` so a missing symbol no-ops instead of crashing.
- **Globe key** — a lone fn down→up under 300ms with no intervening key fires the browser, detected on KeyMonitor's existing `flagsChanged` stream. `AppleFnUsageType=0` hands the key over (needs a logout to fully apply — surfaced in the UI); prior value stashed and restored on disable.
- **Two independent toggles** — "Replace System Picker" claims ⌃⌘Space + the Globe key in one tap; reset restores the ⌃⌥Space default; the Globe key is also toggleable on its own.
- **Custom `ShortcutRecorder`** — the KeyboardShortcuts library's `Recorder` misbehaved in this app (keys leaked into the field editor, chords didn't register), so this captures via `keyDown` on the responder chain. Native text-field styling + focus ring, a clear (X) button, click-away/Escape dismiss. Reused for the pause-hotkey fields too.
- The event tap is **suspended while the Settings window is key** so it doesn't fight the recorder for keystrokes.
- The hotkey **toggles** the browser (a second press closes it), matching the panel.

## Test plan
- ⌃⌘Space and the Globe key both open the browser (IRL-confirmed); a second press closes it.
- Settings: Replace → claims ⌃⌘Space + Globe; reset → ⌃⌥Space default + restores panel/Globe; Globe toggle works independently.
- Recorder: click to record, capture a chord, clear with X, dismiss with Escape / click-away; no key leakage.
- Pause-hotkey recorders capture correctly with the new control.
- Unit suite green (`scripts/run-tests.sh`).

## Notes / risk
- Private CGS API: no notarization impact (Developer-ID, non-sandboxed); every call guards its return, so OS churn renumbering the hotkey ID just no-ops.
- Globe takeover needs a logout to stop the OS panel; ⌃⌘Space is immediate and self-heals (CGS state resets each login).

Refs W-433