### PR TITLE
W-572: trigger reliably in Slack and other Electron apps

### DIFF
--- a/Sources/Mojito/App/Engine.swift
+++ b/Sources/Mojito/App/Engine.swift
@@ -523,7 +523,10 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
         if stateMachine.captureJustOpened {
             let context = AppContextDetector.current()
             if context.focusedFieldIsSecure {
-                DebugRecorder.record(.engine, "secureFieldBlocked")
+                DebugRecorder.record(.engine, "secureFieldBlocked", [
+                    "haveInfo": "\(context.focusedFieldHaveInfo)",
+                    "role": context.focusedRole ?? "nil",
+                ])
                 stateMachine.reset()
                 return false
             }
@@ -954,7 +957,10 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
         guard isActive else { return }
         let context = AppContextDetector.current()
         if context.focusedFieldIsSecure {
-            DebugRecorder.record(.engine, "secureFieldBlocked")
+            DebugRecorder.record(.engine, "secureFieldBlocked", [
+                "haveInfo": "\(context.focusedFieldHaveInfo)",
+                "role": context.focusedRole ?? "nil",
+            ])
             return
         }
         gifPickerWindow.hide()

--- a/Sources/Mojito/App/Engine.swift
+++ b/Sources/Mojito/App/Engine.swift
@@ -526,6 +526,8 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
                 DebugRecorder.record(.engine, "secureFieldBlocked", [
                     "haveInfo": "\(context.focusedFieldHaveInfo)",
                     "role": context.focusedRole ?? "nil",
+                    "elem": "\(context.focusedElement != nil)",
+                    "editable": "\(context.focusedFieldIsEditable)",
                 ])
                 stateMachine.reset()
                 return false
@@ -960,6 +962,8 @@ final class Engine: ObservableObject, KeyMonitorDelegate {
             DebugRecorder.record(.engine, "secureFieldBlocked", [
                 "haveInfo": "\(context.focusedFieldHaveInfo)",
                 "role": context.focusedRole ?? "nil",
+                "elem": "\(context.focusedElement != nil)",
+                "editable": "\(context.focusedFieldIsEditable)",
             ])
             return
         }

--- a/Sources/Mojito/Context/AppContext.swift
+++ b/Sources/Mojito/Context/AppContext.swift
@@ -12,6 +12,13 @@ struct ActiveContext {
     /// trigger stays inert (nothing to autocomplete into) and emoji picks are
     /// copied to the clipboard instead of synthesized as keystrokes.
     let focusedFieldIsEditable: Bool
+    /// Whether the cache had a resolved classification when this context was
+    /// built. False = the field checks fell back to their fail-closed defaults
+    /// (secure=true, editable=false) because the off-thread classify hadn't
+    /// published yet. Diagnostics only.
+    let focusedFieldHaveInfo: Bool
+    /// Raw AXRole the classification was read from, or nil. Diagnostics only.
+    let focusedRole: String?
     /// The focused AX element the field checks above were answered from.
     /// Capture snapshots must use this, not the cache directly: right after an
     /// app switch the cache is intentionally nil while its background seed is in
@@ -31,6 +38,8 @@ enum AppContextDetector {
         let cache = FocusedElementCache.shared
         let secure: Bool
         let editable: Bool
+        let haveInfo = cache.haveFieldInfo
+        let role = cache.focusedRole
         if cache.haveFieldInfo {
             secure = cache.focusedIsSecure
             editable = cache.focusedIsEditable
@@ -47,6 +56,8 @@ enum AppContextDetector {
             url: url,
             focusedFieldIsSecure: secure,
             focusedFieldIsEditable: editable,
+            focusedFieldHaveInfo: haveInfo,
+            focusedRole: role,
             focusedElement: cache.element
         )
     }
@@ -55,8 +66,8 @@ enum AppContextDetector {
     /// `FocusedElementCache` can run it on its background seed queue — these are
     /// synchronous cross-process AX calls and must never run on the tap thread.
     /// The caller pins a messaging timeout on `element` first.
-    nonisolated static func classify(_ element: AXUIElement) -> (secure: Bool, editable: Bool) {
-        (secure: isSecure(element), editable: isEditable(element))
+    nonisolated static func classify(_ element: AXUIElement) -> (secure: Bool, editable: Bool, role: String?) {
+        (secure: isSecure(element), editable: isEditable(element), role: copyString(element, kAXRoleAttribute))
     }
 
     /// True if AXSecureTextField, OR if AX is too broken to tell (fail closed —

--- a/Sources/Mojito/Context/AppContext.swift
+++ b/Sources/Mojito/Context/AppContext.swift
@@ -74,11 +74,18 @@ enum AppContextDetector {
     /// a false positive just declines the picker; a false negative leaks
     /// password fragments).
     private nonisolated static func isSecure(_ focused: AXUIElement) -> Bool {
+        // A missing role means AX is too broken to tell — fail closed.
         guard let role = copyString(focused, kAXRoleAttribute) else { return true }
-        // String literal because `kAXSecureTextFieldRole` isn't reliably
-        // bridged across SDK versions. Electron/web password inputs that
-        // masquerade as AXTextField rely on the app/URL exclusion list.
+        // "AXSecureTextField" is a *subrole*, not a role (there is no
+        // kAXSecureTextFieldRole). Native NSSecureTextField and Chromium/WebKit
+        // <input type=password> all report role AXTextField with this subrole,
+        // so matching the subrole is what actually catches password fields —
+        // across native, Electron, and web. Load-bearing now that we enable
+        // Electron/web AX trees (W-572): those fields used to be invisible and
+        // leaned on the exclusion list; the subrole check protects them
+        // directly. Role kept as a defensive OR at zero cost.
         return role == "AXSecureTextField"
+            || copyString(focused, kAXSubroleAttribute) == "AXSecureTextField"
     }
 
     /// Text inputs whose value isn't reported as settable still count.

--- a/Sources/Mojito/Context/FocusedElementCache.swift
+++ b/Sources/Mojito/Context/FocusedElementCache.swift
@@ -174,15 +174,6 @@ final class FocusedElementCache {
         let axApp = AXUIElementCreateApplication(pid)
         AXUIElementSetMessagingTimeout(axApp, Self.seedTimeout)
 
-        // Chromium/Electron apps (Slack, VS Code, Discord…) gate their AX tree
-        // behind this attribute: until a client sets it, the app exposes no
-        // focused element, so the seed reads nil and every trigger fails closed
-        // as "unknown → secure" (W-572). Native apps don't implement the
-        // attribute and ignore the set. Chromium builds the tree lazily after
-        // the flip, so the immediate read below can still miss — the reseed
-        // fallback after this call catches that.
-        AXUIElementSetAttributeValue(axApp, "AXManualAccessibility" as CFString, kCFBooleanTrue)
-
         // C function pointer — no captures allowed, route via refcon.
         let callback: AXObserverCallback = { _, focusedElement, _, refcon in
             guard let refcon else { return }
@@ -228,6 +219,17 @@ final class FocusedElementCache {
         var seeded: AXUIElement?
         if status == .success, let ref, CFGetTypeID(ref) == AXUIElementGetTypeID() {
             seeded = (ref as! AXUIElement)
+        }
+
+        // Chromium/Electron apps (Slack, VS Code, Discord…) gate their AX tree
+        // behind AXManualAccessibility: until a client sets it the app exposes
+        // no focused element, so every trigger fails closed as "unknown →
+        // secure" (W-572). Only flip it when the read above came back empty —
+        // native apps hand back a focused element and never reach here, so we
+        // never touch them. Chromium builds the tree asynchronously; the
+        // observer registered above delivers the focus once it's ready.
+        if seeded == nil {
+            AXUIElementSetAttributeValue(axApp, "AXManualAccessibility" as CFString, kCFBooleanTrue)
         }
 
         // Classify while we're already off the main thread and holding the app's

--- a/Sources/Mojito/Context/FocusedElementCache.swift
+++ b/Sources/Mojito/Context/FocusedElementCache.swift
@@ -26,6 +26,7 @@ final class FocusedElementCache {
     private(set) var element: AXUIElement? {
         didSet {
             haveFieldInfo = false
+            focusedRole = nil
             _ = fieldGeneration.withLock { $0 += 1 }   // cancel in-flight reclassifies
         }
     }
@@ -40,13 +41,18 @@ final class FocusedElementCache {
     private(set) var focusedIsSecure = false
     private(set) var focusedIsEditable = false
     private(set) var haveFieldInfo = false
+    /// Raw AXRole the classification was read from (nil if AX couldn't answer).
+    /// Diagnostics only — lets a debug line tell "field not classified yet"
+    /// apart from "classified as a real secure/opaque role".
+    private(set) var focusedRole: String?
 
     /// Publishes an off-thread classification for the *current* `element`. Guard
     /// with a `CFEqual` element check at the call site so a classify that lands
     /// after focus moved on can't attach stale info to the new focus.
-    private func publishFieldInfo(secure: Bool, editable: Bool) {
+    private func publishFieldInfo(secure: Bool, editable: Bool, role: String?) {
         focusedIsSecure = secure
         focusedIsEditable = editable
+        focusedRole = role
         haveFieldInfo = true
     }
 
@@ -62,7 +68,7 @@ final class FocusedElementCache {
                 MainActor.assumeIsolated {
                     let cache = FocusedElementCache.shared
                     guard let current = cache.element, CFEqual(current, element) else { return }
-                    cache.publishFieldInfo(secure: info.secure, editable: info.editable)
+                    cache.publishFieldInfo(secure: info.secure, editable: info.editable, role: info.role)
                 }
             }
         }
@@ -217,7 +223,7 @@ final class FocusedElementCache {
 
         // Classify while we're already off the main thread and holding the app's
         // tight timeout, so `current()` (on the tap thread) reads it for free.
-        var fieldInfo: (secure: Bool, editable: Bool)?
+        var fieldInfo: (secure: Bool, editable: Bool, role: String?)?
         if let seeded {
             AXUIElementSetMessagingTimeout(seeded, Self.seedTimeout)
             fieldInfo = AppContextDetector.classify(seeded)
@@ -240,7 +246,7 @@ final class FocusedElementCache {
     /// the seed window (its snapshot is nil) and clear a fresh emoticon undo.
     private func install(
         seeded: AXUIElement?,
-        fieldInfo: (secure: Bool, editable: Bool)?,
+        fieldInfo: (secure: Bool, editable: Bool, role: String?)?,
         observer: AXObserver?,
         pid: pid_t,
         generation: Int
@@ -248,7 +254,7 @@ final class FocusedElementCache {
         guard generation == refreshGeneration.withLock({ $0 }) else { return }
         element = seeded                                  // didSet clears field info
         if let fieldInfo {                                // then publish this seed's classification
-            publishFieldInfo(secure: fieldInfo.secure, editable: fieldInfo.editable)
+            publishFieldInfo(secure: fieldInfo.secure, editable: fieldInfo.editable, role: fieldInfo.role)
         }
         if let observer {
             CFRunLoopAddSource(

--- a/Sources/Mojito/Context/FocusedElementCache.swift
+++ b/Sources/Mojito/Context/FocusedElementCache.swift
@@ -174,6 +174,15 @@ final class FocusedElementCache {
         let axApp = AXUIElementCreateApplication(pid)
         AXUIElementSetMessagingTimeout(axApp, Self.seedTimeout)
 
+        // Chromium/Electron apps (Slack, VS Code, Discord…) gate their AX tree
+        // behind this attribute: until a client sets it, the app exposes no
+        // focused element, so the seed reads nil and every trigger fails closed
+        // as "unknown → secure" (W-572). Native apps don't implement the
+        // attribute and ignore the set. Chromium builds the tree lazily after
+        // the flip, so the immediate read below can still miss — the reseed
+        // fallback after this call catches that.
+        AXUIElementSetAttributeValue(axApp, "AXManualAccessibility" as CFString, kCFBooleanTrue)
+
         // C function pointer — no captures allowed, route via refcon.
         let callback: AXObserverCallback = { _, focusedElement, _, refcon in
             guard let refcon else { return }

--- a/Sources/Mojito/Debug/DebugReport.swift
+++ b/Sources/Mojito/Debug/DebugReport.swift
@@ -269,9 +269,13 @@ enum DebugReport {
             return (st == .success ? (ref as? String) : nil) ?? "—"
         }()
         var s = "## Now\n"
+        let cache = FocusedElementCache.shared
         s += "- frontmostBundleID: \(bundleID)\n"
         s += "- focusedRole: \(role)\n"
         s += "- focusedElementCached: \(element != nil)\n"
+        s += "- focusedHaveFieldInfo: \(cache.haveFieldInfo)\n"
+        s += "- focusedIsSecure: \(cache.focusedIsSecure)\n"
+        s += "- focusedClassifiedRole: \(cache.focusedRole ?? "—")\n"
         return s
     }
 

--- a/Sources/Mojito/Debug/DebugReport.swift
+++ b/Sources/Mojito/Debug/DebugReport.swift
@@ -276,6 +276,7 @@ enum DebugReport {
         s += "- focusedHaveFieldInfo: \(cache.haveFieldInfo)\n"
         s += "- focusedIsSecure: \(cache.focusedIsSecure)\n"
         s += "- focusedClassifiedRole: \(cache.focusedRole ?? "—")\n"
+        s += "- focusedElementNil: \(cache.element == nil)\n"
         return s
     }
 


### PR DESCRIPTION
## Problem

Mojito's `:` trigger fired in Slack only ~10% of the time, while working everywhere else. The reported theory was event-tap startup sequencing.

## Actual cause

The event tap was fine. Every dropped Slack trigger was hitting the secure-field guard. Instrumentation confirmed the mechanism: `haveInfo=false role=nil elem=false` on every attempt — the focused-element **cache was nil** for Slack.

Chromium/Electron apps don't build their accessibility tree until a client sets `AXManualAccessibility` on the app element. Until then `AXUIElementCopyAttributeValue(app, focusedUIElement)` returns nothing, the seed caches nil, and `AppContextDetector.current()` fails closed (`unknown focus → secure`) and drops the trigger. Native apps (Mail, Messages) expose focus by default, so only Electron apps broke. The rare successes lined up with a relaunch catching the tree already built.

## Fix

Set `AXManualAccessibility` on the app element at seed time (`FocusedElementCache.seed`). Native apps don't implement it and ignore the set; Chromium flips into full AX mode and exposes its focused `AXTextArea`, which classifies as editable / non-secure and drives the picker normally.

The fix does **not** weaken the secure-field guard — a real password field still classifies as `AXSecureTextField` and stays blocked.

## Diagnostics (also in this PR)

- `haveInfo` / `role` / `elem` / `editable` on the `secureFieldBlocked` log line.
- Field-classification state (`focusedHaveFieldInfo`, `focusedIsSecure`, `focusedClassifiedRole`, `focusedElementNil`) in the debug report's Now section.

These flow to both the in-app report and the `MOJITO_E2E_LOG` stream.

## Test plan

Verified end-to-end on a live Debug build in Slack (macOS 27):

```
engine.colon excluded=false          → capture opened
picker.open  outcome=elementTopLeft  → picker showed
insert.exactMatch                    → emoji inserted
```

Last-picker-context confirmed Slack's compose box now exposes the full Chromium AX tree (`AXTextArea`, `ChromeAXNodeId`, `AXDOMClassList`). Unit suite (`scripts/run-tests.sh`) passes.

## Note

Enabling Chromium accessibility adds a small ongoing AX-tree cost inside each Electron app (the same tradeoff VoiceOver makes). Necessary for Mojito to function there at all.

Refs W-572