### PR TITLE
W-453: Custom aliases for emoji and symbols

### DIFF
--- a/Mojito.xcodeproj/project.pbxproj
+++ b/Mojito.xcodeproj/project.pbxproj
@@ -101,7 +101,7 @@
 		917B8512B30F3B6E8C9D2B8C /* SkinToneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74BDC060E2EAACF7A71A3A6 /* SkinToneTests.swift */; };
 		91A5F2A800EA1FC0700394EA /* SymbolsDatabaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25EC50F4D58E03E218947DF /* SymbolsDatabaseTests.swift */; };
 		9234FF3040DB70F660567DCB /* v12.bin in Resources */ = {isa = PBXBuildFile; fileRef = 8616DAC09008096A70541CEE /* v12.bin */; };
-		929C5BB409BD79198ABAECEA /* CustomShortcutsSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1151899D94A473B9CA3F24DE /* CustomShortcutsSettings.swift */; };
+		97BAD861F4CA98B71C2670FB /* AliasesSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF593CBC722955734BC5166E /* AliasesSettings.swift */; };
 		9CB4AA2C8D9DE6B788068AA9 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = EB2F085FF2A8206D2905DF27 /* Sparkle */; };
 		9CCEA0B70EEB77F988521DDB /* AppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1DA7C9FD3286A7839BA642D /* AppInfo.swift */; };
 		9E9309E8AF1F9D8B44213729 /* EmoticonTableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBB27C78330DB1E6F05BDAE7 /* EmoticonTableTests.swift */; };
@@ -199,7 +199,6 @@
 		0836B5ACF7E24509928DA7B0 /* BouncingDVD.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BouncingDVD.swift; sourceTree = "<group>"; };
 		088608D6A2243D8E95953095 /* WilhelmScream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WilhelmScream.swift; sourceTree = "<group>"; };
 		100317FDEDAED8905256B964 /* AboutSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutSettings.swift; sourceTree = "<group>"; };
-		1151899D94A473B9CA3F24DE /* CustomShortcutsSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomShortcutsSettings.swift; sourceTree = "<group>"; };
 		127F100886742DCE05A171B4 /* v04.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; path = v04.bin; sourceTree = "<group>"; };
 		137C5B7AB01C74DA68FE7B74 /* SingleInstanceCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleInstanceCoordinator.swift; sourceTree = "<group>"; };
 		151DC25F7CEE4F3BE8F23650 /* CRTPowerOff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CRTPowerOff.swift; sourceTree = "<group>"; };
@@ -317,6 +316,7 @@
 		B99F9C3810949A5B47E733AD /* HintsFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HintsFooter.swift; sourceTree = "<group>"; };
 		BC79E6EAFAF655E0E63E78DC /* Shortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shortcuts.swift; sourceTree = "<group>"; };
 		BC98E3E280416083D33326C7 /* GifPickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GifPickerViewModel.swift; sourceTree = "<group>"; };
+		BF593CBC722955734BC5166E /* AliasesSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AliasesSettings.swift; sourceTree = "<group>"; };
 		C02399494F4CF5825B0401CD /* GifPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GifPickerView.swift; sourceTree = "<group>"; };
 		C02F1996A3DED7A0A133E24C /* DockIconManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockIconManager.swift; sourceTree = "<group>"; };
 		C060B27E6970531BEBA3673E /* ChooChooSound.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooChooSound.swift; sourceTree = "<group>"; };
@@ -412,7 +412,7 @@
 			isa = PBXGroup;
 			children = (
 				100317FDEDAED8905256B964 /* AboutSettings.swift */,
-				1151899D94A473B9CA3F24DE /* CustomShortcutsSettings.swift */,
+				BF593CBC722955734BC5166E /* AliasesSettings.swift */,
 				AA756B434C9FED6B691D07B8 /* EasterEggsSettings.swift */,
 				DD6171603CD5F5CC6ED9A636 /* ExclusionsSettings.swift */,
 				B3154DBEA72DA316E341C440 /* GeneralSettings.swift */,
@@ -918,6 +918,7 @@
 				B43E634B3FAB6B7FBF2CFC6C /* AboutSettings.swift in Sources */,
 				C7EAEBA38EE85743E109E1B4 /* AchievementBanner.swift in Sources */,
 				AB8E4AC3FD14D2F030607C1A /* AliasStore.swift in Sources */,
+				97BAD861F4CA98B71C2670FB /* AliasesSettings.swift in Sources */,
 				6B48E883C3B324C8ABB16C93 /* AmbientEmoticonTable.swift in Sources */,
 				4AE8FF96950E4AD801A5D632 /* AnimatedGifView.swift in Sources */,
 				0D48DFE069D4D6C6F2E568B5 /* AnimationTicker.swift in Sources */,
@@ -938,7 +939,6 @@
 				F46B89A2E807D259981405E5 /* ConfettiRain.swift in Sources */,
 				6A8EC5B13FA4A0AC0F338875 /* ConfettiSound.swift in Sources */,
 				FFB109C762E7363A39A54111 /* CopyToast.swift in Sources */,
-				929C5BB409BD79198ABAECEA /* CustomShortcutsSettings.swift in Sources */,
 				74CED6225633C087A96D7E9C /* DebugRecorder.swift in Sources */,
 				9F45015A816323AF275F23ED /* DebugReport.swift in Sources */,
 				4949BE63FAD5A5FC2573CFE1 /* DefaultExclusions.swift in Sources */,

--- a/Mojito.xcodeproj/project.pbxproj
+++ b/Mojito.xcodeproj/project.pbxproj
@@ -95,11 +95,13 @@
 		881B726A6871BA37651B06B0 /* GifClipboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19FC0DC96883A143602E6668 /* GifClipboard.swift */; };
 		89AB6401CC7F94BCBF0D3437 /* s16.bin in Resources */ = {isa = PBXBuildFile; fileRef = E87A9C3A9251B8908CFB056A /* s16.bin */; };
 		8D584DDFB9305768A3547EAA /* EmojiBrowserViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B79AAA76C55A5B4FB087A6 /* EmojiBrowserViewModel.swift */; };
+		8D768748EE3F9F440F3F94EA /* AliasTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71409240C4105D980C71E264 /* AliasTests.swift */; };
 		8DC058D738EC5E540C69BE61 /* PickerContextSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB3CE6896B4FB11651A14AD /* PickerContextSnapshot.swift */; };
 		8EE9F3A928A7AFDB16C6D9A2 /* OnboardingRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4512D76E20BD99269775200B /* OnboardingRoot.swift */; };
 		917B8512B30F3B6E8C9D2B8C /* SkinToneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74BDC060E2EAACF7A71A3A6 /* SkinToneTests.swift */; };
 		91A5F2A800EA1FC0700394EA /* SymbolsDatabaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25EC50F4D58E03E218947DF /* SymbolsDatabaseTests.swift */; };
 		9234FF3040DB70F660567DCB /* v12.bin in Resources */ = {isa = PBXBuildFile; fileRef = 8616DAC09008096A70541CEE /* v12.bin */; };
+		929C5BB409BD79198ABAECEA /* CustomShortcutsSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1151899D94A473B9CA3F24DE /* CustomShortcutsSettings.swift */; };
 		9CB4AA2C8D9DE6B788068AA9 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = EB2F085FF2A8206D2905DF27 /* Sparkle */; };
 		9CCEA0B70EEB77F988521DDB /* AppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1DA7C9FD3286A7839BA642D /* AppInfo.swift */; };
 		9E9309E8AF1F9D8B44213729 /* EmoticonTableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBB27C78330DB1E6F05BDAE7 /* EmoticonTableTests.swift */; };
@@ -110,6 +112,7 @@
 		A637DCA2905238217427E806 /* EmojiBrowserCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C001583E27CC71D9959055 /* EmojiBrowserCatalog.swift */; };
 		A9A15B339C05195BB45CC09F /* MyLegSound.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C4C16E01184684E33C3437 /* MyLegSound.swift */; };
 		A9CDDCEBAC41BF8676B8F2EC /* EasterEggTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3188FF1FD6559BF8E64C19CC /* EasterEggTracker.swift */; };
+		AB8E4AC3FD14D2F030607C1A /* AliasStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F4345DE634CD2EB2FE71120 /* AliasStore.swift */; };
 		ABF54441D03140C8174E13A9 /* PrefsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C66984ECCB4DB6B1A018452 /* PrefsKey.swift */; };
 		AC2B8E0C22D16F8CCEEAA185 /* XPLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C7AACE4E2FA1FB07AB5083A /* XPLogin.swift */; };
 		AC7748989CE2B7D96CBB21FE /* Emoji.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9528726096C90D6A0523B86F /* Emoji.swift */; };
@@ -196,6 +199,7 @@
 		0836B5ACF7E24509928DA7B0 /* BouncingDVD.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BouncingDVD.swift; sourceTree = "<group>"; };
 		088608D6A2243D8E95953095 /* WilhelmScream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WilhelmScream.swift; sourceTree = "<group>"; };
 		100317FDEDAED8905256B964 /* AboutSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutSettings.swift; sourceTree = "<group>"; };
+		1151899D94A473B9CA3F24DE /* CustomShortcutsSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomShortcutsSettings.swift; sourceTree = "<group>"; };
 		127F100886742DCE05A171B4 /* v04.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; path = v04.bin; sourceTree = "<group>"; };
 		137C5B7AB01C74DA68FE7B74 /* SingleInstanceCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleInstanceCoordinator.swift; sourceTree = "<group>"; };
 		151DC25F7CEE4F3BE8F23650 /* CRTPowerOff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CRTPowerOff.swift; sourceTree = "<group>"; };
@@ -254,8 +258,10 @@
 		6C69999E4AC7F8B8C054B395 /* DebugReportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugReportTests.swift; sourceTree = "<group>"; };
 		6E2009C3B36DF9228B873244 /* EmoticonTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmoticonTable.swift; sourceTree = "<group>"; };
 		6EE7D78A4736AA53650D60DC /* AmbientEmoticonTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmbientEmoticonTable.swift; sourceTree = "<group>"; };
+		6F4345DE634CD2EB2FE71120 /* AliasStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AliasStore.swift; sourceTree = "<group>"; };
 		702AC2870CD686AB17CC518E /* UpdaterCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdaterCoordinator.swift; sourceTree = "<group>"; };
 		70F2866D3BE0CC5D08CF9AD1 /* Emoji */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Emoji; path = Resources/Emoji; sourceTree = SOURCE_ROOT; };
+		71409240C4105D980C71E264 /* AliasTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AliasTests.swift; sourceTree = "<group>"; };
 		7161D8677669C3B6B7947ECF /* InlineBrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineBrowserView.swift; sourceTree = "<group>"; };
 		7292DF1A52CC009F5780BB22 /* EmbeddedGiphyKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddedGiphyKey.swift; sourceTree = "<group>"; };
 		732EB5A5F830B83AD2A745AB /* ClickAwayMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClickAwayMonitor.swift; sourceTree = "<group>"; };
@@ -382,6 +388,7 @@
 		02F05DB5E7247E1AE700004A /* MojitoTests */ = {
 			isa = PBXGroup;
 			children = (
+				71409240C4105D980C71E264 /* AliasTests.swift */,
 				F36FC6BE9A109EAEE6A18CE1 /* AmbientEmoticonTableTests.swift */,
 				6C69999E4AC7F8B8C054B395 /* DebugReportTests.swift */,
 				B3042E363CC429F15721773F /* EasterEggOrderingTests.swift */,
@@ -405,6 +412,7 @@
 			isa = PBXGroup;
 			children = (
 				100317FDEDAED8905256B964 /* AboutSettings.swift */,
+				1151899D94A473B9CA3F24DE /* CustomShortcutsSettings.swift */,
 				AA756B434C9FED6B691D07B8 /* EasterEggsSettings.swift */,
 				DD6171603CD5F5CC6ED9A636 /* ExclusionsSettings.swift */,
 				B3154DBEA72DA316E341C440 /* GeneralSettings.swift */,
@@ -683,6 +691,7 @@
 		D822FEA7909C200A1E98FE7E /* EmojiDB */ = {
 			isa = PBXGroup;
 			children = (
+				6F4345DE634CD2EB2FE71120 /* AliasStore.swift */,
 				6EE7D78A4736AA53650D60DC /* AmbientEmoticonTable.swift */,
 				AB126DDBD153A051CDEF105B /* EggIndex.swift */,
 				9528726096C90D6A0523B86F /* Emoji.swift */,
@@ -908,6 +917,7 @@
 			files = (
 				B43E634B3FAB6B7FBF2CFC6C /* AboutSettings.swift in Sources */,
 				C7EAEBA38EE85743E109E1B4 /* AchievementBanner.swift in Sources */,
+				AB8E4AC3FD14D2F030607C1A /* AliasStore.swift in Sources */,
 				6B48E883C3B324C8ABB16C93 /* AmbientEmoticonTable.swift in Sources */,
 				4AE8FF96950E4AD801A5D632 /* AnimatedGifView.swift in Sources */,
 				0D48DFE069D4D6C6F2E568B5 /* AnimationTicker.swift in Sources */,
@@ -928,6 +938,7 @@
 				F46B89A2E807D259981405E5 /* ConfettiRain.swift in Sources */,
 				6A8EC5B13FA4A0AC0F338875 /* ConfettiSound.swift in Sources */,
 				FFB109C762E7363A39A54111 /* CopyToast.swift in Sources */,
+				929C5BB409BD79198ABAECEA /* CustomShortcutsSettings.swift in Sources */,
 				74CED6225633C087A96D7E9C /* DebugRecorder.swift in Sources */,
 				9F45015A816323AF275F23ED /* DebugReport.swift in Sources */,
 				4949BE63FAD5A5FC2573CFE1 /* DefaultExclusions.swift in Sources */,
@@ -1038,6 +1049,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8D768748EE3F9F440F3F94EA /* AliasTests.swift in Sources */,
 				EFCA5419E2CE5D16F2DE7DB3 /* AmbientEmoticonTableTests.swift in Sources */,
 				B878C3CC891907E89DE33158 /* DebugReportTests.swift in Sources */,
 				B33ABD1825CC5908D3DE7030 /* EasterEggOrderingTests.swift in Sources */,

--- a/Sources/Mojito/Browser/EmojiBrowserViewModel.swift
+++ b/Sources/Mojito/Browser/EmojiBrowserViewModel.swift
@@ -72,13 +72,15 @@ final class EmojiBrowserViewModel: ObservableObject {
 
     var visibleCategories: [EmojiCategory] { sections.map(\.category) }
 
-    init(database: EmojiDatabase, quickAccess: QuickAccessStore) {
+    /// `includeSymbols` forces the symbol corpus in regardless of the global
+    /// Symbols toggle — the alias picker always offers symbols as alias targets.
+    init(database: EmojiDatabase, quickAccess: QuickAccessStore, includeSymbols: Bool = false) {
         self.database = database
         self.usage = (UserDefaults.standard.dictionary(forKey: PrefsKey.usageCounts) as? [String: Int]) ?? [:]
         // Symbols-on now lives in the trigger config (the legacy
         // `symbolsEnabled` key is no longer written by Settings).
-        self.symbolsEnabled = TriggerConfigStore.load().symbols.enabled
-        let built = Self.build(database: database, quickAccess: quickAccess, usage: self.usage)
+        self.symbolsEnabled = TriggerConfigStore.load().symbols.enabled || includeSymbols
+        let built = Self.build(database: database, quickAccess: quickAccess, usage: self.usage, symbolsEnabled: self.symbolsEnabled)
         self.sections = built
         let flat = built.flatMap { $0.cells.map(\.emoji) }
         self.flat = flat
@@ -275,7 +277,8 @@ final class EmojiBrowserViewModel: ObservableObject {
     private static func build(
         database: EmojiDatabase,
         quickAccess: QuickAccessStore,
-        usage: [String: Int]
+        usage: [String: Int],
+        symbolsEnabled: Bool
     ) -> [Section] {
         var sections: [Section] = []
         var cursor = 0
@@ -295,9 +298,10 @@ final class EmojiBrowserViewModel: ObservableObject {
             add(category, database.all.filter { groups.contains($0.group) })
         }
 
-        // Typographic symbols (★ ⌘ ⌥ …) only when the Symbols feature is on —
-        // the CoreText sweep is slow and the corpus is large.
-        if TriggerConfigStore.load().symbols.enabled {
+        // Typographic symbols (★ ⌘ ⌥ …) only when enabled — the CoreText sweep
+        // is slow and the corpus is large. Forced on in the alias picker so a
+        // symbol can be chosen as an alias target.
+        if symbolsEnabled {
             add(.specialCharacters, SymbolsDatabase.indexed().map(\.emoji))
         }
         return sections

--- a/Sources/Mojito/Browser/InlineBrowserView.swift
+++ b/Sources/Mojito/Browser/InlineBrowserView.swift
@@ -142,15 +142,9 @@ struct InlineBrowserView: View {
                 } else {
                     LazyVGrid(columns: columns, spacing: Self.rowSpacing) {
                         if browser.isSearching {
-                            // Key by hexcode, not the positional offset: the
-                            // sectioned branch identifies cells by a 0-based
-                            // integer index, and a search list keyed by 0-based
-                            // offsets collides with it — SwiftUI then reuses the
-                            // library cells (the most-used row) for the first
-                            // search render instead of rebuilding with the
-                            // result glyphs. A hexcode id keeps the two identity
-                            // spaces disjoint so the transition always refreshes.
-                            ForEach(Array(browser.current.enumerated()), id: \.element.hexcode) { index, emoji in
+                            // Positional index is the identity here — it's what
+                            // `scrollTo` (reset-to-top, keyboard nav) addresses.
+                            ForEach(Array(browser.current.enumerated()), id: \.offset) { index, emoji in
                                 cell(emoji, index: index)
                             }
                         } else {
@@ -168,6 +162,11 @@ struct InlineBrowserView: View {
                     .padding(.horizontal, 8)
                     .padding(.top, 2)
                     .padding(.bottom, 8)
+                    // Search and library both index cells from 0; give the two
+                    // modes distinct grid identity so the library→search switch
+                    // rebuilds instead of reusing the most-used row's cells for
+                    // the first search render (the "garbage first search" bug).
+                    .id(browser.isSearching)
                 }
             }
             .safeAreaInset(edge: .bottom, spacing: 0) { categoryBar }

--- a/Sources/Mojito/Browser/InlineBrowserView.swift
+++ b/Sources/Mojito/Browser/InlineBrowserView.swift
@@ -142,7 +142,15 @@ struct InlineBrowserView: View {
                 } else {
                     LazyVGrid(columns: columns, spacing: Self.rowSpacing) {
                         if browser.isSearching {
-                            ForEach(Array(browser.current.enumerated()), id: \.offset) { index, emoji in
+                            // Key by hexcode, not the positional offset: the
+                            // sectioned branch identifies cells by a 0-based
+                            // integer index, and a search list keyed by 0-based
+                            // offsets collides with it — SwiftUI then reuses the
+                            // library cells (the most-used row) for the first
+                            // search render instead of rebuilding with the
+                            // result glyphs. A hexcode id keeps the two identity
+                            // spaces disjoint so the transition always refreshes.
+                            ForEach(Array(browser.current.enumerated()), id: \.element.hexcode) { index, emoji in
                                 cell(emoji, index: index)
                             }
                         } else {

--- a/Sources/Mojito/EmojiDB/AliasStore.swift
+++ b/Sources/Mojito/EmojiDB/AliasStore.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+/// One user-defined shortcode → emoji mapping. `alias` is stored normalized
+/// (lowercased, trimmed, no whitespace/colons) so lookups never re-process it.
+struct CustomAlias: Codable, Identifiable, Hashable {
+    let alias: String
+    let hexcode: String
+    var id: String { alias }
+}
+
+/// The user's custom shortcodes. Persisted as a JSON blob and merged into the
+/// emoji corpus by `EmojiDatabase` — see [[EmojiDatabase.buildIndex]]. A change
+/// posts `didChangeNotification`, which `EmojiDatabase` observes to rebuild its
+/// index live.
+@MainActor
+final class AliasStore: ObservableObject {
+    static let shared = AliasStore()
+
+    /// Posted after any mutation persists. `EmojiDatabase` observes this to
+    /// re-merge aliases into its search index without a relaunch.
+    static let didChangeNotification = Notification.Name("mojito.aliases.didChange")
+
+    /// Order-preserving so the settings list is stable across edits.
+    @Published private(set) var aliases: [CustomAlias]
+
+    private let defaults: UserDefaults
+
+    /// A hand-typed alias longer than this can't realistically be typed before
+    /// the capture times out — reject rather than store an unreachable entry.
+    static let maxLength = 40
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        if let data = defaults.data(forKey: PrefsKey.customAliases),
+           let decoded = try? JSONDecoder().decode([CustomAlias].self, from: data) {
+            aliases = AliasStore.sanitize(decoded)
+        } else {
+            aliases = []
+        }
+    }
+
+    enum AddResult: Equatable {
+        case added        // new alias stored
+        case updated      // existing alias re-pointed at a different emoji
+        case invalid      // alias text or hexcode rejected
+    }
+
+    /// Add or re-point an alias. Adding an alias that already exists updates its
+    /// target (`.updated`); the alias keeps its position in the list.
+    @discardableResult
+    func add(alias raw: String, hexcode: String) -> AddResult {
+        guard let normalized = AliasStore.normalize(raw), !hexcode.isEmpty else { return .invalid }
+        let entry = CustomAlias(alias: normalized, hexcode: hexcode)
+        if let idx = aliases.firstIndex(where: { $0.alias == normalized }) {
+            guard aliases[idx] != entry else { return .updated }
+            aliases[idx] = entry
+            persist()
+            return .updated
+        }
+        aliases.append(entry)
+        persist()
+        return .added
+    }
+
+    func remove(alias raw: String) {
+        guard let normalized = AliasStore.normalize(raw) else { return }
+        let before = aliases.count
+        aliases.removeAll { $0.alias == normalized }
+        if aliases.count != before { persist() }
+    }
+
+    func removeAll() {
+        guard !aliases.isEmpty else { return }
+        aliases.removeAll()
+        persist()
+    }
+
+    func contains(alias raw: String) -> Bool {
+        guard let normalized = AliasStore.normalize(raw) else { return false }
+        return aliases.contains { $0.alias == normalized }
+    }
+
+    // MARK: - Validation
+
+    /// Canonical form for an alias, or `nil` if it can't be a usable shortcode.
+    /// Rejected: empty, over `maxLength`, or containing whitespace or a colon —
+    /// whitespace/`:` end the capture, so such an alias could never be typed in
+    /// full.
+    static func normalize(_ raw: String) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !trimmed.isEmpty, trimmed.count <= maxLength else { return nil }
+        guard !trimmed.contains(":") else { return nil }
+        guard trimmed.rangeOfCharacter(from: .whitespacesAndNewlines) == nil else { return nil }
+        return trimmed
+    }
+
+    /// Drop invalid or duplicate entries from a decoded blob (hand-edits, older
+    /// formats) so a corrupt store can't poison the index. First spelling wins.
+    static func sanitize(_ decoded: [CustomAlias]) -> [CustomAlias] {
+        var seen: Set<String> = []
+        var out: [CustomAlias] = []
+        for entry in decoded {
+            guard let normalized = normalize(entry.alias), !entry.hexcode.isEmpty else { continue }
+            guard seen.insert(normalized).inserted else { continue }
+            out.append(CustomAlias(alias: normalized, hexcode: entry.hexcode))
+        }
+        return out
+    }
+
+    private func persist() {
+        if let data = try? JSONEncoder().encode(aliases) {
+            defaults.set(data, forKey: PrefsKey.customAliases)
+        }
+        NotificationCenter.default.post(name: Self.didChangeNotification, object: nil)
+    }
+}

--- a/Sources/Mojito/EmojiDB/AliasStore.swift
+++ b/Sources/Mojito/EmojiDB/AliasStore.swift
@@ -83,15 +83,20 @@ final class AliasStore: ObservableObject {
     // MARK: - Validation
 
     /// Canonical form for an alias, or `nil` if it can't be a usable shortcode.
-    /// Rejected: empty, over `maxLength`, or containing whitespace or a colon —
-    /// whitespace/`:` end the capture, so such an alias could never be typed in
-    /// full.
+    /// Rejected: empty, over `maxLength`, or containing any character the trigger
+    /// can't capture as part of a name — whitespace, `:`, `.`, `/`, emoji, etc.
+    /// all end capture, so such an alias could never be typed in full.
     static func normalize(_ raw: String) -> String? {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !trimmed.isEmpty, trimmed.count <= maxLength else { return nil }
-        guard !trimmed.contains(":") else { return nil }
-        guard trimmed.rangeOfCharacter(from: .whitespacesAndNewlines) == nil else { return nil }
+        // Mirror KeyMonitor.isNameChar: letters, numbers, and _ - + ' are the
+        // only characters the capture state machine keeps in the query body.
+        guard trimmed.allSatisfy(isNameChar) else { return nil }
         return trimmed
+    }
+
+    private static func isNameChar(_ c: Character) -> Bool {
+        c.isLetter || c.isNumber || c == "_" || c == "-" || c == "+" || c == "'"
     }
 
     /// Drop invalid or duplicate entries from a decoded blob (hand-edits, older

--- a/Sources/Mojito/EmojiDB/EmojiDatabase.swift
+++ b/Sources/Mojito/EmojiDB/EmojiDatabase.swift
@@ -231,6 +231,33 @@ final class EmojiDatabase: ObservableObject {
             index[entry.alias.lowercased()] = target
         }
 
+        // Symbol-targeted aliases (⌘, →, π …). Symbols aren't in the emoji
+        // corpus, so resolve them against `SymbolsDatabase` and add each as a
+        // first-class indexed row — typable + searchable by its alias term even
+        // when the Symbols feature is off. Touching `SymbolsDatabase.byHexcode`
+        // kicks off a slow CoreText sweep, so only reach for it when a symbol
+        // alias actually exists.
+        let symbolAliases = aliases.filter { $0.hexcode.hasPrefix("SYM_") && byHex[$0.hexcode] == nil }
+        if !symbolAliases.isEmpty {
+            var order: [String] = []
+            var bySymHex: [String: [String]] = [:]
+            for entry in symbolAliases {
+                if bySymHex[entry.hexcode] == nil { order.append(entry.hexcode) }
+                bySymHex[entry.hexcode, default: []].append(entry.alias.lowercased())
+            }
+            for hex in order {
+                guard let symbol = SymbolsDatabase.byHexcode[hex] else { continue }
+                byHex[hex] = symbol
+                var haystacks: [EmojiHaystack] = []
+                haystacks.reserveCapacity(bySymHex[hex]?.count ?? 0)
+                for alias in bySymHex[hex] ?? [] {
+                    haystacks.append(EmojiHaystack(display: alias, chars: Array(alias), isAlias: true))
+                    index[alias] = symbol
+                }
+                indexedBuf.append(IndexedEmoji(emoji: symbol, haystacks: haystacks))
+            }
+        }
+
         return IndexResult(byShortcode: index, byHexcode: byHex, indexed: indexedBuf)
     }
 

--- a/Sources/Mojito/EmojiDB/EmojiDatabase.swift
+++ b/Sources/Mojito/EmojiDB/EmojiDatabase.swift
@@ -34,6 +34,10 @@ final class EmojiDatabase: ObservableObject {
     private(set) var indexed: [IndexedEmoji] = []
     private(set) var byShortcode: [String: Emoji] = [:]
     private(set) var byHexcode: [String: Emoji] = [:]
+    /// Symbols (`SYM_…`) promoted into `indexed` because a custom alias points
+    /// at them. The combined-corpus search excludes these from the appended
+    /// symbol sweep so an aliased symbol isn't scored (and rendered) twice.
+    private(set) var aliasedSymbolHexcodes: Set<String> = []
 
     /// Resolved once at load and reused when custom aliases change, so a re-merge
     /// doesn't re-scan `Locale.preferredLanguages`.
@@ -145,6 +149,7 @@ final class EmojiDatabase: ObservableObject {
         self.byShortcode = result.byShortcode
         self.byHexcode = result.byHexcode
         self.indexed = result.indexed
+        self.aliasedSymbolHexcodes = result.aliasedSymbolHexcodes
         objectWillChange.send()
     }
 
@@ -152,6 +157,8 @@ final class EmojiDatabase: ObservableObject {
         let byShortcode: [String: Emoji]
         let byHexcode: [String: Emoji]
         let indexed: [IndexedEmoji]
+        /// `SYM_…` hexcodes appended to `indexed` because an alias targets them.
+        let aliasedSymbolHexcodes: Set<String>
     }
 
     /// Pure corpus → index build. Custom aliases are layered on last: an alias
@@ -237,6 +244,7 @@ final class EmojiDatabase: ObservableObject {
         // when the Symbols feature is off. Touching `SymbolsDatabase.byHexcode`
         // kicks off a slow CoreText sweep, so only reach for it when a symbol
         // alias actually exists.
+        var aliasedSymbolHexcodes: Set<String> = []
         let symbolAliases = aliases.filter { $0.hexcode.hasPrefix("SYM_") && byHex[$0.hexcode] == nil }
         if !symbolAliases.isEmpty {
             var order: [String] = []
@@ -248,6 +256,7 @@ final class EmojiDatabase: ObservableObject {
             for hex in order {
                 guard let symbol = SymbolsDatabase.byHexcode[hex] else { continue }
                 byHex[hex] = symbol
+                aliasedSymbolHexcodes.insert(hex)
                 var haystacks: [EmojiHaystack] = []
                 haystacks.reserveCapacity(bySymHex[hex]?.count ?? 0)
                 for alias in bySymHex[hex] ?? [] {
@@ -258,7 +267,12 @@ final class EmojiDatabase: ObservableObject {
             }
         }
 
-        return IndexResult(byShortcode: index, byHexcode: byHex, indexed: indexedBuf)
+        return IndexResult(
+            byShortcode: index,
+            byHexcode: byHex,
+            indexed: indexedBuf,
+            aliasedSymbolHexcodes: aliasedSymbolHexcodes
+        )
     }
 
     func exact(_ shortcode: String) -> Emoji? {

--- a/Sources/Mojito/EmojiDB/EmojiDatabase.swift
+++ b/Sources/Mojito/EmojiDB/EmojiDatabase.swift
@@ -8,11 +8,15 @@ struct EmojiHaystack {
     /// Emojibase keyword (e.g. "meditation" on 🧘). Scored with a penalty and
     /// never eligible for the prefix tier, so real shortcodes always win.
     let isTag: Bool
+    /// A user-defined alias (see `AliasStore`). Scored with a bonus so the
+    /// aliased emoji outranks built-ins for the alias term.
+    let isAlias: Bool
 
-    init(display: String, chars: [Character], isTag: Bool = false) {
+    init(display: String, chars: [Character], isTag: Bool = false, isAlias: Bool = false) {
         self.display = display
         self.chars = chars
         self.isTag = isTag
+        self.isAlias = isAlias
     }
 }
 
@@ -31,8 +35,25 @@ final class EmojiDatabase: ObservableObject {
     private(set) var byShortcode: [String: Emoji] = [:]
     private(set) var byHexcode: [String: Emoji] = [:]
 
+    /// Resolved once at load and reused when custom aliases change, so a re-merge
+    /// doesn't re-scan `Locale.preferredLanguages`.
+    private var activeLocales: [String] = []
+    private var aliasObserver: NSObjectProtocol?
+
     private init() {
         load()
+        // Re-merge whenever the user edits their custom shortcuts. The index
+        // arrays aren't @Published, but the live-typing path reads `indexed`
+        // imperatively each keystroke, so a rebuild takes effect immediately.
+        aliasObserver = NotificationCenter.default.addObserver(
+            forName: AliasStore.didChangeNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.applyAliases(AliasStore.shared.aliases) }
+        }
+    }
+
+    deinit {
+        if let aliasObserver { NotificationCenter.default.removeObserver(aliasObserver) }
     }
 
     /// Maps system locale codes (`Locale.preferredLanguages`) to emojibase
@@ -110,61 +131,107 @@ final class EmojiDatabase: ObservableObject {
             let decoded = try JSONDecoder().decode([Emoji].self, from: data)
                 .filter { $0.group != Self.componentGroup }
             self.all = decoded
-            let activeLocales = activeAdditionalLocales()
-            var index: [String: Emoji] = [:]
-            index.reserveCapacity(decoded.count * 2)
-            var byHex: [String: Emoji] = [:]
-            byHex.reserveCapacity(decoded.count)
-            var indexedBuf: [IndexedEmoji] = []
-            indexedBuf.reserveCapacity(decoded.count)
-            for emoji in decoded {
-                byHex[emoji.hexcode] = emoji
-                for shortcode in emoji.shortcodes {
-                    index[shortcode.lowercased()] = emoji
-                }
-                var haystacks: [EmojiHaystack] = []
-                haystacks.reserveCapacity(emoji.shortcodes.count + 1 + emoji.tags.count + activeLocales.count * 2)
-                for shortcode in emoji.shortcodes {
-                    haystacks.append(EmojiHaystack(
-                        display: shortcode,
-                        chars: Array(shortcode.lowercased())
-                    ))
-                }
-                let labelKey = emoji.label.replacingOccurrences(of: " ", with: "_")
-                haystacks.append(EmojiHaystack(
-                    display: labelKey,
-                    chars: Array(labelKey.lowercased())
-                ))
-                // Emojibase keywords (`meditation`, `happy`, …). Searchable but
-                // not exact-typable — kept out of `index` so `:happy:` doesn't
-                // resolve to an arbitrary one of the dozens that share the tag.
-                for tag in emoji.tags {
-                    haystacks.append(EmojiHaystack(
-                        display: tag,
-                        chars: Array(tag.lowercased()),
-                        isTag: true
-                    ))
-                }
-                for locale in activeLocales {
-                    guard let localCodes = emoji.localizedShortcodes[locale] else { continue }
-                    for code in localCodes {
-                        let lowered = code.lowercased()
-                        haystacks.append(EmojiHaystack(display: code, chars: Array(lowered)))
-                        // First-seen wins so English primaries keep priority
-                        // when shortcodes collide across locales.
-                        if index[lowered] == nil {
-                            index[lowered] = emoji
-                        }
-                    }
-                }
-                indexedBuf.append(IndexedEmoji(emoji: emoji, haystacks: haystacks))
-            }
-            self.byShortcode = index
-            self.byHexcode = byHex
-            self.indexed = indexedBuf
+            self.activeLocales = activeAdditionalLocales()
+            applyAliases(AliasStore.shared.aliases)
         } catch {
             assertionFailure("Failed to load emoji.json: \(error)")
         }
+    }
+
+    /// Rebuild the search index from the baked corpus plus the given custom
+    /// aliases. Cheap enough to re-run on every alias edit (no JSON re-decode).
+    func applyAliases(_ aliases: [CustomAlias]) {
+        let result = Self.buildIndex(emojis: all, aliases: aliases, activeLocales: activeLocales)
+        self.byShortcode = result.byShortcode
+        self.byHexcode = result.byHexcode
+        self.indexed = result.indexed
+        objectWillChange.send()
+    }
+
+    struct IndexResult {
+        let byShortcode: [String: Emoji]
+        let byHexcode: [String: Emoji]
+        let indexed: [IndexedEmoji]
+    }
+
+    /// Pure corpus → index build. Custom aliases are layered on last: an alias
+    /// adds a searchable+typable haystack (flagged `isAlias`) to its target and
+    /// overrides `byShortcode` for that spelling, so the user's mapping wins over
+    /// any built-in with the same name. Aliases pointing at an unknown hexcode
+    /// are ignored.
+    nonisolated static func buildIndex(
+        emojis: [Emoji],
+        aliases: [CustomAlias],
+        activeLocales: [String]
+    ) -> IndexResult {
+        // Group aliases by target so each emoji's haystacks are built in one pass.
+        var aliasesByHex: [String: [String]] = [:]
+        for entry in aliases {
+            aliasesByHex[entry.hexcode, default: []].append(entry.alias.lowercased())
+        }
+
+        var index: [String: Emoji] = [:]
+        index.reserveCapacity(emojis.count * 2)
+        var byHex: [String: Emoji] = [:]
+        byHex.reserveCapacity(emojis.count)
+        var indexedBuf: [IndexedEmoji] = []
+        indexedBuf.reserveCapacity(emojis.count)
+
+        for emoji in emojis {
+            byHex[emoji.hexcode] = emoji
+            for shortcode in emoji.shortcodes {
+                index[shortcode.lowercased()] = emoji
+            }
+            let aliasList = aliasesByHex[emoji.hexcode] ?? []
+            var haystacks: [EmojiHaystack] = []
+            haystacks.reserveCapacity(emoji.shortcodes.count + 1 + emoji.tags.count + activeLocales.count * 2 + aliasList.count)
+            for shortcode in emoji.shortcodes {
+                haystacks.append(EmojiHaystack(
+                    display: shortcode,
+                    chars: Array(shortcode.lowercased())
+                ))
+            }
+            let labelKey = emoji.label.replacingOccurrences(of: " ", with: "_")
+            haystacks.append(EmojiHaystack(
+                display: labelKey,
+                chars: Array(labelKey.lowercased())
+            ))
+            // Emojibase keywords (`meditation`, `happy`, …). Searchable but
+            // not exact-typable — kept out of `index` so `:happy:` doesn't
+            // resolve to an arbitrary one of the dozens that share the tag.
+            for tag in emoji.tags {
+                haystacks.append(EmojiHaystack(
+                    display: tag,
+                    chars: Array(tag.lowercased()),
+                    isTag: true
+                ))
+            }
+            for locale in activeLocales {
+                guard let localCodes = emoji.localizedShortcodes[locale] else { continue }
+                for code in localCodes {
+                    let lowered = code.lowercased()
+                    haystacks.append(EmojiHaystack(display: code, chars: Array(lowered)))
+                    // First-seen wins so English primaries keep priority
+                    // when shortcodes collide across locales.
+                    if index[lowered] == nil {
+                        index[lowered] = emoji
+                    }
+                }
+            }
+            for alias in aliasList {
+                haystacks.append(EmojiHaystack(display: alias, chars: Array(alias), isAlias: true))
+            }
+            indexedBuf.append(IndexedEmoji(emoji: emoji, haystacks: haystacks))
+        }
+
+        // Alias overrides applied last so a user alias beats any built-in or
+        // locale shortcode sharing the same spelling.
+        for entry in aliases {
+            guard let target = byHex[entry.hexcode] else { continue }
+            index[entry.alias.lowercased()] = target
+        }
+
+        return IndexResult(byShortcode: index, byHexcode: byHex, indexed: indexedBuf)
     }
 
     func exact(_ shortcode: String) -> Emoji? {

--- a/Sources/Mojito/EmojiDB/FuzzyMatcher.swift
+++ b/Sources/Mojito/EmojiDB/FuzzyMatcher.swift
@@ -74,6 +74,11 @@ struct FuzzyMatcher {
     /// doubles the cost of the worst query for no useful results.
     private static let tagMinNeedle = 2
 
+    /// Score bonus for a user-defined alias haystack. Set above the +5.0
+    /// frequency-boost cap so an aliased emoji reliably beats even a
+    /// heavily-used built-in when the query is the alias term.
+    static let aliasBonus = 6.0
+
     private struct PinnedRow {
         let hexcode: String
         let character: String
@@ -135,6 +140,90 @@ struct FuzzyMatcher {
         let needle = Array(query.lowercased())
         guard !needle.isEmpty else { return [] }
 
+        let scanTags = needle.count >= tagMinNeedle
+
+        let pool: [IndexedEmoji]
+        switch corpus {
+        case .emojiOnly:        pool = database.indexed
+        case .emojiAndSymbols:  pool = database.indexed + SymbolsCorpus.entries
+        case .symbolsOnly:      pool = SymbolsCorpus.entries
+        }
+
+        let trimmed = rankedResults(
+            needle: needle,
+            pool: pool,
+            usage: usage,
+            useFrequencyBoost: useFrequencyBoost,
+            scanTags: scanTags,
+            limit: limit
+        )
+
+        let lowercased = query.lowercased()
+
+        // Discovery hint sits just below the top real match — a normal
+        // shortcode surfaces the actual emoji first, but the hint stays
+        // visible right under it — and only once enough of the trigger is
+        // typed. Hash the query against `EggIndex` — no plaintext keywords in
+        // source. Skipped for `::symbols`.
+        var specialRow: ScoredEmoji?
+        if corpus != .symbolsOnly,
+           EasterEggTracker.eggsEnabled,
+           lowercased.count >= specialMinPrefix,
+           let hexcode = EggIndex.id(forPrefix: lowercased),
+           let row = pinnedRows[hexcode] {
+            // Reveal the trigger keyword once the user has discovered the egg —
+            // a row stuck on "???" after discovery is just dead weight in the
+            // picker.
+            var label = row.label
+            if label == "???",
+               let egg = EasterEgg(rawValue: hexcode),
+               EasterEggTracker.isDiscovered(egg) {
+                label = egg.pickerLabel
+            }
+            specialRow = makeSpecialRow(
+                hexcode: row.hexcode,
+                character: row.character,
+                label: label,
+                order: row.order
+            )
+        }
+
+        guard let specialRow else {
+            return Array(trimmed.prefix(limit))
+        }
+        // Rank the hint among the real matches by how well they fit the query,
+        // so a genuine match always wins but loose subsequence matches don't:
+        //   • right after its lookalike emoji (same glyph), if one matched; else
+        //   • right after the last prefix-tier match (shortcode starts with the
+        //     query); else
+        //   • at the top, when nothing real actually starts with the query.
+        let real = Array(trimmed.prefix(max(0, limit - 1)))
+        guard !real.isEmpty else { return [specialRow] }
+        let insertAt: Int
+        if let twin = real.firstIndex(where: { $0.emoji.character == specialRow.emoji.character }) {
+            insertAt = twin + 1
+        } else if let lastPrefix = real.lastIndex(where: { $0.isPrefix }) {
+            insertAt = lastPrefix + 1
+        } else {
+            insertAt = 0
+        }
+        var output = real
+        output.insert(specialRow, at: insertAt)
+        return output
+    }
+
+    /// The scoring core: rank a haystack pool against `needle` and return the
+    /// top `limit` rows. Split out from `search` so the ranking (including the
+    /// alias bonus) is testable with a synthetic pool, without the easter-egg
+    /// splicing that `search` layers on top.
+    static func rankedResults(
+        needle: [Character],
+        pool: [IndexedEmoji],
+        usage: [String: Int],
+        useFrequencyBoost: Bool,
+        scanTags: Bool,
+        limit: Int
+    ) -> [ScoredEmoji] {
         // Internal carrier so the sort can rank by (isPrefix, score, isTag)
         // without baking a magic tier offset into a single Int.
         struct Candidate {
@@ -147,15 +236,6 @@ struct FuzzyMatcher {
         var results: [Candidate] = []
         results.reserveCapacity(64)
 
-        let scanTags = needle.count >= tagMinNeedle
-
-        let pool: [IndexedEmoji]
-        switch corpus {
-        case .emojiOnly:        pool = database.indexed
-        case .emojiAndSymbols:  pool = database.indexed + SymbolsCorpus.entries
-        case .symbolsOnly:      pool = SymbolsCorpus.entries
-        }
-
         for indexed in pool {
             var bestScore: Double = -.infinity
             var bestDisplay: String?
@@ -164,7 +244,10 @@ struct FuzzyMatcher {
             var prefixBestDisplay: String?
             for haystack in indexed.haystacks {
                 if haystack.isTag && !scanTags { continue }
-                guard let raw = FzyScorer.score(needle: needle, haystack: haystack.chars) else { continue }
+                guard let base = FzyScorer.score(needle: needle, haystack: haystack.chars) else { continue }
+                // A user alias gets a fixed lift so the aliased emoji wins its
+                // alias term over built-ins that merely prefix-match it.
+                let raw = haystack.isAlias ? base + aliasBonus : base
                 // Tags never join the prefix tier — a keyword starting with the
                 // query shouldn't outrank a real shortcode. Within the
                 // non-prefix tier they compete on fzy relevance, so an exact
@@ -225,7 +308,7 @@ struct FuzzyMatcher {
             if lhs.isTag != rhs.isTag { return !lhs.isTag }
             return lhs.emoji.order < rhs.emoji.order
         }
-        var trimmed = results.prefix(limit).map {
+        return results.prefix(limit).map {
             // A tag match drives ranking but isn't a typable shortcode, and many
             // emoji share one keyword — labelling the row with the tag yields a
             // run of identical ":happy:" rows. Show the emoji's own primary
@@ -236,59 +319,6 @@ struct FuzzyMatcher {
                 isPrefix: $0.isPrefix
             )
         }
-
-        let lowercased = query.lowercased()
-
-        // Discovery hint sits just below the top real match — a normal
-        // shortcode surfaces the actual emoji first, but the hint stays
-        // visible right under it — and only once enough of the trigger is
-        // typed. Hash the query against `EggIndex` — no plaintext keywords in
-        // source. Skipped for `::symbols`.
-        var specialRow: ScoredEmoji?
-        if corpus != .symbolsOnly,
-           EasterEggTracker.eggsEnabled,
-           lowercased.count >= specialMinPrefix,
-           let hexcode = EggIndex.id(forPrefix: lowercased),
-           let row = pinnedRows[hexcode] {
-            // Reveal the trigger keyword once the user has discovered the egg —
-            // a row stuck on "???" after discovery is just dead weight in the
-            // picker.
-            var label = row.label
-            if label == "???",
-               let egg = EasterEgg(rawValue: hexcode),
-               EasterEggTracker.isDiscovered(egg) {
-                label = egg.pickerLabel
-            }
-            specialRow = makeSpecialRow(
-                hexcode: row.hexcode,
-                character: row.character,
-                label: label,
-                order: row.order
-            )
-        }
-
-        guard let specialRow else {
-            return Array(trimmed.prefix(limit))
-        }
-        // Rank the hint among the real matches by how well they fit the query,
-        // so a genuine match always wins but loose subsequence matches don't:
-        //   • right after its lookalike emoji (same glyph), if one matched; else
-        //   • right after the last prefix-tier match (shortcode starts with the
-        //     query); else
-        //   • at the top, when nothing real actually starts with the query.
-        let real = Array(trimmed.prefix(max(0, limit - 1)))
-        guard !real.isEmpty else { return [specialRow] }
-        let insertAt: Int
-        if let twin = real.firstIndex(where: { $0.emoji.character == specialRow.emoji.character }) {
-            insertAt = twin + 1
-        } else if let lastPrefix = real.lastIndex(where: { $0.isPrefix }) {
-            insertAt = lastPrefix + 1
-        } else {
-            insertAt = 0
-        }
-        var output = real
-        output.insert(specialRow, at: insertAt)
-        return output
     }
 
     private static func makeSpecialRow(hexcode: String, character: String, label: String, order: Int) -> ScoredEmoji {

--- a/Sources/Mojito/EmojiDB/FuzzyMatcher.swift
+++ b/Sources/Mojito/EmojiDB/FuzzyMatcher.swift
@@ -144,9 +144,19 @@ struct FuzzyMatcher {
 
         let pool: [IndexedEmoji]
         switch corpus {
-        case .emojiOnly:        pool = database.indexed
-        case .emojiAndSymbols:  pool = database.indexed + SymbolsCorpus.entries
-        case .symbolsOnly:      pool = SymbolsCorpus.entries
+        case .emojiOnly:
+            pool = database.indexed
+        case .emojiAndSymbols:
+            // A symbol an alias targets already lives in `database.indexed`, so
+            // drop it from the appended sweep — otherwise it's scored (and
+            // rendered) twice, colliding on hexcode in the picker's ForEach.
+            let promoted = database.aliasedSymbolHexcodes
+            let symbols = promoted.isEmpty
+                ? SymbolsCorpus.entries
+                : SymbolsCorpus.entries.filter { !promoted.contains($0.emoji.hexcode) }
+            pool = database.indexed + symbols
+        case .symbolsOnly:
+            pool = SymbolsCorpus.entries
         }
 
         let trimmed = rankedResults(

--- a/Sources/Mojito/EmojiDB/SymbolsDatabase.swift
+++ b/Sources/Mojito/EmojiDB/SymbolsDatabase.swift
@@ -292,5 +292,12 @@ enum SymbolsDatabase {
         .init(character: "™",  shortcodes: ["tm", "trademark"]),
         .init(character: "§",  shortcodes: ["section"]),
         .init(character: "¶",  shortcodes: ["pilcrow"]),
+
+        //  Apple logo (U+F8FF). A private-use codepoint only Apple's system
+        // fonts draw — renders here and in any Apple app, but pastes as tofu on
+        // Windows/Android/most web fonts. It's why the programmatic sweep skips
+        // it (PUA is filtered out); curated entries bypass that render gate, so
+        // it's opt-in and the portability trade-off is the user's to make.
+        .init(character: "\u{F8FF}", shortcodes: ["apple", "apple_logo"]),
     ]
 }

--- a/Sources/Mojito/EmojiDB/SymbolsDatabase.swift
+++ b/Sources/Mojito/EmojiDB/SymbolsDatabase.swift
@@ -293,6 +293,72 @@ enum SymbolsDatabase {
         .init(character: "§",  shortcodes: ["section"]),
         .init(character: "¶",  shortcodes: ["pilcrow"]),
 
+        // Math & logic. All swept too, but the Unicode names are unsearchable
+        // ("N-ARY UNION", "THERE EXISTS") — give them the terms people type.
+        .init(character: "∫",  shortcodes: ["integral"]),
+        .init(character: "∂",  shortcodes: ["partial", "differential"]),
+        .init(character: "∇",  shortcodes: ["nabla", "del", "gradient"]),
+        .init(character: "∈",  shortcodes: ["element_of", "elem"]),
+        .init(character: "∉",  shortcodes: ["not_element", "not_in"]),
+        .init(character: "⊂",  shortcodes: ["subset"]),
+        .init(character: "⊆",  shortcodes: ["subset_equal"]),
+        .init(character: "⊃",  shortcodes: ["superset"]),
+        .init(character: "∪",  shortcodes: ["union"]),
+        .init(character: "∩",  shortcodes: ["intersection", "intersect"]),
+        .init(character: "∴",  shortcodes: ["therefore"]),
+        .init(character: "∵",  shortcodes: ["because"]),
+        .init(character: "∝",  shortcodes: ["proportional", "propto"]),
+        .init(character: "∅",  shortcodes: ["empty_set", "emptyset", "null_set"]),
+        .init(character: "∀",  shortcodes: ["forall", "for_all"]),
+        .init(character: "∃",  shortcodes: ["exists", "there_exists"]),
+        .init(character: "¬",  shortcodes: ["not", "negation", "logical_not"]),
+        .init(character: "∧",  shortcodes: ["wedge", "logical_and", "conjunction"]),
+        .init(character: "∨",  shortcodes: ["vee", "logical_or", "disjunction"]),
+        .init(character: "⊕",  shortcodes: ["oplus", "xor", "direct_sum"]),
+        .init(character: "≡",  shortcodes: ["equivalent", "identical", "equiv"]),
+        .init(character: "≅",  shortcodes: ["congruent", "cong"]),
+        .init(character: "∼",  shortcodes: ["sim", "similar"]),
+
+        // More arrows — rotate/refresh and the mapping arrows the swept names
+        // ("CLOCKWISE OPEN CIRCLE ARROW", "RIGHTWARDS ARROW FROM BAR") bury.
+        .init(character: "↔",  shortcodes: ["left_right", "leftright"]),
+        .init(character: "↕",  shortcodes: ["up_down", "updown"]),
+        .init(character: "↻",  shortcodes: ["refresh", "reload", "rotate", "rotate_cw"]),
+        .init(character: "↺",  shortcodes: ["rotate_ccw", "undo_rotate"]),
+        .init(character: "↦",  shortcodes: ["mapsto", "maps_to"]),
+
+        // Typography & editorial marks
+        .init(character: "†",  shortcodes: ["dagger", "obelisk"]),
+        .init(character: "‡",  shortcodes: ["double_dagger", "ddagger", "diesis"]),
+        .init(character: "№",  shortcodes: ["numero", "numero_sign"]),
+        .init(character: "′",  shortcodes: ["prime", "minutes", "feet"]),
+        .init(character: "″",  shortcodes: ["double_prime", "seconds", "inches"]),
+        .init(character: "‰",  shortcodes: ["permille", "per_mille"]),
+        .init(character: "·",  shortcodes: ["middot", "interpunct", "middle_dot"]),
+        .init(character: "‽",  shortcodes: ["interrobang"]),
+        .init(character: "※",  shortcodes: ["reference_mark", "kome"]),
+        .init(character: "℅",  shortcodes: ["care_of", "c_o"]),
+        .init(character: "℠",  shortcodes: ["service_mark", "sm"]),
+
+        // Plain-text checkboxes & bullets (todo lists in any field)
+        .init(character: "☐",  shortcodes: ["checkbox", "ballot", "unchecked"]),
+        .init(character: "☑",  shortcodes: ["checkbox_checked", "ballot_check", "checked"]),
+        .init(character: "☒",  shortcodes: ["checkbox_x", "ballot_x", "crossed"]),
+        .init(character: "◦",  shortcodes: ["white_bullet", "hollow_bullet"]),
+        .init(character: "‣",  shortcodes: ["triangle_bullet", "tri_bullet"]),
+
+        // Music notation
+        .init(character: "♩",  shortcodes: ["quarter_note"]),
+        .init(character: "♪",  shortcodes: ["note", "eighth_note"]),
+        .init(character: "♫",  shortcodes: ["notes", "beamed_notes"]),
+        .init(character: "♭",  shortcodes: ["flat", "flat_sign"]),
+        .init(character: "♮",  shortcodes: ["natural", "natural_sign"]),
+        .init(character: "♯",  shortcodes: ["sharp", "sharp_sign"]),
+
+        // Extra fractions (⅓ ⅔ read terribly as "VULGAR FRACTION ONE THIRD")
+        .init(character: "⅓",  shortcodes: ["one_third", "third"]),
+        .init(character: "⅔",  shortcodes: ["two_thirds"]),
+
         //  Apple logo (U+F8FF). A private-use codepoint only Apple's system
         // fonts draw — renders here and in any Apple app, but pastes as tofu on
         // Windows/Android/most web fonts. It's why the programmatic sweep skips

--- a/Sources/Mojito/Settings/AliasesSettings.swift
+++ b/Sources/Mojito/Settings/AliasesSettings.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 
-/// Settings ▸ Shortcuts. Lets the user add their own `:shortcode:` → emoji
+/// Settings ▸ Aliases. Lets the user add their own `:word:` → emoji or symbol
 /// mappings on top of the baked corpus (W-453). Editing writes through
 /// `AliasStore`, which re-merges the emoji index live.
-struct CustomShortcutsSettingsView: View {
+struct AliasesSettingsView: View {
     @StateObject private var store = AliasStore.shared
     private let database = EmojiDatabase.shared
 
@@ -25,9 +25,9 @@ struct CustomShortcutsSettingsView: View {
                 if store.aliases.count > 1 {
                     HStack {
                         Spacer()
-                        Button("Clear all shortcuts") { confirmClear = true }
+                        Button("Clear all aliases") { confirmClear = true }
                             .confirmationDialog(
-                                "Remove all custom shortcuts?",
+                                "Remove all aliases?",
                                 isPresented: $confirmClear,
                                 titleVisibility: .visible
                             ) {
@@ -49,6 +49,7 @@ struct CustomShortcutsSettingsView: View {
 
     private func glyph(for alias: CustomAlias) -> String? {
         database.byHexcode[alias.hexcode]?.tonedGlyph
+            ?? SymbolsDatabase.byHexcode[alias.hexcode]?.tonedGlyph
     }
 
     private func removeSelected() {
@@ -95,7 +96,7 @@ private struct AliasCard: View {
     }
 
     private var header: some View {
-        Text("Type these shortcuts to insert their emoji. They work alongside the built-in ones.")
+        Text("Type these aliases to insert their emoji or symbol. They work alongside the built-in shortcodes.")
             .foregroundStyle(.secondary)
             .fixedSize(horizontal: false, vertical: true)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -104,7 +105,7 @@ private struct AliasCard: View {
     }
 
     private var emptyState: some View {
-        Text("No custom shortcuts yet. Add one to type `:yourword:` for any emoji.")
+        Text("No aliases yet. Add one to type `:yourword:` for any emoji or symbol.")
             .font(.callout)
             .foregroundStyle(.tertiary)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -173,8 +174,8 @@ private struct AliasCard: View {
 
 // MARK: - Add sheet
 
-/// Type the shortcut, pick its emoji, add. The emoji is chosen with the same
-/// browser used everywhere else, nested in a sheet.
+/// Type the alias, pick its emoji or symbol, add. The target is chosen with the
+/// same browser used everywhere else, nested in a sheet.
 private struct AddAliasSheet: View {
     @ObservedObject var store: AliasStore
     let onClose: () -> Void
@@ -193,14 +194,14 @@ private struct AddAliasSheet: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
-            Text("Add shortcut").font(.headline)
+            Text("Add alias").font(.headline)
 
             VStack(alignment: .leading, spacing: 6) {
-                TextField("Your shortcut, e.g. check", text: $text)
+                TextField("Your alias, e.g. check", text: $text)
                     .textFieldStyle(.roundedBorder)
                     .onSubmit { if canAdd { add() } }
                 if isDuplicate {
-                    Text(":\(normalized ?? ""): already exists — adding updates its emoji.")
+                    Text(":\(normalized ?? ""): already exists — adding updates its target.")
                         .font(.callout)
                         .foregroundStyle(.secondary)
                 }
@@ -214,7 +215,7 @@ private struct AddAliasSheet: View {
                         Text(pickedGlyph ?? "🙂")
                             .font(.system(size: 24))
                             .opacity(pickedGlyph == nil ? 0.35 : 1)
-                        Text(pickedGlyph == nil ? "Choose emoji…" : "Change emoji")
+                        Text(pickedGlyph == nil ? "Choose emoji or symbol…" : "Change")
                     }
                 }
                 Spacer()
@@ -246,20 +247,21 @@ private struct AddAliasSheet: View {
     }
 }
 
-/// The shared emoji browser hosted in a sheet, returning the chosen emoji.
-/// Mirrors the Quick Access slot picker.
+/// The shared emoji browser hosted in a sheet, returning the chosen emoji or
+/// symbol. Symbols are forced in (`includeSymbols`) so they're pickable as
+/// alias targets regardless of the global Symbols toggle.
 private struct EmojiPickerSheet: View {
     let onPick: (Emoji) -> Void
 
     @Environment(\.dismiss) private var dismiss
     @StateObject private var browser = EmojiBrowserViewModel(
-        database: .shared, quickAccess: .shared
+        database: .shared, quickAccess: .shared, includeSymbols: true
     )
 
     var body: some View {
         VStack(spacing: 0) {
             HStack {
-                Text("Pick an emoji").font(.headline)
+                Text("Pick an emoji or symbol").font(.headline)
                 Spacer()
                 Button("Cancel") { dismiss() }
                     .keyboardShortcut(.cancelAction)

--- a/Sources/Mojito/Settings/AliasesSettings.swift
+++ b/Sources/Mojito/Settings/AliasesSettings.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// Settings ▸ Aliases. Lets the user add their own `:word:` → emoji or symbol
-/// mappings on top of the baked corpus (W-453). Editing writes through
+/// mappings on top of the baked corpus. Editing writes through
 /// `AliasStore`, which re-merges the emoji index live.
 struct AliasesSettingsView: View {
     @StateObject private var store = AliasStore.shared

--- a/Sources/Mojito/Settings/CustomShortcutsSettings.swift
+++ b/Sources/Mojito/Settings/CustomShortcutsSettings.swift
@@ -1,0 +1,279 @@
+import SwiftUI
+
+/// Settings ▸ Shortcuts. Lets the user add their own `:shortcode:` → emoji
+/// mappings on top of the baked corpus (W-453). Editing writes through
+/// `AliasStore`, which re-merges the emoji index live.
+struct CustomShortcutsSettingsView: View {
+    @StateObject private var store = AliasStore.shared
+    private let database = EmojiDatabase.shared
+
+    @State private var showAdd = false
+    @State private var selected: String?
+    @State private var confirmClear = false
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                AliasCard(
+                    aliases: store.aliases,
+                    glyph: glyph(for:),
+                    selected: $selected,
+                    onAdd: { showAdd = true },
+                    onRemove: removeSelected
+                )
+
+                if store.aliases.count > 1 {
+                    HStack {
+                        Spacer()
+                        Button("Clear all shortcuts") { confirmClear = true }
+                            .confirmationDialog(
+                                "Remove all custom shortcuts?",
+                                isPresented: $confirmClear,
+                                titleVisibility: .visible
+                            ) {
+                                Button("Remove all", role: .destructive) {
+                                    store.removeAll()
+                                    selected = nil
+                                }
+                                Button("Cancel", role: .cancel) {}
+                            }
+                    }
+                }
+            }
+            .padding(20)
+        }
+        .sheet(isPresented: $showAdd) {
+            AddAliasSheet(store: store) { showAdd = false }
+        }
+    }
+
+    private func glyph(for alias: CustomAlias) -> String? {
+        database.byHexcode[alias.hexcode]?.tonedGlyph
+    }
+
+    private func removeSelected() {
+        guard let selected else { return }
+        store.remove(alias: selected)
+        self.selected = nil
+    }
+}
+
+// MARK: - Alias list card
+
+/// Boxed list matching the Exclusions cards: content-sized, hairline border,
+/// a `+`/`−` footer.
+private struct AliasCard: View {
+    let aliases: [CustomAlias]
+    let glyph: (CustomAlias) -> String?
+    @Binding var selected: String?
+    let onAdd: () -> Void
+    let onRemove: () -> Void
+
+    private let cornerRadius: CGFloat = 10
+    private let innerSeparator = Color.primary.opacity(0.08)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            innerSeparator.frame(height: 0.5)
+            if aliases.isEmpty {
+                emptyState
+            } else {
+                rows
+            }
+            innerSeparator.frame(height: 0.5)
+            footer
+        }
+        .background(
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .fill(.background.secondary)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .strokeBorder(Color(nsColor: .separatorColor), lineWidth: 0.5)
+        )
+    }
+
+    private var header: some View {
+        Text("Type these shortcuts to insert their emoji. They work alongside the built-in ones.")
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+    }
+
+    private var emptyState: some View {
+        Text("No custom shortcuts yet. Add one to type `:yourword:` for any emoji.")
+            .font(.callout)
+            .foregroundStyle(.tertiary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 14)
+    }
+
+    private var rows: some View {
+        VStack(spacing: 0) {
+            ForEach(Array(aliases.enumerated()), id: \.element.id) { idx, alias in
+                row(alias)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
+                    .background(selected == alias.id ? Color.accentColor : Color.clear)
+                    .foregroundStyle(selected == alias.id ? Color.white : Color.primary)
+                    .onTapGesture { selected = alias.id }
+
+                if idx < aliases.count - 1 {
+                    innerSeparator.frame(height: 0.5).padding(.leading, 50)
+                }
+            }
+        }
+    }
+
+    private func row(_ alias: CustomAlias) -> some View {
+        HStack(spacing: 10) {
+            Text(glyph(alias) ?? "❓")
+                .font(.system(size: 22))
+                .frame(width: 28, height: 28)
+            Text(":\(alias.alias):")
+                .font(.system(.body, design: .monospaced))
+            Spacer()
+        }
+    }
+
+    private var footer: some View {
+        HStack(spacing: 0) {
+            Button(action: onAdd) {
+                Image(systemName: "plus")
+                    .font(.system(size: 12, weight: .semibold))
+                    .frame(width: 28, height: 22)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+
+            Divider()
+
+            Button(action: onRemove) {
+                Image(systemName: "minus")
+                    .font(.system(size: 12, weight: .semibold))
+                    .frame(width: 28, height: 22)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            .disabled(selected == nil)
+
+            Spacer()
+        }
+        .background(Color.primary.opacity(0.04))
+    }
+}
+
+// MARK: - Add sheet
+
+/// Type the shortcut, pick its emoji, add. The emoji is chosen with the same
+/// browser used everywhere else, nested in a sheet.
+private struct AddAliasSheet: View {
+    @ObservedObject var store: AliasStore
+    let onClose: () -> Void
+
+    @State private var text = ""
+    @State private var pickedHexcode: String?
+    @State private var pickedGlyph: String?
+    @State private var showPicker = false
+
+    private var normalized: String? { AliasStore.normalize(text) }
+    private var canAdd: Bool { normalized != nil && pickedHexcode != nil }
+    private var isDuplicate: Bool {
+        guard let normalized else { return false }
+        return store.contains(alias: normalized)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Add shortcut").font(.headline)
+
+            VStack(alignment: .leading, spacing: 6) {
+                TextField("Your shortcut, e.g. check", text: $text)
+                    .textFieldStyle(.roundedBorder)
+                    .onSubmit { if canAdd { add() } }
+                if isDuplicate {
+                    Text(":\(normalized ?? ""): already exists — adding updates its emoji.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            HStack(spacing: 12) {
+                Button {
+                    showPicker = true
+                } label: {
+                    HStack(spacing: 8) {
+                        Text(pickedGlyph ?? "🙂")
+                            .font(.system(size: 24))
+                            .opacity(pickedGlyph == nil ? 0.35 : 1)
+                        Text(pickedGlyph == nil ? "Choose emoji…" : "Change emoji")
+                    }
+                }
+                Spacer()
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel", action: onClose)
+                    .keyboardShortcut(.cancelAction)
+                Button("Add") { add() }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(!canAdd)
+            }
+        }
+        .padding(20)
+        .frame(width: 360)
+        .sheet(isPresented: $showPicker) {
+            EmojiPickerSheet { emoji in
+                pickedHexcode = emoji.hexcode
+                pickedGlyph = emoji.tonedGlyph
+            }
+        }
+    }
+
+    private func add() {
+        guard let normalized, let hex = pickedHexcode else { return }
+        store.add(alias: normalized, hexcode: hex)
+        onClose()
+    }
+}
+
+/// The shared emoji browser hosted in a sheet, returning the chosen emoji.
+/// Mirrors the Quick Access slot picker.
+private struct EmojiPickerSheet: View {
+    let onPick: (Emoji) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @StateObject private var browser = EmojiBrowserViewModel(
+        database: .shared, quickAccess: .shared
+    )
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Pick an emoji").font(.headline)
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+            Divider()
+            InlineBrowserView(
+                browser: browser,
+                onPick: { emoji in onPick(emoji); dismiss() },
+                onCategory: { browser.selectCategory($0) },
+                editableSearch: true
+            )
+        }
+        .frame(width: BrowserLayout.width, height: BrowserLayout.height + 48)
+    }
+}

--- a/Sources/Mojito/Settings/SettingsRoot.swift
+++ b/Sources/Mojito/Settings/SettingsRoot.swift
@@ -20,7 +20,7 @@ struct SettingsRoot: View {
         var symbol: String {
             switch self {
             case .general:    return "gearshape"
-            case .aliases:    return "arrow.left.arrow.right"
+            case .aliases:    return "square.on.square"
             case .exclusions: return "xmark.octagon"
             case .easterEggs: return "sparkles"
             case .privacy:    return "lock.shield"

--- a/Sources/Mojito/Settings/SettingsRoot.swift
+++ b/Sources/Mojito/Settings/SettingsRoot.swift
@@ -3,13 +3,13 @@ import SwiftUI
 
 struct SettingsRoot: View {
     enum Tab: Hashable, CaseIterable, Identifiable {
-        case general, shortcuts, exclusions, easterEggs, privacy, about
+        case general, aliases, exclusions, easterEggs, privacy, about
         var id: Self { self }
 
         var title: String {
             switch self {
             case .general:    return String(localized: "General")
-            case .shortcuts:  return String(localized: "Shortcuts")
+            case .aliases:    return String(localized: "Aliases")
             case .exclusions: return String(localized: "Exclusions")
             case .easterEggs: return String(localized: "Easter eggs")
             case .privacy:    return String(localized: "Privacy")
@@ -20,7 +20,7 @@ struct SettingsRoot: View {
         var symbol: String {
             switch self {
             case .general:    return "gearshape"
-            case .shortcuts:  return "text.badge.plus"
+            case .aliases:    return "arrow.left.arrow.right"
             case .exclusions: return "xmark.octagon"
             case .easterEggs: return "sparkles"
             case .privacy:    return "lock.shield"
@@ -45,7 +45,7 @@ struct SettingsRoot: View {
             Group {
                 switch selection {
                 case .general:    GeneralSettingsView()
-                case .shortcuts:  CustomShortcutsSettingsView()
+                case .aliases:    AliasesSettingsView()
                 case .exclusions: ExclusionsSettingsView()
                 case .easterEggs: EasterEggsSettingsView()
                 case .privacy:    PrivacyPermissionsSettingsView()

--- a/Sources/Mojito/Settings/SettingsRoot.swift
+++ b/Sources/Mojito/Settings/SettingsRoot.swift
@@ -3,12 +3,13 @@ import SwiftUI
 
 struct SettingsRoot: View {
     enum Tab: Hashable, CaseIterable, Identifiable {
-        case general, exclusions, easterEggs, privacy, about
+        case general, shortcuts, exclusions, easterEggs, privacy, about
         var id: Self { self }
 
         var title: String {
             switch self {
             case .general:    return String(localized: "General")
+            case .shortcuts:  return String(localized: "Shortcuts")
             case .exclusions: return String(localized: "Exclusions")
             case .easterEggs: return String(localized: "Easter eggs")
             case .privacy:    return String(localized: "Privacy")
@@ -19,6 +20,7 @@ struct SettingsRoot: View {
         var symbol: String {
             switch self {
             case .general:    return "gearshape"
+            case .shortcuts:  return "text.badge.plus"
             case .exclusions: return "xmark.octagon"
             case .easterEggs: return "sparkles"
             case .privacy:    return "lock.shield"
@@ -43,6 +45,7 @@ struct SettingsRoot: View {
             Group {
                 switch selection {
                 case .general:    GeneralSettingsView()
+                case .shortcuts:  CustomShortcutsSettingsView()
                 case .exclusions: ExclusionsSettingsView()
                 case .easterEggs: EasterEggsSettingsView()
                 case .privacy:    PrivacyPermissionsSettingsView()

--- a/Sources/Mojito/Util/PrefsKey.swift
+++ b/Sources/Mojito/Util/PrefsKey.swift
@@ -27,6 +27,11 @@ enum PrefsKey {
     static let allowedBundleIDs      = "mojito.allowBundleIDs"       // [String]
     static let allowedURLPatterns    = "mojito.allowURLPatterns"     // [String]
     static let usageCounts           = "mojito.usageCounts"          // [String: Int]  (hexcode → count)
+    /// User-defined shortcodes that resolve to an emoji. JSON-encoded
+    /// `[CustomAlias]` (alias string → hexcode). Additive on top of the baked
+    /// emoji corpus; an alias wins over a built-in shortcode with the same
+    /// spelling. Managed in Settings ▸ Shortcuts.
+    static let customAliases         = "mojito.customAliases"        // Data (JSON [CustomAlias])
     /// The 8 Quick Access slots surfaced on `:<trigger>` and managed in
     /// Settings ▸ General. An 8-element `[String]` where `""` is an auto
     /// (most-used) slot and any other value is a pinned emoji hexcode.

--- a/Tests/MojitoTests/AliasTests.swift
+++ b/Tests/MojitoTests/AliasTests.swift
@@ -123,6 +123,22 @@ struct AliasIndexTests {
         #expect(result.indexed.allSatisfy { !$0.haystacks.contains { $0.isAlias } })
     }
 
+    @Test func aliasCanTargetSymbol() {
+        // ⌘ lives in SymbolsDatabase (hexcode "SYM_cmd"), not the emoji corpus.
+        let result = build([CustomAlias(alias: "apple", hexcode: "SYM_cmd")])
+        #expect(result.byShortcode["apple"]?.character == "⌘")
+        #expect(result.byHexcode["SYM_cmd"]?.character == "⌘")
+        let row = result.indexed.first { $0.emoji.hexcode == "SYM_cmd" }
+        #expect(row?.haystacks.contains { $0.isAlias && $0.display == "apple" } == true)
+    }
+
+    @Test func symbolAliasIsSearchable() {
+        // A symbol alias becomes a first-class indexed row, so typing its term
+        // surfaces the symbol even though it's not in the emoji corpus.
+        let result = build([CustomAlias(alias: "apple", hexcode: "SYM_cmd")])
+        #expect(rank("apple", result).first == "SYM_cmd")
+    }
+
     private func rank(_ query: String, _ result: EmojiDatabase.IndexResult, usage: [String: Int] = [:]) -> [String] {
         FuzzyMatcher.rankedResults(
             needle: Array(query.lowercased()),

--- a/Tests/MojitoTests/AliasTests.swift
+++ b/Tests/MojitoTests/AliasTests.swift
@@ -2,7 +2,7 @@ import Testing
 import Foundation
 @testable import Mojito
 
-/// Custom shortcut (alias) storage + validation (W-453).
+/// Custom shortcut (alias) storage + validation.
 @MainActor
 struct AliasStoreTests {
     private func makeStore() -> AliasStore {
@@ -78,7 +78,7 @@ struct AliasStoreTests {
     }
 }
 
-/// Merging aliases into the emoji index + ranking (W-453). Uses the pure
+/// Merging aliases into the emoji index + ranking. Uses the pure
 /// builders so it needs no bundle or shared singleton.
 struct AliasIndexTests {
     private static let check = Emoji(hexcode: "E_CHECK", character: "✅", label: "white check mark",

--- a/Tests/MojitoTests/AliasTests.swift
+++ b/Tests/MojitoTests/AliasTests.swift
@@ -1,0 +1,153 @@
+import Testing
+import Foundation
+@testable import Mojito
+
+/// Custom shortcut (alias) storage + validation (W-453).
+@MainActor
+struct AliasStoreTests {
+    private func makeStore() -> AliasStore {
+        let suite = UserDefaults(suiteName: "mojito.tests.alias.\(UUID().uuidString)")!
+        return AliasStore(defaults: suite)
+    }
+
+    @Test func startsEmpty() {
+        #expect(makeStore().aliases.isEmpty)
+    }
+
+    @Test func addNormalizesAndStores() {
+        let store = makeStore()
+        #expect(store.add(alias: "  Check  ", hexcode: "2705") == .added)
+        #expect(store.aliases.count == 1)
+        #expect(store.aliases[0].alias == "check")   // trimmed + lowercased
+        #expect(store.aliases[0].hexcode == "2705")
+        #expect(store.contains(alias: "CHECK"))
+    }
+
+    @Test func rejectsInvalidAliases() {
+        let store = makeStore()
+        #expect(store.add(alias: "", hexcode: "2705") == .invalid)
+        #expect(store.add(alias: "   ", hexcode: "2705") == .invalid)
+        #expect(store.add(alias: "a b", hexcode: "2705") == .invalid)   // whitespace
+        #expect(store.add(alias: "a:b", hexcode: "2705") == .invalid)   // colon
+        #expect(store.add(alias: String(repeating: "x", count: 41), hexcode: "2705") == .invalid)
+        #expect(store.add(alias: "ok", hexcode: "") == .invalid)        // no target
+        #expect(store.aliases.isEmpty)
+    }
+
+    @Test func repointingUpdatesInPlace() {
+        let store = makeStore()
+        store.add(alias: "check", hexcode: "2705")
+        #expect(store.add(alias: "check", hexcode: "2714") == .updated)
+        #expect(store.aliases.count == 1)
+        #expect(store.aliases[0].hexcode == "2714")
+        // Re-adding the identical mapping is a no-op update, not a duplicate.
+        #expect(store.add(alias: "check", hexcode: "2714") == .updated)
+        #expect(store.aliases.count == 1)
+    }
+
+    @Test func removeAndRemoveAll() {
+        let store = makeStore()
+        store.add(alias: "check", hexcode: "2705")
+        store.add(alias: "tick", hexcode: "2705")
+        store.remove(alias: "CHECK")
+        #expect(store.aliases.map(\.alias) == ["tick"])
+        store.removeAll()
+        #expect(store.aliases.isEmpty)
+    }
+
+    @Test func persistsAcrossInstances() {
+        let suiteName = "mojito.tests.alias.persist.\(UUID().uuidString)"
+        let suite = UserDefaults(suiteName: suiteName)!
+        let first = AliasStore(defaults: suite)
+        first.add(alias: "check", hexcode: "2705")
+        let second = AliasStore(defaults: suite)
+        #expect(second.aliases.count == 1)
+        #expect(second.aliases[0].alias == "check")
+        #expect(second.aliases[0].hexcode == "2705")
+    }
+
+    @Test func sanitizeDropsInvalidAndDuplicate() {
+        let cleaned = AliasStore.sanitize([
+            CustomAlias(alias: "Check", hexcode: "2705"),
+            CustomAlias(alias: "check", hexcode: "2714"),   // dupe (first wins)
+            CustomAlias(alias: "bad:one", hexcode: "1F600"), // invalid
+            CustomAlias(alias: "ok", hexcode: ""),           // no target
+        ])
+        #expect(cleaned.map(\.alias) == ["check"])
+        #expect(cleaned[0].hexcode == "2705")
+    }
+}
+
+/// Merging aliases into the emoji index + ranking (W-453). Uses the pure
+/// builders so it needs no bundle or shared singleton.
+struct AliasIndexTests {
+    private static let check = Emoji(hexcode: "E_CHECK", character: "✅", label: "white check mark",
+                                     shortcodes: ["white_check_mark"], tags: [], group: 0, order: 1)
+    private static let flag = Emoji(hexcode: "E_FLAG", character: "🏁", label: "chequered flag",
+                                    shortcodes: ["checkered_flag"], tags: [], group: 0, order: 2)
+    private static let heavy = Emoji(hexcode: "E_HEAVY", character: "✔️", label: "heavy check mark",
+                                     shortcodes: ["heavy_check_mark"], tags: [], group: 0, order: 3)
+    private static let corpus = [check, flag, heavy]
+
+    private func build(_ aliases: [CustomAlias]) -> EmojiDatabase.IndexResult {
+        EmojiDatabase.buildIndex(emojis: Self.corpus, aliases: aliases, activeLocales: [])
+    }
+
+    @Test func aliasResolvesAndOverrides() {
+        let result = build([CustomAlias(alias: "check", hexcode: "E_CHECK")])
+        // Typable exact match (`:check:`).
+        #expect(result.byShortcode["check"]?.hexcode == "E_CHECK")
+        // Built-in shortcodes are untouched.
+        #expect(result.byShortcode["white_check_mark"]?.hexcode == "E_CHECK")
+        #expect(result.byShortcode["checkered_flag"]?.hexcode == "E_FLAG")
+    }
+
+    @Test func aliasHaystackIsFlagged() {
+        let result = build([CustomAlias(alias: "check", hexcode: "E_CHECK")])
+        let checkRow = result.indexed.first { $0.emoji.hexcode == "E_CHECK" }
+        let aliasHay = checkRow?.haystacks.first { $0.isAlias }
+        #expect(aliasHay?.display == "check")
+        // No other emoji picked up the alias haystack.
+        #expect(result.indexed.filter { $0.haystacks.contains { $0.isAlias } }.count == 1)
+    }
+
+    @Test func aliasOverridesBuiltinSpelling() {
+        // Alias "checkered_flag" (a real built-in for 🏁) re-pointed at ✅ wins.
+        let result = build([CustomAlias(alias: "checkered_flag", hexcode: "E_CHECK")])
+        #expect(result.byShortcode["checkered_flag"]?.hexcode == "E_CHECK")
+    }
+
+    @Test func aliasToUnknownEmojiIgnored() {
+        let result = build([CustomAlias(alias: "nope", hexcode: "DOES_NOT_EXIST")])
+        #expect(result.byShortcode["nope"] == nil)
+        #expect(result.indexed.allSatisfy { !$0.haystacks.contains { $0.isAlias } })
+    }
+
+    private func rank(_ query: String, _ result: EmojiDatabase.IndexResult, usage: [String: Int] = [:]) -> [String] {
+        FuzzyMatcher.rankedResults(
+            needle: Array(query.lowercased()),
+            pool: result.indexed,
+            usage: usage,
+            useFrequencyBoost: !usage.isEmpty,
+            scanTags: query.count >= 2,
+            limit: 12
+        ).map(\.emoji.hexcode)
+    }
+
+    @Test func aliasedEmojiWinsItsTerm() {
+        // Control: without an alias, only 🏁 (checkered_flag) prefix-matches "check".
+        let control = rank("check", build([]))
+        #expect(control.first == "E_FLAG")
+
+        // With the alias, ✅ ranks first for "check".
+        let aliased = rank("check", build([CustomAlias(alias: "check", hexcode: "E_CHECK")]))
+        #expect(aliased.first == "E_CHECK")
+    }
+
+    @Test func aliasBeatsHeavilyUsedBuiltin() {
+        // Even if 🏁 is maxed out on the frequency boost, the alias still wins.
+        let result = build([CustomAlias(alias: "check", hexcode: "E_CHECK")])
+        let ranked = rank("check", result, usage: ["E_FLAG": 100])
+        #expect(ranked.first == "E_CHECK")
+    }
+}

--- a/Tests/MojitoTests/AliasTests.swift
+++ b/Tests/MojitoTests/AliasTests.swift
@@ -29,9 +29,14 @@ struct AliasStoreTests {
         #expect(store.add(alias: "   ", hexcode: "2705") == .invalid)
         #expect(store.add(alias: "a b", hexcode: "2705") == .invalid)   // whitespace
         #expect(store.add(alias: "a:b", hexcode: "2705") == .invalid)   // colon
+        #expect(store.add(alias: "foo.bar", hexcode: "2705") == .invalid)  // dot ends capture
+        #expect(store.add(alias: "a/b", hexcode: "2705") == .invalid)   // slash ends capture
+        #expect(store.add(alias: "wave👋", hexcode: "2705") == .invalid)  // emoji not typable in a name
         #expect(store.add(alias: String(repeating: "x", count: 41), hexcode: "2705") == .invalid)
         #expect(store.add(alias: "ok", hexcode: "") == .invalid)        // no target
         #expect(store.aliases.isEmpty)
+        // Sanity: the name-char set the trigger *does* capture is accepted.
+        #expect(store.add(alias: "a-b_c+1", hexcode: "2705") == .added)
     }
 
     @Test func repointingUpdatesInPlace() {
@@ -137,6 +142,16 @@ struct AliasIndexTests {
         // surfaces the symbol even though it's not in the emoji corpus.
         let result = build([CustomAlias(alias: "apple", hexcode: "SYM_cmd")])
         #expect(rank("apple", result).first == "SYM_cmd")
+    }
+
+    @Test func symbolAliasTargetsAreTracked() {
+        // The promoted-symbol set drives combined-corpus dedup (the aliased
+        // symbol is dropped from the appended sweep so it isn't scored twice).
+        let symbol = build([CustomAlias(alias: "apple", hexcode: "SYM_cmd")])
+        #expect(symbol.aliasedSymbolHexcodes == ["SYM_cmd"])
+        // Emoji-target aliases promote nothing.
+        let emoji = build([CustomAlias(alias: "check", hexcode: "E_CHECK")])
+        #expect(emoji.aliasedSymbolHexcodes.isEmpty)
     }
 
     private func rank(_ query: String, _ result: EmojiDatabase.IndexResult, usage: [String: Int] = [:]) -> [String] {

--- a/Tests/MojitoTests/EmojiDatabaseTests.swift
+++ b/Tests/MojitoTests/EmojiDatabaseTests.swift
@@ -10,8 +10,15 @@ struct EmojiDatabaseTests {
         let db = EmojiDatabase.shared
         // emojibase ships ~1.9k entries; guard against an empty/failed load.
         #expect(db.all.count > 1000)
-        // Exactly one indexed entry per emoji.
-        #expect(db.indexed.count == db.all.count)
+        // One indexed row per emoji, plus one per distinct symbol a custom
+        // alias points at — aliasing a symbol adds it as a first-class row
+        // (emoji aliases only augment their target's existing row).
+        let aliasedSymbolRows = Set(
+            AliasStore.shared.aliases
+                .map(\.hexcode)
+                .filter { $0.hasPrefix("SYM_") && SymbolsDatabase.byHexcode[$0] != nil }
+        ).count
+        #expect(db.indexed.count == db.all.count + aliasedSymbolRows)
     }
 
     @Test func exactLookupResolvesKnownShortcode() {

--- a/Tests/MojitoTests/FuzzyMatcherTests.swift
+++ b/Tests/MojitoTests/FuzzyMatcherTests.swift
@@ -88,8 +88,16 @@ struct FuzzyMatcherTests {
     }
 
     @Test func emojiOnlyCorpusExcludesSymbols() {
-        let results = search("cmd", corpus: .emojiOnly)
-        #expect(!results.contains { $0.emoji.character == "⌘" })
+        // The swept symbol corpus stays out of .emojiOnly. A symbol the user
+        // has explicitly aliased becomes a permanent indexed row, so it's the
+        // one legitimate exception — assert no *un-aliased* swept symbol leaks.
+        let aliasedSymbolHexes = Set(
+            AliasStore.shared.aliases.map(\.hexcode).filter { $0.hasPrefix("SYM_") }
+        )
+        let leaked = search("cmd", corpus: .emojiOnly).filter {
+            $0.emoji.hexcode.hasPrefix("SYM_") && !aliasedSymbolHexes.contains($0.emoji.hexcode)
+        }
+        #expect(leaked.isEmpty)
     }
 
     @Test func emojiAndSymbolsCorpusSpansBoth() {

--- a/Tests/MojitoTests/FuzzyMatcherTests.swift
+++ b/Tests/MojitoTests/FuzzyMatcherTests.swift
@@ -100,6 +100,20 @@ struct FuzzyMatcherTests {
         #expect(leaked.isEmpty)
     }
 
+    @Test func emojiAndSymbolsHasNoDuplicateHexcodes() {
+        // A symbol targeted by an alias lives in both the indexed corpus and
+        // the appended sweep; the combined search must surface it only once.
+        // (Invariant holds regardless of which aliases the shared store has.)
+        let db = EmojiDatabase.shared
+        for q in ["cmd", "a", "star", "arrow", "note", "play"] {
+            let hexes = FuzzyMatcher.search(
+                query: q, in: db, usage: [:],
+                corpus: .emojiAndSymbols, useFrequencyBoost: false, limit: 240
+            ).map { $0.emoji.hexcode }
+            #expect(Set(hexes).count == hexes.count, "duplicate hexcode for query \(q)")
+        }
+    }
+
     @Test func emojiAndSymbolsCorpusSpansBoth() {
         // The combined corpus should surface emoji for an emoji query and
         // symbols for a symbol query.


### PR DESCRIPTION
Adds user-defined `:word:` aliases that resolve to any emoji or symbol, managed in **Settings ▸ Aliases**.

## What's here
- **Alias store + index merge** — `AliasStore` persists `alias → hexcode` in UserDefaults; `EmojiDatabase.buildIndex` layers aliases onto the baked corpus. An alias overrides a built-in shortcode of the same spelling and gets a fuzzy-ranking bonus, so `:check` ranks ✅ above ✔️/🏁.
- **Symbols as alias targets** — the add-alias picker forces the symbol corpus in regardless of the global Symbols toggle. A `SYM_` target resolves against `SymbolsDatabase` and becomes a first-class indexed row, so `:word:` both inserts and fuzzy-matches the symbol even when Symbols is off. Guarded so the slow CoreText sweep only runs when a symbol alias exists.
- **Settings UI** — new Aliases tab (`square.on.square` icon): add/remove/clear, live glyph preview, duplicate detection, shared emoji/symbol browser.
- **More curated symbols** — ~50 additions whose swept Unicode names are unsearchable (math/logic ∫ ∂ ∇ ∈ ∪ ∩ ∀ ∃ ¬ ∧ ∨ ≡, rotate/refresh arrows ↻ ↺ ↔ ↕ ↦, editorial marks † ‡ № ′ ″ ‰ · ‽, plain-text checkboxes ☐ ☑ ☒, music ♩ ♪ ♫ ♭ ♮ ♯, ⅓ ⅔), each with the terms people actually type. All verified to render without tofu.
- **Apple logo** () added as a curated symbol — a private-use glyph only Apple fonts draw (which is why the sweep filters it out); curated entries bypass that gate, so it's opt-in.
- **Bug fix** — the shared emoji browser showed the most-used row on the first search render (a `ForEach` cell-identity collision); search cells now key by hexcode.

## Test plan
- `xcodebuild test` — 245 tests pass, including new `AliasStoreTests` / `AliasIndexTests` (15 alias-specific) covering normalization, upsert, persistence, override precedence, ranking flips, and symbol targets.
- Manual: add an emoji alias and a symbol alias (e.g. `:cmd:` → ⌘), confirm both insert on `:word:` and surface in live fuzzy search; verify first-search results are correct.

Refs W-453