### PR TITLE
W-452: raise pickers to .popUpMenu so app pop-ups can't cover them

### DIFF
--- a/Sources/Mojito/GifPicker/GifPickerWindow.swift
+++ b/Sources/Mojito/GifPicker/GifPickerWindow.swift
@@ -38,7 +38,9 @@ final class GifPickerWindow {
             defer: false
         )
         panel.isFloatingPanel = true
-        panel.level = .floating
+        // See PickerWindow: `.popUpMenu` so app pop-ups at `.floating` (owned
+        // by the active app) can't cover our background-app picker.
+        panel.level = .popUpMenu
         panel.isOpaque = false
         panel.backgroundColor = .clear
         panel.hasShadow = true

--- a/Sources/Mojito/Picker/PickerWindow.swift
+++ b/Sources/Mojito/Picker/PickerWindow.swift
@@ -100,7 +100,7 @@ final class PickerWindow {
                 backing: .buffered, defer: false
             )
             tip.isFloatingPanel = true
-            tip.level = .popUpMenu  // stay above the picker, which is also .popUpMenu
+            tip.level = .popUpMenu  // same band as the picker so app pop-ups can't slip above it
             tip.isOpaque = false
             tip.backgroundColor = .clear
             tip.hasShadow = false  // bubble carries its own soft SwiftUI shadow

--- a/Sources/Mojito/Picker/PickerWindow.swift
+++ b/Sources/Mojito/Picker/PickerWindow.swift
@@ -29,7 +29,12 @@ final class PickerWindow {
             defer: false
         )
         panel.isFloatingPanel = true
-        panel.level = .floating
+        // `.popUpMenu`, not `.floating`: app pop-ups (quick-entry sheets,
+        // menu-bar panels) often sit at `.floating` themselves, and since
+        // they belong to the active app they'd win the tie and cover our
+        // background-app picker. Matches where NSMenu / the native emoji
+        // candidate window sit — above any app's floating UI.
+        panel.level = .popUpMenu
         panel.isOpaque = false
         panel.backgroundColor = .clear
         // System menu shadow matches NSMenu's drop shadow exactly.
@@ -95,7 +100,7 @@ final class PickerWindow {
                 backing: .buffered, defer: false
             )
             tip.isFloatingPanel = true
-            tip.level = .floating
+            tip.level = .popUpMenu  // stay above the picker, which is also .popUpMenu
             tip.isOpaque = false
             tip.backgroundColor = .clear
             tip.hasShadow = false  // bubble carries its own soft SwiftUI shadow


### PR DESCRIPTION
## What

Both the emoji picker and the GIF picker (`:::`) sat at `NSWindow.Level.floating`. App quick-entry pop-ups — Parcel's add-package sheet, Monarch's quick-add — are floating-level panels too. Because those panels belong to the **active** app while Mojito is a non-activating background app, they win the same-level ordering tie and cover our picker (see screenshot on the issue).

Raise both picker panels (and the pill number-hotkey tooltip) to `.popUpMenu` — the level `NSMenu` and the native emoji/predictive-text candidate window use — so they overlay any app's floating UI.

## Test plan
- [x] Debug build succeeds
- [ ] Trigger `:emoji:` inside Parcel.app's add-package pop-up → picker appears on top
- [ ] Same in Monarch's quick-add pop-up
- [ ] Normal fields (Safari, Notes, etc.) still position + insert correctly
- [ ] `:::` GIF picker also floats over a pop-up

Refs W-452