### PR TITLE
W-454: read Arc's tab URL via AppleScript so per-site exclusions work

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -30,6 +30,8 @@
 	<string>14.0</string>
 	<key>LSUIElement</key>
 	<true/>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>Mojito reads the current tab's URL in Arc to apply your per-site exclusions.</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2026 Wells Riley</string>
 	<key>SUEnableInstallerLauncherService</key>

--- a/Sources/Mojito/Context/BrowserURL.swift
+++ b/Sources/Mojito/Context/BrowserURL.swift
@@ -21,7 +21,37 @@ enum BrowserURL {
         if let raw = focusedAddressBarValue(in: app), let url = normalizedURL(from: raw) {
             return url
         }
+
+        // Arc suppresses the Chromium web-content a11y tree entirely — no
+        // AXWebArea, no AXURL, and its address bar is a transient command bar
+        // with no persistent AXTextField. The AX paths above always return nil
+        // there, so per-site exclusions silently can't fire. AppleScript is the
+        // only way to read Arc's tab URL. It's gated to this one bundle ID
+        // because it's the sole browser we've found that needs it (Dia, same
+        // vendor, exposes AXURL fine) and because the first call triggers a
+        // one-time Automation permission prompt we don't want to inflict on
+        // browsers the AX path already handles.
+        if appleScriptURLBundleIDs.contains(bundleID),
+           let url = appleScriptURL(bundleID: bundleID) {
+            return url
+        }
         return nil
+    }
+
+    private static let appleScriptURLBundleIDs: Set<String> = [
+        "company.thebrowser.Browser",   // Arc
+    ]
+
+    /// `URL of active tab of front window` via AppleScript. Returns nil on any
+    /// failure — no window, denied Automation permission, or a non-URL value —
+    /// so callers fall through to "no URL" exactly as if AX had come up empty.
+    private static func appleScriptURL(bundleID: String) -> URL? {
+        let source = "tell application id \"\(bundleID)\" to return URL of active tab of front window"
+        guard let script = NSAppleScript(source: source) else { return nil }
+        var error: NSDictionary?
+        let result = script.executeAndReturnError(&error)
+        guard error == nil, let raw = result.stringValue else { return nil }
+        return normalizedURL(from: raw)
     }
 
     private static func isBrowser(bundleID: String) -> Bool {

--- a/project.yml
+++ b/project.yml
@@ -164,6 +164,10 @@ targets:
         LSUIElement: true
         LSApplicationCategoryType: public.app-category.utilities
         NSHumanReadableCopyright: "© 2026 Wells Riley"
+        # Required for the AppleScript fallback that reads Arc's active-tab URL
+        # (Arc hides it from accessibility). Without this key macOS denies the
+        # Apple event outright instead of prompting. Only Arc triggers it.
+        NSAppleEventsUsageDescription: "Mojito reads the current tab's URL in Arc to apply your per-site exclusions."
         SUFeedURL: "https://mojito.wells.ee/appcast.xml"
         SUEnableInstallerLauncherService: true
         SUPublicEDKey: "NUW/cpxaKEqfwn2Uca4Zz9n01EmxhN0RRwhdma8GIuM="


### PR DESCRIPTION
## Problem

Per-site (URL) exclusions silently never fire in Arc. A user reported it (#157 / W-454); their debug report showed `hasURL=false` on every Arc trigger.

## Root cause

Arc suppresses the Chromium web-content accessibility tree entirely — no `AXWebArea`, no `AXURL` anywhere in the window, and its address bar is a transient command bar with no persistent `AXTextField`. `BrowserURL.detect()` is AX-only, so it always returned `nil` for Arc, and `ExclusionStore.isExcluded` never got a host to match URL patterns against.

Confirmed on a live Arc tab: a depth-60 AX walk finds no `AXWebArea` and no `AXURL` (the tree bottoms out at depth 10, all chrome UI). Dia — same vendor — exposes `AXURL` at depth 1 and works with the existing code, so this is Arc-specific.

## Fix

Add an AppleScript fallback (`URL of active tab of front window`) after the AX paths come up empty, gated to Arc's bundle ID alone (`company.thebrowser.Browser`). AppleScript is the only way to read Arc's tab URL. Scoping it to Arc means no other browser pays the one-time Automation permission prompt, since the AX path already handles them.

Any failure — no window, denied permission, non-URL value — returns `nil`, so behavior degrades to exactly what it is today (no URL, no URL-based exclusion). `NSAppleEventsUsageDescription` is required or macOS denies the Apple event outright.

## Verification

- [x] Debug build compiles.
- [x] On a live Arc tab, a depth-60 AX walk finds no `AXWebArea`/`AXURL` (reproduces the bug); AppleScript returns the real URL.
- [x] Dia exposes `AXURL` normally — correctly left off the fallback list.
- [x] A binary signed with the **release posture** (hardened runtime, `NSAppleEventsUsageDescription`, and *no* `com.apple.security.automation.apple-events` entitlement) sends the Apple event and returns Arc's live URL — so the shipped build doesn't need an extra entitlement.
- [x] The one-time Automation consent prompt renders as expected.
- [x] End-to-end in a Developer ID-signed **Release** build running as `ee.wells.Mojito`: with `*.amazon.com` excluded, Mojito correctly stops firing on `www.amazon.com` in Arc; removing the wildcard (bare `amazon.com`) fires again, matching the exact-host semantics.

Refs: W-454
