### PR TITLE
W-534: match subdomains for plain URL exclusion patterns

### DIFF
--- a/Sources/Mojito/Exclusions/ExclusionStore.swift
+++ b/Sources/Mojito/Exclusions/ExclusionStore.swift
@@ -141,14 +141,24 @@ final class ExclusionStore: ObservableObject {
         return try? NSRegularExpression(pattern: regexPattern)
     }
 
-    /// Pure host/pattern decision. Equality unless the pattern carries a
-    /// `*` wildcard. Compiles on demand — the instance hot path uses the
-    /// `compiledPatterns` cache instead to avoid per-`:` recompilation.
+    /// Pure host/pattern decision. A wildcard pattern goes through the regex;
+    /// a plain pattern matches the domain itself or any subdomain of it
+    /// (label-boundary suffix), so `google.com` covers `mail.google.com` but
+    /// not `notgoogle.com`. Compiles on demand — the instance hot path uses
+    /// the `compiledPatterns` cache instead to avoid per-`:` recompilation.
     nonisolated static func matches(host: String, pattern: String) -> Bool {
-        guard pattern.contains("*") else { return host == pattern }
+        guard pattern.contains("*") else { return hostMatchesDomain(host, pattern) }
         guard let regex = compiledGlob(for: pattern) else { return false }
         let range = NSRange(host.startIndex..., in: host)
         return regex.firstMatch(in: host, range: range) != nil
+    }
+
+    /// A plain (non-wildcard) pattern matches its apex and every subdomain.
+    /// The leading `.` on the suffix check keeps the match on a label
+    /// boundary — `notgoogle.com` shares the `google.com` suffix but isn't a
+    /// subdomain, so it must not match.
+    nonisolated static func hostMatchesDomain(_ host: String, _ pattern: String) -> Bool {
+        host == pattern || host.hasSuffix("." + pattern)
     }
 
     func isExcluded(bundleID: String?, url: URL?) -> Bool {
@@ -184,9 +194,10 @@ final class ExclusionStore: ObservableObject {
         allowedURLPatterns = []
     }
 
-    /// `*` matches any single subdomain segment.
+    /// `*` matches any single subdomain segment; a plain pattern matches the
+    /// domain and its subdomains (see `hostMatchesDomain`).
     private func matches(host: String, pattern: String) -> Bool {
-        if !pattern.contains("*") { return host == pattern }
+        if !pattern.contains("*") { return Self.hostMatchesDomain(host, pattern) }
         guard let regex = compiledPatterns[pattern] else { return false }
         let range = NSRange(host.startIndex..., in: host)
         return regex.firstMatch(in: host, range: range) != nil

--- a/Tests/MojitoTests/ExclusionStoreTests.swift
+++ b/Tests/MojitoTests/ExclusionStoreTests.swift
@@ -3,13 +3,33 @@ import Testing
 
 /// Host-pattern matching for URL exclusions. A `*` wildcard matches exactly
 /// one subdomain segment (`[^.]+`) and is anchored at both ends, so it can't
-/// span dots or match a suffix of a longer host. Patterns without a wildcard
-/// are compared by exact equality.
+/// span dots or match a suffix of a longer host. A pattern without a wildcard
+/// matches the domain itself and any subdomain of it (label-boundary suffix),
+/// so `google.com` covers `google.com`, `mail.google.com`, and deeper — but
+/// not lookalikes like `notgoogle.com`.
 struct ExclusionStoreTests {
 
-    @Test func plainPatternMatchesByEquality() {
+    @Test func plainPatternMatchesApexAndSubdomains() {
+        #expect(ExclusionStore.matches(host: "google.com", pattern: "google.com"))
+        #expect(ExclusionStore.matches(host: "www.google.com", pattern: "google.com"))
+        #expect(ExclusionStore.matches(host: "mail.google.com", pattern: "google.com"))
+        #expect(ExclusionStore.matches(host: "a.b.google.com", pattern: "google.com"))
+    }
+
+    @Test func plainPatternRespectsLabelBoundary() {
+        // A shared suffix that isn't on a dot boundary must not match.
+        #expect(!ExclusionStore.matches(host: "notgoogle.com", pattern: "google.com"))
+        // The pattern must be an actual suffix — a longer host that merely
+        // contains it isn't excluded.
+        #expect(!ExclusionStore.matches(host: "google.com.evil.com", pattern: "google.com"))
+    }
+
+    @Test func plainPatternIsNarrowerThanItsSubdomains() {
+        // `mail.google.com` still excludes itself and its own subdomains, but
+        // not sibling subdomains of the apex.
         #expect(ExclusionStore.matches(host: "mail.google.com", pattern: "mail.google.com"))
-        #expect(!ExclusionStore.matches(host: "mail.google.com", pattern: "google.com"))
+        #expect(ExclusionStore.matches(host: "x.mail.google.com", pattern: "mail.google.com"))
+        #expect(!ExclusionStore.matches(host: "drive.google.com", pattern: "mail.google.com"))
     }
 
     @Test func wildcardMatchesOneSegment() {
@@ -23,7 +43,8 @@ struct ExclusionStoreTests {
     }
 
     @Test func wildcardRequiresANonEmptySegment() {
-        // `[^.]+` needs at least one char, so the bare apex doesn't match.
+        // `[^.]+` needs at least one char, so the bare apex doesn't match the
+        // wildcard form (use the plain `google.com` pattern to cover the apex).
         #expect(!ExclusionStore.matches(host: "google.com", pattern: "*.google.com"))
     }
 


### PR DESCRIPTION
## Problem

URL exclusion patterns without a `*` were matched by **exact host equality**, so adding `amazon.com` didn't exclude `www.amazon.com` — the host isn't string-equal to the pattern. Users reasonably expect a bare domain to cover the site. The built-in defaults worked around it by pairing each domain with its wildcard (`github.com` + `*.github.com`), which is itself a sign the plain form was surprising.

Surfaced while verifying W-454 (#159): the Arc URL was read correctly, but a bare `amazon.com` pattern silently didn't match.

## Change

A plain pattern now matches the domain **and any subdomain of it** via a label-boundary suffix check (`host == pattern || host.hasSuffix("." + pattern)`):

- `amazon.com` matches `amazon.com`, `www.amazon.com`, `a.b.amazon.com`
- does **not** match `notamazon.com` or `amazon.com.evil.com` (boundary-safe)

Wildcards (`*`) keep their exact single-segment meaning. The change is additive — every host that matched before still matches, so no existing exclusion breaks; the paired `*.example.com` defaults just become redundant.

## Test plan

- [x] `Tests/MojitoTests/ExclusionStoreTests.swift` updated: apex, subdomain, multi-level subdomain, label-boundary non-matches, and the narrower `mail.google.com`-style pattern. Wildcard tests unchanged.
- [x] Full suite green — 230 tests, 16 suites.

Refs: W-534
