### PR TITLE
W-447: Always-filled Emoji settings icon

### DIFF
--- a/Sources/Mojito/Settings/GeneralSettings.swift
+++ b/Sources/Mojito/Settings/GeneralSettings.swift
@@ -81,7 +81,7 @@ struct GeneralSettingsView: View {
 
             Section {
                 SettingsSectionHeader(
-                    systemImage: "face.smiling",
+                    systemImage: "face.smiling.fill",
                     tint: .orange,
                     title: "Emoji",
                     subtitle: "Type a shortcut to insert any emoji.",


### PR DESCRIPTION
The Emoji section header used the outline `face.smiling` (filled in dark, outline in light). Switched to `face.smiling.fill` so it's filled in both modes, matching the other section icons (`bolt.fill`, `photo.fill`).

Refs W-447