### PR TITLE
Add v1.9.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ single source of truth for that release: `scripts/release.sh` extracts it for
 both the GitHub Release body and the Sparkle update notes shown in the in-app
 updater.
 
+## v1.9.0
+
+## New
+- **Search by what you mean, not just what it's called:** `:deploy:` finds 🚀, `:ghosting:` finds 👻, `:urgent:` finds 🚨. Around 8,300 everyday-concept keywords were added on top of the official emoji names. ([#183](https://github.com/wr/mojito/pull/183))
+- **Inflected words work too:** `:ghosted:`, `:deployed:`, `:launching:`, and `:parties:` now find what you'd expect. ([#185](https://github.com/wr/mojito/pull/185))
+
+## Fixed
+- A query with no real match now shows nothing instead of an unrelated emoji. `:yeet:` used to return 🐞, because those four letters happen to appear scattered through "lady beetle". ([#183](https://github.com/wr/mojito/pull/183))
+
 ## v1.8.1
 
 ## New


### PR DESCRIPTION
Release notes for the semantic search work (#183, #185). `release.sh` extracts this section for both the GitHub Release body and the in-app Sparkle update notes, so it has to land before tagging v1.9.0.