### PR TITLE
W-451: Onboarding refresh + symbols on by default

### DIFF
--- a/Sources/Mojito/App/AppDelegate.swift
+++ b/Sources/Mojito/App/AppDelegate.swift
@@ -133,6 +133,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             .sink { [weak self] _ in self?.engine.showBrowser() }
             .store(in: &observers)
 
+        // Onboarding's Done step asks the engine to go live early so its
+        // "try it out" field expands shortcuts. Idempotent — start() reconciles.
+        NotificationCenter.default.publisher(for: .mojitoShouldStartEngine)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.engine.start() }
+            .store(in: &observers)
+
         // Discovery banner click: open Settings, then ask the navigator to
         // reveal the egg. Order matters — open first so a fresh window's
         // views mount and pick up the (already-set) reveal request on appear.

--- a/Sources/Mojito/KeyMonitor/TriggerConfig.swift
+++ b/Sources/Mojito/KeyMonitor/TriggerConfig.swift
@@ -61,7 +61,7 @@ struct TriggerConfig: Equatable, Codable {
 
     static let `default` = TriggerConfig(
         emoji:       Trigger(mode: .emoji,       open: ":",   enabled: true),
-        symbols:     Trigger(mode: .symbols,     open: "::",  enabled: false),
+        symbols:     Trigger(mode: .symbols,     open: "::",  enabled: true),
         gif:         Trigger(mode: .gif,         open: ":::", enabled: true),
         quickAccess: Trigger(mode: .quickAccess, open: ":?",  enabled: true),
         symbolsFollowEmoji: true,

--- a/Sources/Mojito/KeyMonitor/TriggerConfigStore.swift
+++ b/Sources/Mojito/KeyMonitor/TriggerConfigStore.swift
@@ -39,7 +39,7 @@ enum TriggerConfigStore {
         //   enabled + requireDoubleColon → scoped (`::`, follow=false)
         //   enabled + !requireDoubleColon → blended (follow=true)
         //   !enabled → off
-        let symbolsEnabled = defaults.object(forKey: PrefsKey.symbolsEnabled) as? Bool ?? false
+        let symbolsEnabled = defaults.object(forKey: PrefsKey.symbolsEnabled) as? Bool ?? true
         let requireDoubleColon = defaults.object(forKey: PrefsKey.symbolsRequireDoubleColon) as? Bool ?? false
         let symbolsFollowEmoji = symbolsEnabled && !requireDoubleColon
         let gifEnabled = defaults.object(forKey: PrefsKey.gifSearchEnabled) as? Bool ?? true

--- a/Sources/Mojito/Onboarding/OnboardingRoot.swift
+++ b/Sources/Mojito/Onboarding/OnboardingRoot.swift
@@ -5,8 +5,8 @@ struct OnboardingRoot: View {
     /// content switch all derive from this enum.
     private enum Step: Int, CaseIterable {
         case welcome
+        case features
         case permissions
-        case replaceEmoji
         case done
 
         var isFirst: Bool { self == .welcome }
@@ -81,6 +81,7 @@ struct OnboardingRoot: View {
     private var content: some View {
         switch step {
         case .welcome:           WelcomeStep()
+        case .features:          FeaturesStep()
         case .permissions:
             PermissionsStep(
                 accessibilityGranted: permissions.accessibility,
@@ -90,7 +91,6 @@ struct OnboardingRoot: View {
                 openAccessibilitySettings: permissions.openAccessibilitySettings,
                 openInputMonitoringSettings: permissions.openInputMonitoringSettings
             )
-        case .replaceEmoji:      ReplaceEmojiStep()
         case .done:              DoneStep()
         }
     }
@@ -191,4 +191,6 @@ extension Notification.Name {
     static let mojitoShouldShowOnboarding = Notification.Name("mojitoShouldShowOnboarding")
     /// Opens the full-library emoji browser window.
     static let mojitoShouldOpenBrowser = Notification.Name("mojitoShouldOpenBrowser")
+    /// Starts the engine early (the onboarding Done step's "try it out" field).
+    static let mojitoShouldStartEngine = Notification.Name("mojitoShouldStartEngine")
 }

--- a/Sources/Mojito/Onboarding/OnboardingScreens.swift
+++ b/Sources/Mojito/Onboarding/OnboardingScreens.swift
@@ -465,61 +465,87 @@ struct PermissionsStep: View {
     }
 }
 
-// MARK: - Replace system emoji picker
+// MARK: - Features
 
-struct ReplaceEmojiStep: View {
-    @AppStorage(PrefsKey.replaceSystemEmojiPickerEnabled) private var enabled: Bool = false
-    @State private var needsLogout = false
+/// Enable/disable the emoji, symbols, and GIF features and pick each one's
+/// trigger — the same controls as Settings ▸ General, reusing
+/// `SettingsSectionHeader` + `TriggerPicker`. Edits persist immediately.
+struct FeaturesStep: View {
+    @State private var triggers: TriggerConfig = TriggerConfigStore.load()
 
-    var body: some View {
-        VStack(spacing: 22) {
-            Image(systemName: "face.smiling")
-                .font(.system(size: 44))
-                .foregroundStyle(.tint)
-
-            VStack(spacing: 6) {
-                Text("Replace the system emoji picker")
-                    .font(.system(size: 22, weight: .semibold))
-                Text("Make ⌃⌘Space and the \(Image(systemName: "globe")) key open \(AppInfo.displayName) instead of the macOS Emoji & Symbols panel.")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                    .frame(maxWidth: 480)
-            }
-
-            Button(action: toggle) {
-                Label(
-                    enabled ? "Using \(AppInfo.displayName)" : "Replace system emoji picker",
-                    systemImage: enabled ? "checkmark.circle.fill" : "wand.and.stars"
-                )
-                .frame(maxWidth: 300)
-            }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.large)
-            .tint(enabled ? .green : .accentColor)
-
-            VStack(spacing: 4) {
-                if enabled && needsLogout {
-                    Text("Log out and back in to finish handing over the \(Image(systemName: "globe")) key.")
-                        .font(.system(size: 13))
-                        .foregroundStyle(.secondary)
-                }
-                Text("Optional — you can change this any time in Settings.")
-                    .font(.system(size: 12))
-                    .foregroundStyle(.tertiary)
-            }
-
-            Spacer(minLength: 0)
-        }
+    /// Opens claimed by the other active triggers, so each menu grays collisions.
+    private func takenOpens(excluding mode: TriggerMode) -> Set<String> {
+        var normalized = triggers
+        normalized.normalize()
+        return Set(normalized.active.filter { $0.mode != mode }.map(\.open))
     }
 
-    private func toggle() {
-        if enabled {
-            SystemEmojiPickerReplacer.shared.restoreSystemPicker()
-            needsLogout = false
-        } else {
-            SystemEmojiPickerReplacer.shared.replaceSystemPicker()
-            needsLogout = SystemEmojiPickerReplacer.shared.needsLogoutForGlobe
+    var body: some View {
+        Form {
+            Section {
+                SettingsSectionHeader(
+                    systemImage: "face.smiling.fill",
+                    tint: .orange,
+                    title: "Emoji",
+                    subtitle: "Type a shortcut to insert any emoji.",
+                    iconSize: 16,
+                    iconOffsetY: -1,
+                    isOn: $triggers.emoji.enabled
+                )
+                if triggers.emoji.enabled {
+                    TriggerPicker(
+                        mode: .emoji,
+                        open: $triggers.emoji.open,
+                        takenOpens: takenOpens(excluding: .emoji),
+                        defaultOpen: TriggerConfig.default.emoji.open
+                    )
+                }
+            }
+
+            Section {
+                SettingsSectionHeader(
+                    systemImage: "command",
+                    tint: .indigo,
+                    title: "Symbols",
+                    subtitle: "Symbols like ★ ✓ ÷ ©.",
+                    isOn: $triggers.symbols.enabled
+                )
+                if triggers.symbols.enabled {
+                    TriggerPicker(
+                        mode: .symbols,
+                        open: $triggers.symbols.open,
+                        takenOpens: takenOpens(excluding: .symbols),
+                        defaultOpen: TriggerConfig.default.symbols.open,
+                        sameAsEmoji: $triggers.symbolsFollowEmoji,
+                        defaultFollowsEmoji: true
+                    )
+                }
+            }
+
+            Section {
+                SettingsSectionHeader(
+                    systemImage: "photo.fill",
+                    tint: .pink,
+                    title: "GIF search",
+                    subtitle: "GIFs from Giphy.",
+                    isOn: $triggers.gif.enabled
+                )
+                if triggers.gif.enabled {
+                    TriggerPicker(
+                        mode: .gif,
+                        open: $triggers.gif.open,
+                        takenOpens: takenOpens(excluding: .gif),
+                        defaultOpen: TriggerConfig.default.gif.open
+                    )
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .scrollContentBackground(.hidden)
+        .scrollDisabled(true)
+        .frame(maxWidth: 480)
+        .onChange(of: triggers) { _, _ in
+            TriggerConfigStore.save(triggers)
         }
     }
 }
@@ -527,10 +553,13 @@ struct ReplaceEmojiStep: View {
 // MARK: - Done
 
 struct DoneStep: View {
-    @AppStorage(PrefsKey.launchAtLogin) private var launchAtLogin: Bool = false
     @AppStorage(PrefsKey.skinTone) private var skinToneRaw: String = SkinTone.default.rawValue
-    @AppStorage(PrefsKey.telemetryEnabled) private var telemetryEnabled: Bool = true
+    @AppStorage(PrefsKey.replaceSystemEmojiPickerEnabled) private var replacePicker: Bool = false
+    @AppStorage(PrefsKey.launchAtLogin) private var launchAtLogin: Bool = false
     @State private var autoUpdates: Bool = UpdaterCoordinator.shared.automaticUpdates
+    @State private var replaceNeedsLogout = false
+    @State private var tryItText = ""
+    @FocusState private var tryItFocused: Bool
 
     var body: some View {
         VStack(spacing: 16) {
@@ -542,76 +571,108 @@ struct DoneStep: View {
                 VStack(spacing: 6) {
                     Text("You're all set")
                         .font(.system(size: 24, weight: .semibold))
-                    Text("\(AppInfo.displayName) lives in your menu bar. Try typing `:tada:` in any text field.")
+                    Text("\(AppInfo.displayName) lives in your menu bar — give it a try:")
                         .font(.callout)
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
                         .frame(maxWidth: 440)
                 }
+
+                TextField("Try typing :smile", text: $tryItText)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: 15))
+                    .frame(maxWidth: 280)
+                    .focused($tryItFocused)
             }
             .padding(.top, 4)
 
             Form {
-                HStack {
-                    Text("Skin tone")
-                    Spacer(minLength: 12)
-                    HStack(spacing: 4) {
-                        ForEach(SkinTone.allCases) { tone in
-                            Button {
-                                skinToneRaw = tone.rawValue
-                            } label: {
-                                Text(tone.swatchEmoji)
-                                    .font(.system(size: 18))
-                                    .frame(width: 26, height: 26)
-                                    .background(
-                                        RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                            .fill(skinToneRaw == tone.rawValue
-                                                  ? Color.accentColor.opacity(0.22)
-                                                  : Color.clear)
-                                    )
-                                    .overlay(
-                                        RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                            .strokeBorder(
-                                                skinToneRaw == tone.rawValue ? Color.accentColor : Color.clear,
-                                                lineWidth: 1.5
-                                            )
-                                    )
+                Section {
+                    HStack {
+                        Text("Skin tone")
+                        Spacer(minLength: 12)
+                        skinToneSwatches
+                    }
+
+                    Toggle(isOn: $replacePicker) {
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text("Replace system emoji picker")
+                            Text("Open \(AppInfo.displayName) on ⌃⌘Space and the \(Image(systemName: "globe")) key.")
+                                .font(.callout)
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                            if replacePicker && replaceNeedsLogout {
+                                Text("Log out and back in to finish handing over the \(Image(systemName: "globe")) key.")
+                                    .font(.callout)
+                                    .foregroundStyle(.secondary)
                             }
-                            .buttonStyle(.plain)
-                            .help(tone.displayName)
+                        }
+                    }
+                    .toggleStyle(.switch)
+                    .onChange(of: replacePicker) { _, on in
+                        if on {
+                            SystemEmojiPickerReplacer.shared.replaceSystemPicker()
+                            replaceNeedsLogout = SystemEmojiPickerReplacer.shared.needsLogoutForGlobe
+                        } else {
+                            SystemEmojiPickerReplacer.shared.restoreSystemPicker()
+                            replaceNeedsLogout = false
                         }
                     }
                 }
 
-                Toggle("Automatic updates", isOn: $autoUpdates)
-                    .toggleStyle(.switch)
-                    .onChange(of: autoUpdates) { _, newValue in
-                        UpdaterCoordinator.shared.automaticUpdates = newValue
-                    }
+                Section {
+                    Toggle("Automatic updates", isOn: $autoUpdates)
+                        .toggleStyle(.switch)
+                        .onChange(of: autoUpdates) { _, newValue in
+                            UpdaterCoordinator.shared.automaticUpdates = newValue
+                        }
 
-                Toggle("Start at login", isOn: $launchAtLogin)
-                    .toggleStyle(.switch)
-                    .onChange(of: launchAtLogin) { _, newValue in
-                        LaunchAtLogin.apply(newValue)
-                    }
-
-                Toggle(isOn: $telemetryEnabled) {
-                    HStack(spacing: 4) {
-                        Text("Share anonymous usage stats")
-                        StatsHelpButton()
-                    }
+                    Toggle("Start at login", isOn: $launchAtLogin)
+                        .toggleStyle(.switch)
+                        .onChange(of: launchAtLogin) { _, newValue in
+                            LaunchAtLogin.apply(newValue)
+                        }
                 }
-                .toggleStyle(.switch)
             }
             .formStyle(.grouped)
             .scrollContentBackground(.hidden)
             .scrollDisabled(true)
             .frame(maxWidth: 460)
-            .onAppear {
-                // Reaching the final step discloses stats sharing, so it
-                // satisfies the consent gate — no separate launch alert needed
-                // for users who just finished onboarding.
-                UserDefaults.standard.set(true, forKey: PrefsKey.telemetryConsentSeen)
+        }
+        .onAppear {
+            // Bring the engine live so the "try it out" field actually expands
+            // shortcuts — it isn't started until onboarding finishes otherwise.
+            NotificationCenter.default.post(name: .mojitoShouldStartEngine, object: nil)
+            // Focus the field once the step's transition has settled.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { tryItFocused = true }
+        }
+    }
+
+    private var skinToneSwatches: some View {
+        HStack(spacing: 4) {
+            ForEach(SkinTone.allCases) { tone in
+                Button {
+                    skinToneRaw = tone.rawValue
+                } label: {
+                    Text(tone.swatchEmoji)
+                        .font(.system(size: 18))
+                        .frame(width: 26, height: 26)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                .fill(skinToneRaw == tone.rawValue
+                                      ? Color.accentColor.opacity(0.22)
+                                      : Color.clear)
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                .strokeBorder(
+                                    skinToneRaw == tone.rawValue ? Color.accentColor : Color.clear,
+                                    lineWidth: 1.5
+                                )
+                        )
+                }
+                .buttonStyle(.plain)
+                .help(tone.displayName)
             }
         }
     }

--- a/Sources/Mojito/Settings/PrivacyPermissionsSettings.swift
+++ b/Sources/Mojito/Settings/PrivacyPermissionsSettings.swift
@@ -148,6 +148,7 @@ struct PrivacyDetailsRows: View {
 /// Surfaced by the onboarding permissions step.
 struct PrivacyDetailsSheet: View {
     @Environment(\.dismiss) private var dismiss
+    @AppStorage(PrefsKey.telemetryEnabled) private var telemetryEnabled: Bool = true
 
     var body: some View {
         VStack(spacing: 0) {
@@ -169,6 +170,14 @@ struct PrivacyDetailsSheet: View {
 
                 Form {
                     PrivacyDetailsRows()
+
+                    Toggle(isOn: $telemetryEnabled) {
+                        HStack(spacing: 4) {
+                            Text("Share anonymous usage stats")
+                            StatsHelpButton()
+                        }
+                    }
+                    .toggleStyle(.switch)
                 }
                 .formStyle(.grouped)
                 .scrollDisabled(true)
@@ -182,6 +191,11 @@ struct PrivacyDetailsSheet: View {
             .padding(.horizontal, 20)
             .padding(.vertical, 14)
         }
-        .frame(width: 500, height: 520)
+        .frame(width: 500, height: 560)
+        .onAppear {
+            // Seeing the privacy sheet (with the stats toggle + anonymity
+            // explanation) satisfies the one-time stats-consent gate.
+            UserDefaults.standard.set(true, forKey: PrefsKey.telemetryConsentSeen)
+        }
     }
 }

--- a/Tests/MojitoTests/TriggerConfigStoreTests.swift
+++ b/Tests/MojitoTests/TriggerConfigStoreTests.swift
@@ -32,7 +32,7 @@ struct TriggerConfigStoreTests {
         // that still carries `close` decodes cleanly into the open-only model.
         let legacy = """
         {"emoji":{"mode":"emoji","open":":","close":":","enabled":true},
-         "symbols":{"mode":"symbols","open":"::","close":":","enabled":false},
+         "symbols":{"mode":"symbols","open":"::","close":":","enabled":true},
          "gif":{"mode":"gif","open":":::","enabled":true},
          "quickAccess":{"mode":"quickAccess","open":":?","enabled":true}}
         """
@@ -99,18 +99,20 @@ struct TriggerConfigStoreTests {
 
     // MARK: migration from legacy prefs
 
-    @Test func migrationOnEmptyDefaultsMatchesHistoricalDefault() {
+    @Test func migrationOnEmptyDefaultsEnablesAllFeatures() {
         let suite = freshSuite()
         let config = TriggerConfigStore.load(defaults: suite)
-        // No legacy prefs set → symbols trigger off, everything else default.
+        // No legacy prefs set → every feature on; symbols blends into emoji
+        // search (follow=true), so its open mirrors the emoji open.
         #expect(config.emoji == Trigger(mode: .emoji, open: ":", enabled: true))
-        #expect(config.symbols == Trigger(mode: .symbols, open: "::", enabled: false))
+        #expect(config.symbols.enabled == true)
+        #expect(config.symbolsFollowEmoji == true)
         #expect(config.gif == Trigger(mode: .gif, open: ":::", enabled: true))
         #expect(config.quickAccess == Trigger(mode: .quickAccess, open: ":?", enabled: true))
     }
 
-    @Test func symbolsTriggerDefaultsOff() {
-        #expect(TriggerConfig.default.symbols.enabled == false)
+    @Test func symbolsTriggerDefaultsOn() {
+        #expect(TriggerConfig.default.symbols.enabled == true)
     }
 
     @Test func migrationMapsSymbolsEnableOntoTrigger() {


### PR DESCRIPTION
Reworks onboarding to feel less pushy and more useful.

## What's in it
- **New "Set up your features" step** (Welcome → **Set up your features** → Permissions → Done): enable/disable Emoji, Symbols, GIF and pick each trigger, reusing the Settings section headers + trigger pickers.
- **Removed the big "Replace system emoji picker" CTA step** and the "More options" overlay. Replace is now a calm toggle on the Done screen; Automatic updates + Start at login sit in a second section there.
- **Live "try it out" field** on Done (autofocused, placeholder `:smile`) — `DoneStep` posts a `mojitoShouldStartEngine` notification so the engine starts early enough for shortcuts to expand right in the field.
- **Stats consent moved** into the onboarding Privacy details sheet (which marks consent seen on appear). Skipping it still fires the existing one-time consent prompt after onboarding, so nothing is sent before disclosure.
- **Symbols now default ON** for fresh installs (`TriggerConfigStore.migrate` + `TriggerConfig.default`), blended into emoji search via follow-emoji — matching emoji/GIF. Existing users' saved configs are untouched.

## Test plan
- Onboarding: Welcome → Features (all three on; symbols "Same as emoji") → Permissions → Done.
- Done: replace toggle works; updates/login in their own section; the `:smile` field is focused and expands live.
- Skip Privacy details → consent prompt appears after finishing; open it → no prompt; nothing sent before either.
- Fresh config defaults symbols on; existing config unaffected.
- Unit suite green (228 tests; updated the symbols-default tests).

## Notes
- **Symbols-on-by-default is a behavior change** for new installs — worth a v1.7.0 release note.

Independent code review: clean, no high-confidence issues.

Refs W-451