### PR TITLE
W-547: keep focus-cache AX seeding off the keystroke path

### DIFF
--- a/Sources/Mojito/App/Engine.swift
+++ b/Sources/Mojito/App/Engine.swift
@@ -199,6 +199,12 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
             }
         }
 
+        FocusedElementCache.shared.onSeedInstalled = { [weak self] in
+            MainActor.assumeIsolated {
+                self?.reconcileCaptureAfterSeed()
+            }
+        }
+
         prefsObserver = NotificationCenter.default.addObserver(
             forName: UserDefaults.didChangeNotification,
             object: UserDefaults.standard,
@@ -297,6 +303,27 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
             cancelCapture()
         }
         // Nil current element = transient focus-transition state; wait for the next callback.
+    }
+
+    /// Focus can move *within* an app during the post-switch seed window —
+    /// the AX observer isn't registered yet, so no callback fires, and the
+    /// seed then publishes the moved-to element silently. Compare it against
+    /// the capture snapshot and cancel on a positive mismatch, so a pick
+    /// can't delete from a field the user never typed the query into.
+    /// Unlike `handleFocusChanged` this must not treat "can't tell" (nil on
+    /// either side) as a change, and must not touch the emoticon-undo window:
+    /// a landing seed is not a user action.
+    private func reconcileCaptureAfterSeed() {
+        switch stateMachine.state {
+        case .capturing, .stickyPicking, .browsing:
+            break
+        default:
+            return
+        }
+        guard let snapshot = captureFocusSnapshot,
+              let current = FocusedElementCache.shared.element,
+              !CFEqual(snapshot, current) else { return }
+        cancelCapture()
     }
 
     private func cancelCapture() {

--- a/Sources/Mojito/App/Engine.swift
+++ b/Sources/Mojito/App/Engine.swift
@@ -507,8 +507,11 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
                 "hasURL": "\(context.url != nil)",
             ])
             // Snapshot now so the deferred picker show and any focus-change
-            // notifications can detect movement out from under us.
-            captureFocusSnapshot = FocusedElementCache.shared.element
+            // notifications can detect movement out from under us. From the
+            // context, not the cache — the cache is nil while a post-switch
+            // seed is in flight, and a nil snapshot cancels the capture on
+            // the next AX callback.
+            captureFocusSnapshot = context.focusedElement
             captureFocusPID = FocusedElementCache.shared.focusedPID
         }
 
@@ -938,7 +941,10 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
             deleteCount = 0
         }
         captureContext = context
-        captureFocusSnapshot = FocusedElementCache.shared.element
+        // From the context, not the cache — see the capture-open snapshot.
+        // Nil is reserved for a genuine no-focus context (e.g. the Finder),
+        // which the browser deliberately tolerates.
+        captureFocusSnapshot = context.focusedElement
         captureFocusPID = FocusedElementCache.shared.focusedPID
         expandToBrowser(deleteCount: deleteCount)
     }

--- a/Sources/Mojito/Context/AppContext.swift
+++ b/Sources/Mojito/Context/AppContext.swift
@@ -12,6 +12,12 @@ struct ActiveContext {
     /// trigger stays inert (nothing to autocomplete into) and emoji picks are
     /// copied to the clipboard instead of synthesized as keystrokes.
     let focusedFieldIsEditable: Bool
+    /// The focused AX element the field checks above were answered from —
+    /// cache when warm, fresh system-wide query otherwise. Capture snapshots
+    /// must use this, not the cache directly: right after an app switch the
+    /// cache is intentionally nil while its background seed is in flight, and
+    /// a nil snapshot would read as "opened with no focused field".
+    let focusedElement: AXUIElement?
 }
 
 @MainActor
@@ -21,21 +27,25 @@ enum AppContextDetector {
         let bundleID = app?.bundleIdentifier
         let pid = app?.processIdentifier
         let url = BrowserURL.detect(bundleID: bundleID, pid: pid)
+        // Resolve once and reuse — each fallback resolution is a synchronous
+        // cross-process AX call.
+        let focused = resolveFocusedElement()
         return ActiveContext(
             bundleID: bundleID,
             processID: pid,
             url: url,
-            focusedFieldIsSecure: focusedFieldIsSecure(),
-            focusedFieldIsEditable: focusedFieldIsEditable()
+            focusedFieldIsSecure: focusedFieldIsSecure(focused),
+            focusedFieldIsEditable: focusedFieldIsEditable(focused),
+            focusedElement: focused
         )
     }
 
     /// True if AXSecureTextField, OR if AX is too broken to tell.
     /// False positives just mean the picker doesn't open in odd contexts;
     /// false negatives leak password fragments. Easy tradeoff.
-    private static func focusedFieldIsSecure() -> Bool {
+    private static func focusedFieldIsSecure(_ focused: AXUIElement?) -> Bool {
         // No focused element = mid-transition; allow capture rather than block.
-        guard let focused = resolveFocusedElement() else { return false }
+        guard let focused else { return false }
         guard let role = copyString(focused, kAXRoleAttribute) else { return true }
         // String literal because `kAXSecureTextFieldRole` isn't reliably
         // bridged across SDK versions. Electron/web password inputs that
@@ -63,8 +73,8 @@ enum AppContextDetector {
     /// `true` (the browser hotkey is explicit, and synthetic keystrokes land in
     /// fields AX can't fully describe); only no focused element at all, or a
     /// positively non-text control, reads as false.
-    private static func focusedFieldIsEditable() -> Bool {
-        guard let focused = resolveFocusedElement() else { return false }
+    private static func focusedFieldIsEditable(_ focused: AXUIElement?) -> Bool {
+        guard let focused else { return false }
         // Role first: a positively non-text element (e.g. a read-only label
         // that still exposes a selection range) has nowhere to type.
         if let role = copyString(focused, kAXRoleAttribute) {

--- a/Sources/Mojito/Context/FocusedElementCache.swift
+++ b/Sources/Mojito/Context/FocusedElementCache.swift
@@ -1,5 +1,6 @@
 import AppKit
 import ApplicationServices
+import os
 
 /// AX-focused element cache. `AXUIElementCopyAttributeValue(system, …)`
 /// is a synchronous cross-process IPC that can stall hundreds of ms on
@@ -34,8 +35,12 @@ final class FocusedElementCache {
     private var workspaceObserver: NSObjectProtocol?
 
     /// Invalidates in-flight background seeds when a newer activation
-    /// supersedes them.
-    private var refreshGeneration = 0
+    /// supersedes them. Lock-protected (not main-actor state) so `seed` can
+    /// check staleness from the background queue and skip its blocking IPC
+    /// instead of running a full round-trip only to be discarded — under a
+    /// sustained activation storm those dead seeds would otherwise queue up
+    /// serially and delay the one that matters.
+    private let refreshGeneration = OSAllocatedUnfairLock(initialState: 0)
 
     /// Coalesces activation bursts (banner appears → app reactivates within
     /// ~100ms) into one seed round-trip.
@@ -77,7 +82,10 @@ final class FocusedElementCache {
     /// seed off the main thread.
     private func refreshActiveApp() {
         teardownObserver()
-        refreshGeneration += 1
+        let generation = refreshGeneration.withLock { value in
+            value += 1
+            return value
+        }
         pendingSeed?.cancel()
 
         guard let app = NSWorkspace.shared.frontmostApplication else {
@@ -92,7 +100,6 @@ final class FocusedElementCache {
         DebugRecorder.record(.focus, "app", ["bundleID": app.bundleIdentifier ?? "—"])
         onFocusChange?()
 
-        let generation = refreshGeneration
         let work = DispatchWorkItem { [weak self] in
             Self.seedQueue.async { self?.seed(pid: pid, generation: generation) }
         }
@@ -101,8 +108,12 @@ final class FocusedElementCache {
     }
 
     /// Runs on `seedQueue`. Both AX calls here block on the target app's
-    /// reply, which is the whole reason they're off the main thread.
+    /// reply, which is the whole reason they're off the main thread. A seed
+    /// superseded by a newer activation bails before each round-trip — its
+    /// result would be discarded anyway, and dead seeds draining serially
+    /// would delay the live one.
     private nonisolated func seed(pid: pid_t, generation: Int) {
+        guard refreshGeneration.withLock({ $0 }) == generation else { return }
         let axApp = AXUIElementCreateApplication(pid)
         AXUIElementSetMessagingTimeout(axApp, Self.seedTimeout)
 
@@ -129,6 +140,7 @@ final class FocusedElementCache {
         }
         let refcon = Unmanaged.passUnretained(self).toOpaque()
 
+        guard refreshGeneration.withLock({ $0 }) == generation else { return }
         var newObserver: AXObserver?
         if AXObserverCreate(pid, callback, &newObserver) == .success, let obs = newObserver {
             // Best-effort — fails for system apps / non-AX apps; the seeded
@@ -150,8 +162,12 @@ final class FocusedElementCache {
     }
 
     /// Publishes a finished seed, unless a newer activation made it stale.
+    /// Deliberately does NOT fire `onFocusChange`: focus hasn't moved — this
+    /// is the same focus the activation-time fire announced, just resolved.
+    /// A synthetic fire here would cancel a capture the user started during
+    /// the seed window (its snapshot is nil) and clear a fresh emoticon undo.
     private func install(seeded: AXUIElement?, observer: AXObserver?, pid: pid_t, generation: Int) {
-        guard generation == refreshGeneration else { return }
+        guard generation == refreshGeneration.withLock({ $0 }) else { return }
         element = seeded
         if let observer {
             CFRunLoopAddSource(
@@ -162,7 +178,6 @@ final class FocusedElementCache {
             self.observer = observer
             self.observedPID = pid
         }
-        onFocusChange?()
     }
 
     private func teardownObserver() {

--- a/Sources/Mojito/Context/FocusedElementCache.swift
+++ b/Sources/Mojito/Context/FocusedElementCache.swift
@@ -6,6 +6,13 @@ import ApplicationServices
 /// hung / busy apps (Electron under load). Doing that on every `:` and
 /// picker show produced visible lag; this converts to a pointer read.
 ///
+/// The seed query and observer registration are themselves synchronous IPC
+/// into the newly-activated app, so they run on a background queue — the
+/// main thread also services the keystroke event tap, and a focus-flap storm
+/// (notification banners, menu-bar overlay apps) blocking it there stalled
+/// typing system-wide (W-547). Until the seed lands, `element` is nil and
+/// callers fall back to a fresh fetch.
+///
 /// Falls back gracefully: if observer creation fails (no AX permission,
 /// non-introspectable app), `element` returns nil and callers fetch fresh.
 @MainActor
@@ -25,6 +32,24 @@ final class FocusedElementCache {
     private var observer: AXObserver?
     private var observedPID: pid_t?
     private var workspaceObserver: NSObjectProtocol?
+
+    /// Invalidates in-flight background seeds when a newer activation
+    /// supersedes them.
+    private var refreshGeneration = 0
+
+    /// Coalesces activation bursts (banner appears → app reactivates within
+    /// ~100ms) into one seed round-trip.
+    private var pendingSeed: DispatchWorkItem?
+    private static let seedDebounce: TimeInterval = 0.1
+
+    /// Serial so a hung app's seed can't overlap the next one; each call is
+    /// bounded by `seedTimeout` below.
+    private static let seedQueue = DispatchQueue(label: "mojito.ax.focusSeed", qos: .userInitiated)
+
+    /// Per-element AX timeout for the seed round-trips. Tighter than the
+    /// process-wide 0.5s: a stale seed is discarded by the generation check
+    /// anyway, so waiting long for a slow app buys nothing.
+    private static let seedTimeout: Float = 0.25
 
     private init() {
         refreshActiveApp()
@@ -47,8 +72,13 @@ final class FocusedElementCache {
         // dropping our AXObserver reference releases the run loop source.
     }
 
+    /// Synchronous part of an app switch: drop the stale element immediately
+    /// (a cross-app pointer must never be served) and schedule the IPC-heavy
+    /// seed off the main thread.
     private func refreshActiveApp() {
         teardownObserver()
+        refreshGeneration += 1
+        pendingSeed?.cancel()
 
         guard let app = NSWorkspace.shared.frontmostApplication else {
             element = nil
@@ -57,23 +87,35 @@ final class FocusedElementCache {
             return
         }
         let pid = app.processIdentifier
-        let axApp = AXUIElementCreateApplication(pid)
+        element = nil
+        focusedPID = pid
+        DebugRecorder.record(.focus, "app", ["bundleID": app.bundleIdentifier ?? "—"])
+        onFocusChange?()
 
-        // Seed so the first call after an app switch isn't a miss.
+        let generation = refreshGeneration
+        let work = DispatchWorkItem { [weak self] in
+            Self.seedQueue.async { self?.seed(pid: pid, generation: generation) }
+        }
+        pendingSeed = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.seedDebounce, execute: work)
+    }
+
+    /// Runs on `seedQueue`. Both AX calls here block on the target app's
+    /// reply, which is the whole reason they're off the main thread.
+    private nonisolated func seed(pid: pid_t, generation: Int) {
+        let axApp = AXUIElementCreateApplication(pid)
+        AXUIElementSetMessagingTimeout(axApp, Self.seedTimeout)
+
         var ref: AnyObject?
         let status = AXUIElementCopyAttributeValue(
             axApp,
             kAXFocusedUIElementAttribute as CFString,
             &ref
         )
+        var seeded: AXUIElement?
         if status == .success, let ref, CFGetTypeID(ref) == AXUIElementGetTypeID() {
-            element = (ref as! AXUIElement)
-        } else {
-            element = nil
+            seeded = (ref as! AXUIElement)
         }
-        focusedPID = pid
-        DebugRecorder.record(.focus, "app", ["bundleID": app.bundleIdentifier ?? "—"])
-        onFocusChange?()
 
         // C function pointer — no captures allowed, route via refcon.
         let callback: AXObserverCallback = { _, focusedElement, _, refcon in
@@ -88,30 +130,45 @@ final class FocusedElementCache {
         let refcon = Unmanaged.passUnretained(self).toOpaque()
 
         var newObserver: AXObserver?
-        guard AXObserverCreate(pid, callback, &newObserver) == .success, let obs = newObserver else {
-            return
+        if AXObserverCreate(pid, callback, &newObserver) == .success, let obs = newObserver {
+            // Best-effort — fails for system apps / non-AX apps; the seeded
+            // value still serves. Synchronous IPC, hence off-main.
+            AXObserverAddNotification(
+                obs,
+                axApp,
+                kAXFocusedUIElementChangedNotification as CFString,
+                refcon
+            )
         }
-        // Best-effort — fails for system apps / non-AX apps; the seeded
-        // value still serves.
-        AXObserverAddNotification(
-            obs,
-            axApp,
-            kAXFocusedUIElementChangedNotification as CFString,
-            refcon
-        )
-        CFRunLoopAddSource(
-            CFRunLoopGetCurrent(),
-            AXObserverGetRunLoopSource(obs),
-            .commonModes
-        )
-        self.observer = obs
-        self.observedPID = pid
+        let observer = newObserver
+
+        DispatchQueue.main.async {
+            MainActor.assumeIsolated {
+                self.install(seeded: seeded, observer: observer, pid: pid, generation: generation)
+            }
+        }
+    }
+
+    /// Publishes a finished seed, unless a newer activation made it stale.
+    private func install(seeded: AXUIElement?, observer: AXObserver?, pid: pid_t, generation: Int) {
+        guard generation == refreshGeneration else { return }
+        element = seeded
+        if let observer {
+            CFRunLoopAddSource(
+                CFRunLoopGetMain(),
+                AXObserverGetRunLoopSource(observer),
+                .commonModes
+            )
+            self.observer = observer
+            self.observedPID = pid
+        }
+        onFocusChange?()
     }
 
     private func teardownObserver() {
         if let obs = observer {
             CFRunLoopRemoveSource(
-                CFRunLoopGetCurrent(),
+                CFRunLoopGetMain(),
                 AXObserverGetRunLoopSource(obs),
                 .commonModes
             )

--- a/Sources/Mojito/Context/FocusedElementCache.swift
+++ b/Sources/Mojito/Context/FocusedElementCache.swift
@@ -30,6 +30,12 @@ final class FocusedElementCache {
     /// Fires on every focus change. Engine cancels in-flight captures.
     var onFocusChange: (() -> Void)?
 
+    /// Fires when a background seed publishes its element. NOT a focus
+    /// event — but focus may have moved while the observer wasn't yet
+    /// registered, so Engine reconciles any in-flight capture against the
+    /// freshly seeded element (and only cancels on a positive mismatch).
+    var onSeedInstalled: (() -> Void)?
+
     private var observer: AXObserver?
     private var observedPID: pid_t?
     private var workspaceObserver: NSObjectProtocol?
@@ -143,6 +149,9 @@ final class FocusedElementCache {
         guard refreshGeneration.withLock({ $0 }) == generation else { return }
         var newObserver: AXObserver?
         if AXObserverCreate(pid, callback, &newObserver) == .success, let obs = newObserver {
+            // Re-check after create (local, but a bump can land any time):
+            // the registration below is the blocking IPC worth skipping.
+            guard refreshGeneration.withLock({ $0 }) == generation else { return }
             // Best-effort — fails for system apps / non-AX apps; the seeded
             // value still serves. Synchronous IPC, hence off-main.
             AXObserverAddNotification(
@@ -178,6 +187,7 @@ final class FocusedElementCache {
             self.observer = observer
             self.observedPID = pid
         }
+        onSeedInstalled?()
     }
 
     private func teardownObserver() {

--- a/Sources/Mojito/Context/FocusedElementCache.swift
+++ b/Sources/Mojito/Context/FocusedElementCache.swift
@@ -123,22 +123,11 @@ final class FocusedElementCache {
         let axApp = AXUIElementCreateApplication(pid)
         AXUIElementSetMessagingTimeout(axApp, Self.seedTimeout)
 
-        var ref: AnyObject?
-        let status = AXUIElementCopyAttributeValue(
-            axApp,
-            kAXFocusedUIElementAttribute as CFString,
-            &ref
-        )
-        var seeded: AXUIElement?
-        if status == .success, let ref, CFGetTypeID(ref) == AXUIElementGetTypeID() {
-            seeded = (ref as! AXUIElement)
-        }
-
         // C function pointer — no captures allowed, route via refcon.
         let callback: AXObserverCallback = { _, focusedElement, _, refcon in
             guard let refcon else { return }
             let cache = Unmanaged<FocusedElementCache>.fromOpaque(refcon).takeUnretainedValue()
-            // Source is on the main run loop (added below), so we're on main.
+            // Source is on the main run loop (added in install()), so we're on main.
             MainActor.assumeIsolated {
                 cache.element = focusedElement
                 cache.onFocusChange?()
@@ -146,7 +135,12 @@ final class FocusedElementCache {
         }
         let refcon = Unmanaged.passUnretained(self).toOpaque()
 
-        guard refreshGeneration.withLock({ $0 }) == generation else { return }
+        // Register BEFORE reading the focused element. A move after the read
+        // but before registration would be missed entirely — no callback, and
+        // install() would publish the stale element as truth. Registered
+        // first, a move during/after the read fires a notification that
+        // queues on the observer's mach port and drains once install() adds
+        // the source to the main run loop, correcting the cache.
         var newObserver: AXObserver?
         if AXObserverCreate(pid, callback, &newObserver) == .success, let obs = newObserver {
             // Re-check after create (local, but a bump can land any time):
@@ -162,6 +156,18 @@ final class FocusedElementCache {
             )
         }
         let observer = newObserver
+
+        guard refreshGeneration.withLock({ $0 }) == generation else { return }
+        var ref: AnyObject?
+        let status = AXUIElementCopyAttributeValue(
+            axApp,
+            kAXFocusedUIElementAttribute as CFString,
+            &ref
+        )
+        var seeded: AXUIElement?
+        if status == .success, let ref, CFGetTypeID(ref) == AXUIElementGetTypeID() {
+            seeded = (ref as! AXUIElement)
+        }
 
         DispatchQueue.main.async {
             MainActor.assumeIsolated {


### PR DESCRIPTION
## Summary

Typing lagged system-wide (worst in Safari) whenever the machine saw a storm of app-activation changes — e.g. repeated notification alerts bouncing focus around (#164). Root cause: `FocusedElementCache` re-seeded on every activation with a synchronous cross-process AX query on the main thread, which also services the keystroke event tap. Slow AX responders (alert daemon, menu-bar overlay apps) blocked each refresh up to 0.5s, queuing every keystroke in the session behind it.

This moves the blocking IPC (seed query + `AXObserverAddNotification`) to a serial background queue: the stale element is dropped synchronously on activation (callers already fall back to a fresh fetch on nil), seeds are debounced 100ms to coalesce bursts, a generation counter discards superseded seeds, and seed round-trips get a tighter 0.25s per-element AX timeout.

## Test plan

- `scripts/run-tests.sh` — passes.
- Sampled the app under a simulated activation storm (Finder/Calculator flapping every 400ms): before, ~300ms per 11s of main-thread block inside `AXUIElementCopyAttributeValue` and 5–10x event-pipeline latency degradation (max 234ms); after, zero main-thread AX samples — the wait relocated to the `mojito.ax.focusSeed` queue.
- Manual: picker/trigger flow unaffected; cache falls back to the existing synchronous fetch during the brief post-switch window.

Refs W-547

https://claude.ai/code/session_019hN7nr1KoGNVXLpYsuhih7