### PR TITLE
Comparison table: swap axes and highlight the Mojito column

### DIFF
--- a/best-emoji-app-for-mac/index.html
+++ b/best-emoji-app-for-mac/index.html
@@ -17,7 +17,7 @@
 <meta name="twitter:image" content="https://mojito.wells.ee/og-image.png">
 <link rel="icon" type="image/png" href="/favicon.png">
 <link rel="apple-touch-icon" href="/favicon.png">
-<link rel="stylesheet" href="/style.css?v=75">
+<link rel="stylesheet" href="/style.css?v=76">
 </head>
 <body>
 
@@ -43,15 +43,52 @@
 
   <h2>How the options compare</h2>
   <div class="table-scroll">
-  <table class="code-table compare-table">
+  <table class="compare-table">
     <thead>
-      <tr><th scope="col">App</th><th scope="col">Price</th><th scope="col">Open source</th><th scope="col">Picker style</th><th scope="col">Symbols</th><th scope="col">GIF search</th></tr>
+      <tr>
+        <td class="corner" aria-hidden="true"></td>
+        <th scope="col">Built-in</th>
+        <th scope="col">Rocket</th>
+        <th scope="col">Raycast</th>
+        <th scope="col" class="is-mojito"><img src="/app-icon.png" alt="" width="18" height="18">Mojito</th>
+      </tr>
     </thead>
     <tbody>
-      <tr><td>Built-in (macOS)</td><td>Free</td><td><span class="mark-no">—</span></td><td>Panel</td><td><span class="mark-no">Character Viewer</span></td><td><span class="mark-no">Messages only</span></td></tr>
-      <tr><td>Rocket</td><td>Free · $10 Pro</td><td><span class="mark-no">—</span></td><td>Inline</td><td><span class="mark-no">Pro catalog</span></td><td><span class="mark-no">Saved only*</span></td></tr>
-      <tr><td>Raycast</td><td>Free · from $8/mo</td><td><span class="mark-no">—</span></td><td>Panel, in Raycast</td><td><span class="mark-yes">✓</span></td><td><span class="mark-no">Via extension</span></td></tr>
-      <tr><td>Mojito</td><td>Free</td><td><span class="mark-yes">✓</span> AGPL</td><td>Inline</td><td><span class="mark-yes">✓</span> <code>::</code></td><td><span class="mark-yes">✓</span> <code>:::</code></td></tr>
+      <tr>
+        <th scope="row">Price</th>
+        <td>Free</td>
+        <td>Free · $10 Pro</td>
+        <td>Free · from $8/mo</td>
+        <td class="is-mojito">Free</td>
+      </tr>
+      <tr>
+        <th scope="row">Open source</th>
+        <td><span class="mark-no">—</span></td>
+        <td><span class="mark-no">—</span></td>
+        <td><span class="mark-no">—</span></td>
+        <td class="is-mojito"><span class="mark-yes">✓</span> AGPL</td>
+      </tr>
+      <tr>
+        <th scope="row">Picker style</th>
+        <td>Panel</td>
+        <td>Inline</td>
+        <td>Launcher panel</td>
+        <td class="is-mojito">Inline</td>
+      </tr>
+      <tr>
+        <th scope="row">Symbols</th>
+        <td><span class="mark-no">Character Viewer</span></td>
+        <td><span class="mark-no">Pro catalog</span></td>
+        <td><span class="mark-yes">✓</span></td>
+        <td class="is-mojito"><span class="mark-yes">✓</span> <code>::</code></td>
+      </tr>
+      <tr>
+        <th scope="row">GIF search</th>
+        <td><span class="mark-no">Messages only</span></td>
+        <td><span class="mark-no">Saved only*</span></td>
+        <td><span class="mark-no">Via extension</span></td>
+        <td class="is-mojito"><span class="mark-yes">✓</span> <code>:::</code></td>
+      </tr>
     </tbody>
   </table>
   </div>

--- a/check-mark-mac/index.html
+++ b/check-mark-mac/index.html
@@ -17,7 +17,7 @@
 <meta name="twitter:image" content="https://mojito.wells.ee/og-image.png">
 <link rel="icon" type="image/png" href="/favicon.png">
 <link rel="apple-touch-icon" href="/favicon.png">
-<link rel="stylesheet" href="/style.css?v=75">
+<link rel="stylesheet" href="/style.css?v=76">
 </head>
 <body>
 

--- a/copyright-trademark-symbols-mac/index.html
+++ b/copyright-trademark-symbols-mac/index.html
@@ -17,7 +17,7 @@
 <meta name="twitter:image" content="https://mojito.wells.ee/og-image.png">
 <link rel="icon" type="image/png" href="/favicon.png">
 <link rel="apple-touch-icon" href="/favicon.png">
-<link rel="stylesheet" href="/style.css?v=75">
+<link rel="stylesheet" href="/style.css?v=76">
 </head>
 <body>
 

--- a/currency-symbols-mac/index.html
+++ b/currency-symbols-mac/index.html
@@ -17,7 +17,7 @@
 <meta name="twitter:image" content="https://mojito.wells.ee/og-image.png">
 <link rel="icon" type="image/png" href="/favicon.png">
 <link rel="apple-touch-icon" href="/favicon.png">
-<link rel="stylesheet" href="/style.css?v=75">
+<link rel="stylesheet" href="/style.css?v=76">
 </head>
 <body>
 

--- a/degree-symbol-mac/index.html
+++ b/degree-symbol-mac/index.html
@@ -17,7 +17,7 @@
 <meta name="twitter:image" content="https://mojito.wells.ee/og-image.png">
 <link rel="icon" type="image/png" href="/favicon.png">
 <link rel="apple-touch-icon" href="/favicon.png">
-<link rel="stylesheet" href="/style.css?v=75">
+<link rel="stylesheet" href="/style.css?v=76">
 </head>
 <body>
 

--- a/em-dash-mac/index.html
+++ b/em-dash-mac/index.html
@@ -17,7 +17,7 @@
 <meta name="twitter:image" content="https://mojito.wells.ee/og-image.png">
 <link rel="icon" type="image/png" href="/favicon.png">
 <link rel="apple-touch-icon" href="/favicon.png">
-<link rel="stylesheet" href="/style.css?v=75">
+<link rel="stylesheet" href="/style.css?v=76">
 </head>
 <body>
 

--- a/emoji-picker-not-working-mac/index.html
+++ b/emoji-picker-not-working-mac/index.html
@@ -17,7 +17,7 @@
 <meta name="twitter:image" content="https://mojito.wells.ee/og-image.png">
 <link rel="icon" type="image/png" href="/favicon.png">
 <link rel="apple-touch-icon" href="/favicon.png">
-<link rel="stylesheet" href="/style.css?v=75">
+<link rel="stylesheet" href="/style.css?v=76">
 </head>
 <body>
 

--- a/emoji-shortcodes/index.html
+++ b/emoji-shortcodes/index.html
@@ -17,7 +17,7 @@
 <meta name="twitter:image" content="https://mojito.wells.ee/og-image.png">
 <link rel="icon" type="image/png" href="/favicon.png">
 <link rel="apple-touch-icon" href="/favicon.png">
-<link rel="stylesheet" href="/style.css?v=75">
+<link rel="stylesheet" href="/style.css?v=76">
 </head>
 <body>
 

--- a/emoji-shortcuts-mac/index.html
+++ b/emoji-shortcuts-mac/index.html
@@ -17,7 +17,7 @@
 <meta name="twitter:image" content="https://mojito.wells.ee/og-image.png">
 <link rel="icon" type="image/png" href="/favicon.png">
 <link rel="apple-touch-icon" href="/favicon.png">
-<link rel="stylesheet" href="/style.css?v=75">
+<link rel="stylesheet" href="/style.css?v=76">
 </head>
 <body>
 

--- a/guides/index.html
+++ b/guides/index.html
@@ -17,7 +17,7 @@
 <meta name="twitter:image" content="https://mojito.wells.ee/og-image.png">
 <link rel="icon" type="image/png" href="/favicon.png">
 <link rel="apple-touch-icon" href="/favicon.png">
-<link rel="stylesheet" href="/style.css?v=75">
+<link rel="stylesheet" href="/style.css?v=76">
 </head>
 <body>
 

--- a/how-to-send-gifs-on-mac/index.html
+++ b/how-to-send-gifs-on-mac/index.html
@@ -17,7 +17,7 @@
 <meta name="twitter:image" content="https://mojito.wells.ee/og-image.png">
 <link rel="icon" type="image/png" href="/favicon.png">
 <link rel="apple-touch-icon" href="/favicon.png">
-<link rel="stylesheet" href="/style.css?v=75">
+<link rel="stylesheet" href="/style.css?v=76">
 </head>
 <body>
 

--- a/how-to-type-emoji-on-mac/index.html
+++ b/how-to-type-emoji-on-mac/index.html
@@ -17,7 +17,7 @@
 <meta name="twitter:image" content="https://mojito.wells.ee/og-image.png">
 <link rel="icon" type="image/png" href="/favicon.png">
 <link rel="apple-touch-icon" href="/favicon.png">
-<link rel="stylesheet" href="/style.css?v=75">
+<link rel="stylesheet" href="/style.css?v=76">
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
 <link rel="alternate" hreflang="he" href="https://mojito.wells.ee/?lang=he">
 <link rel="preload" as="image" fetchpriority="high" href="wallpaper.webp" type="image/webp" media="(prefers-color-scheme: light)">
 <link rel="preload" as="image" fetchpriority="high" href="wallpaper-dark.webp" type="image/webp" media="(prefers-color-scheme: dark)">
-<link rel="stylesheet" href="style.css?v=75">
+<link rel="stylesheet" href="style.css?v=76">
 <script src="i18n.js?v=4"></script>
 </head>
 <body>

--- a/mac-emoji-picker/index.html
+++ b/mac-emoji-picker/index.html
@@ -17,7 +17,7 @@
 <meta name="twitter:image" content="https://mojito.wells.ee/og-image.png">
 <link rel="icon" type="image/png" href="/favicon.png">
 <link rel="apple-touch-icon" href="/favicon.png">
-<link rel="stylesheet" href="/style.css?v=75">
+<link rel="stylesheet" href="/style.css?v=76">
 </head>
 <body>
 

--- a/mac-key-symbols/index.html
+++ b/mac-key-symbols/index.html
@@ -17,7 +17,7 @@
 <meta name="twitter:image" content="https://mojito.wells.ee/og-image.png">
 <link rel="icon" type="image/png" href="/favicon.png">
 <link rel="apple-touch-icon" href="/favicon.png">
-<link rel="stylesheet" href="/style.css?v=75">
+<link rel="stylesheet" href="/style.css?v=76">
 </head>
 <body>
 

--- a/math-symbols-mac/index.html
+++ b/math-symbols-mac/index.html
@@ -17,7 +17,7 @@
 <meta name="twitter:image" content="https://mojito.wells.ee/og-image.png">
 <link rel="icon" type="image/png" href="/favicon.png">
 <link rel="apple-touch-icon" href="/favicon.png">
-<link rel="stylesheet" href="/style.css?v=75">
+<link rel="stylesheet" href="/style.css?v=76">
 </head>
 <body>
 

--- a/style.css
+++ b/style.css
@@ -2068,12 +2068,67 @@ code { unicode-bidi: isolate; }
 .code-table tbody td:first-child { border-radius: 8px 0 0 8px; }
 .code-table tbody td:last-child { border-radius: 0 8px 8px 0; }
 
-/* Comparison tables: first column is a name, not a glyph. */
-.compare-table td:first-child {
-  width: auto;
+/* App-comparison table: features run down the side, apps across the top,
+   and the Mojito column is called out. Standalone styling — deliberately
+   not the shared .code-table zebra/radius rules — so the symbol tables on
+   other guide pages are untouched. */
+.compare-table {
+  --mojito-ring: color-mix(in srgb, var(--accent) 26%, transparent);
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin: 6px 0 18px;
   font-size: 14px;
+}
+.compare-table th,
+.compare-table td {
+  padding: 11px 14px;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+}
+.compare-table tbody tr:last-child th,
+.compare-table tbody tr:last-child td { border-bottom: none; }
+/* Column headers = app names. */
+.compare-table thead th {
   font-weight: 600;
+  color: var(--text);
+  vertical-align: bottom;
+}
+.compare-table thead th img {
+  vertical-align: -4px;
+  margin-right: 6px;
+}
+/* Row headers = feature names: quiet uppercase label, pinned as the table
+   scrolls sideways on narrow screens. */
+.compare-table tbody th,
+.compare-table .corner {
+  position: sticky;
+  left: 0;
+  background: var(--bg);
+}
+.compare-table tbody th {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-soft);
   white-space: nowrap;
+}
+/* Mojito column: tinted panel with an accent ring, rounded top and bottom. */
+.compare-table .is-mojito {
+  background: color-mix(in srgb, var(--accent) 8%, var(--bg));
+  border-left: 1px solid var(--mojito-ring);
+  border-right: 1px solid var(--mojito-ring);
+}
+.compare-table thead th.is-mojito {
+  color: var(--accent-hover);
+  border-top: 1px solid var(--mojito-ring);
+  border-bottom-color: var(--mojito-ring);
+  border-radius: 10px 10px 0 0;
+}
+.compare-table tbody tr:last-child .is-mojito {
+  border-bottom: 1px solid var(--mojito-ring);
+  border-radius: 0 0 10px 10px;
 }
 .mark-yes { color: var(--accent-hover); font-weight: 600; }
 .mark-no { color: var(--text-soft); }
@@ -2088,7 +2143,8 @@ code { unicode-bidi: isolate; }
   overflow-x: auto;
   margin: 6px 0 18px;
 }
-.table-scroll .code-table { margin: 0; min-width: 540px; }
+.table-scroll .code-table,
+.table-scroll .compare-table { margin: 0; min-width: 540px; }
 
 /* /guides/ hub: glyph cards instead of a flat link list. The glyph
    is the guide's own subject — °, ⌘, π — doing the wayfinding. */


### PR DESCRIPTION
Follow-up to the guide design pass (#172). Redesigns the app-comparison table on `best-emoji-app-for-mac/`.

## What changed
- **Swapped axes** — apps run across the top as columns, features down the side. Reads as a product comparison instead of a flat grid.
- **Mojito column called out** — tinted panel, accent ring, app icon in the header, accent label. The "why Mojito" is visual, not just prose.
- Feature labels are quiet uppercase row headers, pinned sticky-left so they stay visible when the table scrolls sideways on mobile.
- `.compare-table` gets standalone CSS (dropped shared `.code-table`), so the symbol tables on other guide pages are untouched.
- Bumped `style.css` cache-buster v75 → v76 across the guide pages.

## Test plan
Headless Chrome at 820px (light + dark) and 375px: no document overflow, sticky labels hold, Mojito column ring/tint renders in both themes.

Refs: W-554