### PR TITLE
W-435: Enable Liquid Glass on the app icon

### DIFF
--- a/Resources/AppIcon.icon/icon.json
+++ b/Resources/AppIcon.icon/icon.json
@@ -20,6 +20,8 @@
     {
       "layers" : [
         {
+          "fill" : "none",
+          "glass" : true,
           "image-name" : "Vectoraa.svg",
           "name" : "Vectoraa",
           "position" : {


### PR DESCRIPTION
Turns on Icon Composer's **Liquid Glass** treatment for the app icon's vector layer (`glass: true`, `fill: none` on the Vectoraa layer) — the Tahoe glass icon look.

Resources/AppIcon.icon/icon.json only; no code.

Refs W-435