### PR TITLE
Tag releases at the commit that carries the version

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -20,8 +20,13 @@
 #   2. Wraps Mojito.app in a DMG with create-dmg.
 #   3. Submits the DMG to Apple notarytool, waits, staples.
 #   4. Signs the DMG with Sparkle's EdDSA key, captures the signature.
-#   5. Creates a GitHub Release with the DMG attached (via gh CLI).
-#   6. Updates appcast.xml on the gh-pages branch with the new entry.
+#   5. Commits the version bump to main and pushes it.
+#   6. Creates a GitHub Release with the DMG attached (via gh CLI), tagged at
+#      that commit — so the tag describes the source the DMG was built from.
+#   7. Updates appcast.xml on the gh-pages branch with the new entry.
+#
+# Must be run from a clean `main` that's in sync with origin; it refuses
+# otherwise, since step 5 would otherwise commit unrelated work.
 #
 # Things you must do before this works:
 #   - Apple Developer Program membership ($99/yr).
@@ -95,6 +100,30 @@ CHANGELOG_CHECK=$(awk -v header="## v$VERSION" '
 if [[ -z "$CHANGELOG_CHECK" ]]; then
     echo "error: no '## v$VERSION' section found in CHANGELOG.md." >&2
     echo "       Add a '## v$VERSION' entry before releasing." >&2
+    exit 1
+fi
+
+# The version bump is committed and tagged further down, so the tree has to be
+# clean going in — otherwise that commit sweeps up whatever else is lying
+# around, and the tag stops describing the released source.
+RELEASE_BRANCH="main"
+CURRENT_BRANCH=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)
+if [[ "$CURRENT_BRANCH" != "$RELEASE_BRANCH" ]]; then
+    echo "error: on branch '$CURRENT_BRANCH', expected '$RELEASE_BRANCH'." >&2
+    exit 1
+fi
+if [[ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]]; then
+    echo "error: working tree is dirty. Commit or stash first:" >&2
+    git -C "$REPO_ROOT" status --short >&2
+    exit 1
+fi
+# Checked now so the push at the end can't fail after the release is public.
+git -C "$REPO_ROOT" fetch --quiet origin "$RELEASE_BRANCH"
+AHEAD=$(git -C "$REPO_ROOT" rev-list --count "origin/$RELEASE_BRANCH..HEAD")
+BEHIND=$(git -C "$REPO_ROOT" rev-list --count "HEAD..origin/$RELEASE_BRANCH")
+if [[ "$AHEAD" != "0" || "$BEHIND" != "0" ]]; then
+    echo "error: $RELEASE_BRANCH is out of sync with origin" \
+         "($AHEAD ahead, $BEHIND behind). Pull/push first." >&2
     exit 1
 fi
 
@@ -244,6 +273,15 @@ if [[ ! -s "$CHANGELOG_FRAGMENT" ]]; then
     exit 1
 fi
 
+# Land the version bump before tagging, so `v$VERSION` points at source that
+# actually carries $VERSION. Deliberately after the build/notarize/sign steps:
+# those are the ones that fail, and a failed run should leave no commit behind.
+echo "→ Committing version bump"
+git -C "$REPO_ROOT" add project.yml "$APP_NAME.xcodeproj/project.pbxproj"
+git -C "$REPO_ROOT" commit -q -m "Release v$VERSION"
+git -C "$REPO_ROOT" push --quiet origin "$RELEASE_BRANCH"
+RELEASE_SHA=$(git -C "$REPO_ROOT" rev-parse HEAD)
+
 echo "→ Creating GitHub Release"
 RELEASE_NOTES_FILE=$(mktemp)
 {
@@ -254,6 +292,7 @@ RELEASE_NOTES_FILE=$(mktemp)
 
 gh release create "v$VERSION" "$DMG_PATH" \
     --repo "$GITHUB_REPO" \
+    --target "$RELEASE_SHA" \
     --title "v$VERSION" \
     --notes-file "$RELEASE_NOTES_FILE"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -106,7 +106,7 @@ fi
 # The version bump is committed and tagged further down, so the tree has to be
 # clean going in — otherwise that commit sweeps up whatever else is lying
 # around, and the tag stops describing the released source.
-RELEASE_BRANCH="wells/release-script-tag-fix"
+RELEASE_BRANCH="main"
 CURRENT_BRANCH=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)
 if [[ "$CURRENT_BRANCH" != "$RELEASE_BRANCH" ]]; then
     echo "error: on branch '$CURRENT_BRANCH', expected '$RELEASE_BRANCH'." >&2

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -106,7 +106,7 @@ fi
 # The version bump is committed and tagged further down, so the tree has to be
 # clean going in — otherwise that commit sweeps up whatever else is lying
 # around, and the tag stops describing the released source.
-RELEASE_BRANCH="main"
+RELEASE_BRANCH="wells/release-script-tag-fix"
 CURRENT_BRANCH=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)
 if [[ "$CURRENT_BRANCH" != "$RELEASE_BRANCH" ]]; then
     echo "error: on branch '$CURRENT_BRANCH', expected '$RELEASE_BRANCH'." >&2

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -117,6 +117,31 @@ if [[ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]]; then
     git -C "$REPO_ROOT" status --short >&2
     exit 1
 fi
+# The bump is pushed to `origin` but the release is cut against $GITHUB_REPO.
+# If those are different repos every other guard still passes, and then
+# `--target` fails because origin's new SHA doesn't exist in $GITHUB_REPO.
+ORIGIN_URL=$(git -C "$REPO_ROOT" remote get-url origin)
+if [[ "$ORIGIN_URL" != *"$GITHUB_REPO"* ]]; then
+    echo "error: origin ($ORIGIN_URL) is not GITHUB_REPO ($GITHUB_REPO)." >&2
+    exit 1
+fi
+
+# Stop a re-run of an already-released version *before* it pushes anything.
+# The bump is unconditional, so without this a retry burns a build number and
+# lands a public "Release vX.Y.Z" commit, only to die at `gh release create`.
+if git -C "$REPO_ROOT" ls-remote --exit-code --tags origin "refs/tags/v$VERSION" >/dev/null 2>&1; then
+    echo "error: tag v$VERSION already exists on origin." >&2
+    echo "       Releasing the same version twice isn't supported — bump it." >&2
+    exit 1
+fi
+# Separate check: a partly-failed `gh release create` can leave a draft behind
+# without ever creating the tag, which the check above wouldn't catch.
+if gh release view "v$VERSION" --repo "$GITHUB_REPO" >/dev/null 2>&1; then
+    echo "error: release v$VERSION already exists on $GITHUB_REPO." >&2
+    echo "       Delete it (gh release delete v$VERSION) or bump the version." >&2
+    exit 1
+fi
+
 # Checked now so the push at the end can't fail after the release is public.
 git -C "$REPO_ROOT" fetch --quiet origin "$RELEASE_BRANCH"
 AHEAD=$(git -C "$REPO_ROOT" rev-list --count "origin/$RELEASE_BRANCH..HEAD")


### PR DESCRIPTION
`release.sh` bumps `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION`, then never commits them. It only commits to `gh-pages`. So every tag points at source declaring the *previous* version:

| tag | `project.yml` at that tag |
| -- | -- |
| v1.9.0 | 1.8.1 |
| v1.8.1 | 1.8.0 |
| v1.8.0 | 1.7.0 |

Checking out a release tag doesn't rebuild that release. The bump has been landing as a manual `Release vX.Y.Z` commit afterwards, one commit too late.

## Change

Commit the bump inside the script and tag the release at that commit (`gh release create --target`).

Placement is deliberate: the commit happens **after** build, notarize, staple and sign — the steps that actually fail — so a run that dies partway leaves no stray commit behind. Everything before that point is reversible.

## Preflight

Committing from the script means the working tree has to be trustworthy, so it now refuses to start unless:

- you're on `main` — not a feature branch
- the tree is clean — otherwise the bump commit sweeps up unrelated work
- `main` is in sync with `origin` — checked up front so the push at the end can't fail *after* the release is already public

All three run before the ~4-minute build, alongside the existing changelog and `SUPublicEDKey` checks.

## Test plan

Each guard exercised against the real script, not a copy:

| condition | result |
| -- | -- |
| feature branch | `error: on branch 'wells/release-script-tag-fix', expected 'main'.` |
| uncommitted changes | `error: working tree is dirty. Commit or stash first:` + `git status --short` |
| 1 commit unpushed | `error: … is out of sync with origin (1 ahead, 0 behind). Pull/push first.` |
| clean and in sync | proceeds past preflight |

`bash -n` clean. The commit/tag path itself runs only during a real release — it'll get its first live exercise on v1.9.1.

## Not fixed

The existing v1.8.0 / v1.8.1 / v1.9.0 tags stay where they are. Moving a published tag rewrites history users may already have fetched.

---

## Review round 2

Adversarial review found that the first commit made re-runs *worse* than before, plus a repo-identity hole. Both fixed.

**A retry could publish a junk commit.** The version bump is unconditional, so re-running an already-released version burned a build number and pushed a public `Release vX.Y.Z` commit — then died at `gh release create` on the tag collision. That's a regression the tagging change introduced, and it lands on `main` where everyone sees it.

Now checked before anything is pushed, as two separate guards:
- the tag exists on origin
- a release exists on `$GITHUB_REPO` — a partly-failed `gh release create` can leave a draft behind without ever creating the tag, which a tag check alone misses

**Origin might not be the release repo.** The bump pushes to `origin` while the release is cut against `$GITHUB_REPO`. If those differ (a fork, or a stale `.env`), every other guard passes and `--target` then references a SHA the release repo doesn't have. Now asserted up front.

Verified against the real script: `v1.9.0` → `error: tag v1.9.0 already exists on origin.`

Review also confirmed as sound: detached-HEAD handling, `set -euo pipefail` interaction, the AHEAD/BEHIND arithmetic, `--target` accepting a just-pushed SHA, and that a rejected push leaves only a local commit with nothing published.
